### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     services:
       redis:
         image: redis:7
@@ -74,7 +74,7 @@ jobs:
   docker:
     name: Build & Push
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     if: github.event_name != 'pull_request'
     permissions:
       id-token: write
@@ -170,7 +170,7 @@ jobs:
   deploy:
     name: Trigger Deploy
     needs: docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     if: github.event_name != 'pull_request'
     environment: staging
 


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`