### PR TITLE
divine-push-service#4: Fix dedup race condition for multi-replica safety

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -94,28 +94,31 @@ pub async fn run(
                     continue;
                 }
 
-                // Check if already processed
-                tokio::select! {
+                // Atomically claim the event to prevent duplicate processing across replicas
+                let claimed = tokio::select! {
                     biased;
                     _ = token.cancelled() => {
-                        info!("Event handler cancelled while checking if event {} was processed.", event_id);
+                        info!("Event handler cancelled while claiming event {}.", event_id);
                         break;
                     }
-                    processed_result = redis_store::is_event_processed(&state.redis_pool, &event_id) => {
-                        match processed_result {
-                            Ok(true) => {
-                                trace!(event_id = %event_id, "Skipping already processed event");
-                                continue;
-                            }
-                            Ok(false) => {
-                                // Not processed, continue handling
-                            }
+                    claim_result = redis_store::try_claim_event(
+                        &state.redis_pool,
+                        &event_id,
+                        state.settings.service.processed_event_ttl_secs,
+                    ) => {
+                        match claim_result {
+                            Ok(claimed) => claimed,
                             Err(e) => {
-                                error!(event_id = %event_id, error = %e, "Failed to check if event was processed");
+                                error!(event_id = %event_id, error = %e, "Failed to claim event");
                                 continue;
                             }
                         }
                     }
+                };
+
+                if !claimed {
+                    trace!(event_id = %event_id, "Skipping already claimed event");
+                    continue;
                 }
 
                 // Route the event based on its type
@@ -124,28 +127,9 @@ pub async fn run(
                 match handler_result {
                     Ok(_) => {
                         trace!(event_id = %event_id, kind = %event_kind, "Handler finished successfully");
-                        tokio::select! {
-                            biased;
-                            _ = token.cancelled() => {
-                                info!("Event handler cancelled before marking event {} as processed.", event_id);
-                                break;
-                            }
-                            mark_result = redis_store::mark_event_processed(
-                                &state.redis_pool,
-                                &event_id,
-                                state.settings.service.processed_event_ttl_secs,
-                            ) => {
-                                if let Err(e) = mark_result {
-                                    error!(event_id = %event_id, error = %e, "Failed to mark event as processed");
-                                } else {
-                                    debug!(event_id = %event_id, "Successfully marked event as processed");
-                                }
-                            }
-                        }
                     }
                     Err(e) => {
                         error!(event_id = %event_id, error = %e, "Failed to handle event");
-                        // Continue processing other events
                     }
                 }
 

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 pub type RedisPool = Pool<RedisConnectionManager>;
 
 // Redis key constants
-const PROCESSED_EVENTS_SET: &str = "processed_nostr_events";
 const STALE_TOKENS_ZSET: &str = "stale_tokens";
 const TOKEN_TO_PUBKEY_HASH: &str = "token_to_pubkey";
 
@@ -248,47 +247,33 @@ pub async fn cleanup_stale_tokens(pool: &RedisPool, max_age_seconds: i64) -> Res
 // Event Processing
 // =============================================================================
 
-/// Checks if an event has already been processed.
-pub async fn is_event_processed(pool: &RedisPool, event_id: &EventId) -> Result<bool> {
+/// Atomically claims an event for processing using SET NX EX.
+/// Returns true if the event was newly claimed (not yet processed).
+/// Returns false if the event was already claimed by another replica.
+pub async fn try_claim_event(
+    pool: &RedisPool,
+    event_id: &EventId,
+    ttl_seconds: u64,
+) -> Result<bool> {
     let mut conn = pool
         .get()
         .await
         .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
 
-    let processed: bool = redis::cmd("SISMEMBER")
-        .arg(PROCESSED_EVENTS_SET)
-        .arg(event_id.to_hex())
+    let key = format!("dedup:{}", event_id.to_hex());
+
+    let result: Option<String> = redis::cmd("SET")
+        .arg(&key)
+        .arg("1")
+        .arg("NX")
+        .arg("EX")
+        .arg(ttl_seconds)
         .query_async(&mut *conn)
         .await
         .map_err(ServiceError::Redis)?;
 
-    Ok(processed)
-}
-
-/// Marks an event as processed with a time-to-live (TTL).
-pub async fn mark_event_processed(
-    pool: &RedisPool,
-    event_id: &EventId,
-    ttl_seconds: u64,
-) -> Result<()> {
-    let mut conn = pool
-        .get()
-        .await
-        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
-
-    let ttl_i64: i64 = ttl_seconds
-        .try_into()
-        .map_err(|_| ServiceError::Internal("TTL value too large".to_string()))?;
-
-    let mut pipe = redis::pipe();
-    pipe.atomic()
-        .sadd(PROCESSED_EVENTS_SET, event_id.to_hex())
-        .expire(PROCESSED_EVENTS_SET, ttl_i64);
-
-    pipe.query_async::<Value>(&mut *conn)
-        .await
-        .map(|_| ())
-        .map_err(ServiceError::Redis)
+    // SET NX returns "OK" if the key was set, None if it already existed
+    Ok(result.is_some())
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #4

## Summary

Fixes a dedup race condition where multiple replicas could both send push notifications for the same event. The old two-step pattern (SISMEMBER then SADD) had a window where concurrent replicas could both read "not processed" before either marked the event.

## Changes

- **`src/redis_store.rs`**: Replace `is_event_processed()` + `mark_event_processed()` with a single `try_claim_event()` that uses `SET NX EX` - atomic set-if-not-exists with per-key TTL
- **`src/redis_store.rs`**: Remove `PROCESSED_EVENTS_SET` constant (shared set no longer used)
- **`src/event_handler.rs`**: Replace check-then-mark pattern with a single `try_claim_event()` call before processing, removing the post-processing mark step entirely

## Decisions

- **`SET NX EX` over `SADD`**: The issue suggested SADD-based atomicity, but SET NX EX is fully atomic (set + TTL in one command) vs SADD + EXPIRE which is still two operations
- **Per-event keys (`dedup:<event_id>`) over shared set**: Fixes the secondary bug where EXPIRE on the shared set was resetting TTL for all events on every insertion. Each key now has independent TTL
- **Claim-before-process**: If processing fails after claiming, the event won't retry for TTL duration. This is an acceptable tradeoff vs duplicate notifications

## Test plan

- [x] All 36 unit tests pass
- [x] Clippy clean
- [ ] Manual test with Redis: verify SET NX EX returns OK on first call, nil on second
- [ ] Follow-up #5 tracks adding integration tests for concurrent dedup scenarios