### PR TITLE
fix(push): verify payload shape to avoid duplicate client rendering

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -52,9 +52,14 @@ The service watches for these event kinds and notifies the tagged recipient:
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Repost | 16 | Repost of user's note (p-tag) |
 
+> **Note:** Follow (kind 3) is defined but **not currently emitted** — the handler skips kind 3 because new-follow detection requires diffing contact-list state, which is not yet implemented. Likes, comments, mentions, and reposts are the types actually delivered today.
+
 ## FCM Payload Format
 
-The service sends **data-only** FCM messages (no `notification` field). This gives the client full control over how notifications are displayed.
+The FCM message carries **no top-level `notification` field** — the `data` map below is always present and is identical in shape for every notification type (only the `title`/`body` strings differ). Per-platform delivery then diverges so that **one incoming push produces exactly one visible banner**:
+
+- **Android** — data-only (`notification` and `android` unset). Android does not auto-display data messages, so the app renders the single banner itself from the `data` fields.
+- **iOS** — the service attaches an APNS override: `aps.alert` (title/body) + `mutable-content: 1`, push-type `alert`, priority 10. The OS presents the single banner; a Notification Service Extension (if shipped) uses `mutable-content` to *enrich* that same banner, never to create a second one. `content-available` is deliberately omitted — see [Avoiding duplicate banners](#avoiding-duplicate-banners).
 
 ```json
 {
@@ -90,13 +95,38 @@ The service sends **data-only** FCM messages (no `notification` field). This giv
 | `timestamp` | string | Unix timestamp of the event as string |
 | `referencedEventId` | hex | (optional) The event being reacted to or replied to |
 
+### iOS APNS shape
+
+For a like, the APNS override the service emits is:
+
+```json
+{
+  "aps": {
+    "alert": { "title": "New like", "body": "Alice liked your post" },
+    "mutable-content": 1
+  },
+  "type": "Like",
+  "eventId": "abc123...",
+  "...": "remaining data fields (title/body live in aps.alert, not duplicated here)"
+}
+```
+
+Headers: `apns-push-type: alert`, `apns-priority: 10`.
+
+A *silent/background* push — a data message with neither `title` nor `body` — instead uses `aps.content-available: 1`, push-type `background`, priority 5. The current notification types always carry `title`/`body`, so this background shape is not emitted today.
+
+### Avoiding duplicate banners
+
+`content-available: 1` is intentionally **absent** from alert pushes. It is iOS's background-update flag: it wakes the app's background isolate, which would build a **second, local** banner on top of the OS-presented `aps.alert` — the duplicate-banner bug ([divine-push-service#20](https://github.com/divinevideo/divine-push-service/issues/20)). An `aps.alert` push is delivered reliably to **terminated** iOS apps *without* `content-available` (that flag matters only for *silent* pushes, which iOS throttles when the app is terminated), so omitting it costs no delivery reliability.
+
+The contract is mirrored on the client ([divine-mobile#4760](https://github.com/divinevideo/divine-mobile/pull/4760)): the app renders a local banner **only** when the message has no OS-presented notification (`message.notification == null`, i.e. the Android data-only case). When iOS surfaces the `aps.alert` as `RemoteMessage.notification`, the client suppresses its local render. Result: **one push → one banner** across foreground, background, and terminated states.
+
 ### Client Handling
 
-Since these are data-only messages:
-- **Android**: The app must create and display the notification itself via `onMessageReceived`
-- **iOS**: The app must use a Notification Service Extension or handle via `application:didReceiveRemoteNotification:`
-- **Foreground**: The app receives the data and decides whether/how to show it
-- **Background**: A background handler must create a local notification from the data fields
+- **Android**: data-only — the app creates and displays the notification via `onMessageReceived` / background handler.
+- **iOS**: the OS presents the `aps.alert`; an optional Notification Service Extension enriches it via `mutable-content`. The app must **not** create a separate local notification for these.
+- **Foreground**: iOS does not OS-present in the foreground, so the app is the sole renderer; Android likewise renders once.
+- **Taps**: tapping the OS-presented banner routes via the platform notification-open callbacks (e.g. `onMessageOpenedApp` / `getInitialMessage`) using the `data` fields; routing does not depend on `content-available`.
 
 ## Service Discovery
 

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use firebase_messaging_rs::{
     fcm::{
         ios::{
-            Alert, ApnsConfig, ApnsHeaders, ApnsPriority, ApnsPushType, Aps, ContentAvailable,
-            MutableContent, RichAlert,
+            Alert, ApnsConfig, ApnsHeaders, ApnsPriority, ApnsPushType, Aps, MutableContent,
+            RichAlert,
         },
         FCMApi, FCMError as FirebaseFCMError, Message, Notification,
     },
@@ -153,13 +153,16 @@ fn build_apns_config(payload: &FcmPayload) -> Option<ApnsConfig> {
         .or_else(|| data.get("body").cloned());
 
     if title.is_some() || body.is_some() {
+        // Alert push: the OS presents this single banner (NSE may enrich it via
+        // mutable-content). Deliberately NO content-available — that flag wakes the
+        // app's background isolate, which renders a *second*, duplicate banner. An
+        // alert push reaches terminated iOS apps without it. See divine-push-service#20.
         let aps = Aps {
             alert: Some(Alert::Structural(Box::new(RichAlert {
                 title,
                 body,
                 ..Default::default()
             }))),
-            content_available: Some(ContentAvailable::On),
             mutable_content: Some(MutableContent::On),
             ..Default::default()
         };
@@ -511,7 +514,6 @@ mod tests {
                         "title": "New like",
                         "body": "Alice liked your post"
                     },
-                    "content-available": 1,
                     "mutable-content": 1
                 },
                 "eventId": "abc123"


### PR DESCRIPTION
## Summary

iOS users saw two banners for a single push. This change makes the push service send one notification shape, so one push produces one banner.

The fix drops `content_available` from iOS alert pushes. That flag was waking the app's background isolate to draw a second, local banner on top of the one iOS already shows from `aps.alert`.

## Motivation

Every notification carried `aps.alert` + `content_available` + `mutable_content` together (added in #17). On iOS the OS presents the `aps.alert` banner, and `content_available` separately wakes the app to render its own — a duplicate.

`content_available` is only needed for silent pushes. An alert push still reaches terminated iOS apps without it, so removing it costs no delivery reliability, and `mutable_content` stays for Notification Service Extension enrichment. The mobile team reached the same root cause in divine-mobile#4760 and recommended this exact server change.

## Related Issue

Closes #20. Mobile contract: divine-mobile#4760 (defense-in-depth client guard, already merged). Follow (kind 3) notifications remain unimplemented and are tracked separately in #21.

## Testing

Ran the full Rust suite locally; all green. Not run on a physical iOS device (push is not deliverable to the simulator).

- `cargo test` — 64 tests pass
- `cargo clippy --all-targets --all-features` — clean
- `cargo fmt --check` — clean
- TDD: flipped the alert-payload unit test to assert `content-available` is absent (watched it fail, then pass).

## Protocol / Ops Notes

iOS payload contract change. Alert pushes now omit `content-available` (still `aps.alert` + `mutable-content`, push-type `alert`, priority 10). Android (data-only) is unchanged. The live mobile guard already suppresses duplicates, so this is the durable server-side layer, not the sole defense.

## Sensitive Information Check

No partner, customer, or brand names appear in the title, description, branch, or code. Confirmed.
