### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report a bug or regression
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors instead of partner, customer, or brand names in public issue titles, bodies, and screenshots unless a maintainer explicitly approves naming them.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug and its impact on relay handling, preferences, notification delivery, or operations.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Publish event or start service ...
+        2. Use config ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Context
+      description: Include logs or examples with sensitive values redacted.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose an enhancement or new capability
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors instead of partner, customer, or brand names in public issue titles, bodies, and screenshots unless a maintainer explicitly approves naming them.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the requested capability.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Explain the product or operational gap this addresses.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the preferred solution or constraints.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Context
+      description: Include examples or references with sensitive names redacted.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- describe the change
+
+## Motivation
+- explain why this change is needed
+
+## Related Issue
+- link the issue or write `N/A`
+
+## Testing
+- describe local verification
+
+## Protocol / Ops Notes
+- include notification, relay, or config behavior changes when relevant, or write `None`
+
+## Sensitive Information Check
+- confirm that public titles, descriptions, branch names, and screenshots do not mention partner/customer/brand names or other sensitive external identities unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,16 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Service code lives in `src/`, with focused modules for relay listening, preferences, Redis storage, cleanup, and FCM delivery.
+- Integration and behavior tests live in `tests/`.
+- Runtime configuration lives in `config/`, with deployment assets in `Dockerfile` and `docker-compose.yml`.
+- Repo-specific maintainer guidance already exists in `CLAUDE.md`; keep that aligned with this file rather than duplicating detailed implementation advice.
+
+## Build, Test, and Development Commands
+- `cargo build`: build the service.
+- `cargo run`: start the service locally.
+- `cargo check`: run a fast compile-only validation pass.
+- `cargo clippy --all-targets --all-features`: run lint checks.
+- `cargo test`: run the full test suite.
+- Use the docs in `README.md` and `docs/` when changing protocol or operational behavior.
+
+## Coding Style & Naming Conventions
+- Use idiomatic Rust with explicit error handling and clear module boundaries.
+- Prefer small, focused modules over broad helper collections.
+- Keep PRs tightly scoped. Do not mix unrelated cleanup, formatting churn, or speculative refactors into the same change.
+- Temporary or transitional code must include `TODO(#issue):` with the tracking issue for removal.
+
+## Pull Request Guardrails
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR. Do not rely on fixing it afterward.
+- If a PR title changes after opening, verify that the semantic PR title check reruns successfully.
+- PR descriptions must include a short summary, motivation, linked issue, and manual test plan.
+- Changes to protocol behavior, notification handling, or operational configuration should include representative examples or rollout notes when helpful.
+
+## Security & Sensitive Information
+- Do not commit secrets, Firebase credentials, private keys, production tokens, or private user data.
+- Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.


### PR DESCRIPTION
## Summary\n- add repo-local contributor and agent guardrails in AGENTS.md\n- add semantic PR title enforcement and GitHub templates\n- add issue templates with semantic title seeds and sensitive-name redaction guidance\n\n## Testing\n- not run (repo metadata and documentation changes only)