### PR TITLE
fix(push): make notification payload targets authoritative for mobile routing and attribution

### DIFF
--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -37,6 +37,7 @@ notification:
     - 3      # Contact list (follows)
     - 7      # Reactions/likes (NIP-25)
     - 16     # Generic reposts (NIP-18)
+    - 1111   # NIP-22 comments
     - 30023  # Long-form content (mentions)
   # Default kinds users receive notifications for (can be customized via kind 3083)
   default_preferences:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -38,6 +38,7 @@ notification:
     - 3      # Contact list (follows)
     - 7      # Reactions/likes (NIP-25)
     - 16     # Generic reposts (NIP-18)
+    - 1111   # NIP-22 comments
     - 30023  # Long-form content (mentions)
   # Default kinds users receive notifications for (can be customized via kind 3083)
   default_preferences:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -48,11 +48,14 @@ The service watches for these event kinds and notifies the tagged recipient:
 |------|-----------|---------|
 | Like | 7 | Reaction to user's note (p-tag) |
 | Comment | 1 | Reply to user's note (p-tag, with e-tag reference) |
+| Comment | 1111 | NIP-22 comment on a user's video or article (notifies root author `P` and parent author `p`) |
 | Follow | 3 | New contact list including user (p-tag) |
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Repost | 16 | Repost of user's note (p-tag) |
 
 > **Note:** Follow (kind 3) is defined but **not currently emitted** — the handler skips kind 3 because new-follow detection requires diffing contact-list state, which is not yet implemented. Likes, comments, mentions, and reposts are the types actually delivered today.
+
+> **Note:** diVine video comments are NIP-22 `kind:1111`, not `kind:1`. They notify both the **root author** (uppercase `P` — the video owner, so they hear about comments on their video) and the **direct parent author** (lowercase `p` — for a reply, the parent comment's author). The two coincide for a top-level comment and are deduplicated. Every such push carries the authoritative root-video coordinate (see [Routing & attribution contract](#routing--attribution-contract)), so a reply to someone else's comment still routes to the correct video instead of a guessed one.
 
 ## FCM Payload Format
 
@@ -118,7 +121,7 @@ When the triggering event carries no addressable reference (a follow, a mention 
 | `eventKind` | string | Triggering Nostr event kind as a string (e.g. "7") |
 | `timestamp` | string | Unix timestamp of the triggering event as a string |
 
-The `referenced*` coordinate fields are emitted only when the triggering event references an addressable event — currently kind 34236 videos via likes/reposts. Likes/reposts on non-video targets and follows/mentions omit them.
+The `referenced*` coordinate fields are emitted only when the triggering event references an addressable event — currently kind 34236 videos via likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and follows/mentions omit them.
 
 ### iOS APNS shape
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -56,7 +56,7 @@ The service watches for these event kinds and notifies the tagged recipient:
 
 ## FCM Payload Format
 
-The FCM message carries **no top-level `notification` field** — the `data` map below is always present and is identical in shape for every notification type (only the `title`/`body` strings differ). Per-platform delivery then diverges so that **one incoming push produces exactly one visible banner**:
+The FCM message carries **no top-level `notification` field** — the `data` map below is always present and is identical in shape for every notification type (only the `title`/`body` strings differ); every `data` value is a string. Per-platform delivery then diverges so that **one incoming push produces exactly one visible banner**:
 
 - **Android** — data-only (`notification` and `android` unset). Android does not auto-display data messages, so the app renders the single banner itself from the `data` fields.
 - **iOS** — the service attaches an APNS override: `aps.alert` (title/body) + `mutable-content: 1`, push-type `alert`, priority 10. The OS presents the single banner; a Notification Service Extension (if shipped) uses `mutable-content` to *enrich* that same banner, never to create a second one. `content-available` is deliberately omitted — see [Avoiding duplicate banners](#avoiding-duplicate-banners).
@@ -64,7 +64,7 @@ The FCM message carries **no top-level `notification` field** — the `data` map
 ```json
 {
   "data": {
-    "type": "Like",
+    "type": "like",
     "eventId": "abc123...",
     "title": "New like",
     "body": "Alice liked your post",
@@ -74,26 +74,51 @@ The FCM message carries **no top-level `notification` field** — the `data` map
     "receiverNpub": "npub1...",
     "eventKind": "7",
     "timestamp": "1712345678",
-    "referencedEventId": "fedcba..."
+    "referencedEventId": "fedcba...",
+    "referencedAddress": "34236:9b2f...:my-vine-id",
+    "referencedKind": "34236",
+    "referencedAuthorPubkey": "9b2f...",
+    "referencedDTag": "my-vine-id"
   }
 }
 ```
 
-### Fields
+### Routing & attribution contract
+
+Each field is either **authoritative** — the client may route to and attribute the notification from it directly — or **presentation-only** — safe to display, but never used to decide *which* target to open.
+
+For a like, comment, or repost on a video the authoritative target is the addressable coordinate in `referencedAddress` (`kind:pubkey:d-tag`), taken verbatim from the triggering event's `a`/`A` tag. The owner pubkey is therefore the one the actor signed into the event, not the notification recipient.
+
+> **Clients MUST NOT** synthesize a video coordinate by pairing `referencedDTag` (or any d-tag) with the *recipient's* pubkey. The recipient is not necessarily the video owner — e.g. a reply to another user's comment, or a mention — and doing so attributes the notification to the wrong (or a nonexistent) video. Use `referencedAuthorPubkey` / `referencedAddress` for ownership; fall back to `referencedEventId` when no coordinate is present.
+
+When the triggering event carries no addressable reference (a follow, a mention in a plain note, or a like on a comment), the `referenced*` video fields are omitted and the client falls back to `referencedEventId`, then to the actor's profile.
+
+#### Authoritative (routing / attribution)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | string | `Like`, `Comment`, `Follow`, `Mention`, or `Repost` |
-| `eventId` | hex | The Nostr event that triggered the notification |
+| `type` | string | `like`, `comment`, `follow`, `mention`, or `repost` (lowercase) |
+| `eventId` | hex | The Nostr event that triggered the notification (the like/comment/repost/follow event itself); stable id for dedup and a routing fallback |
+| `senderPubkey` | hex | Pubkey of the actor who triggered the event; routes follows and otherwise-unresolved taps |
+| `receiverPubkey` | hex | Pubkey of the notification recipient |
+| `referencedEventId` | hex | (optional) Target event. Root-aware: the NIP-22 uppercase `E` root scope when present, else the lowercase `e` tag — so comments anchor to the root video, not the parent comment |
+| `referencedAddress` | string | (optional) Authoritative addressable target coordinate `kind:pubkey:d-tag`, from the event's `A` (NIP-22 root) or `a` tag. Present when the target is an addressable event such as a kind 34236 video |
+| `referencedKind` | string | (optional) Kind component of `referencedAddress` (e.g. `34236`) |
+| `referencedAuthorPubkey` | hex | (optional) Owner-pubkey component of `referencedAddress` — the authoritative video owner |
+| `referencedDTag` | string | (optional) `d`-tag component of `referencedAddress`. Combine only with `referencedAuthorPubkey` (never the recipient) to rebuild the coordinate |
+
+#### Presentation-only (display)
+
+| Field | Type | Description |
+|-------|------|-------------|
 | `title` | string | Human-readable title (e.g. "New like") |
 | `body` | string | Human-readable body (e.g. "Alice liked your post") |
-| `senderPubkey` | hex | Pubkey of the user who triggered the event |
 | `senderName` | string | Display name or truncated npub of the sender |
-| `receiverPubkey` | hex | Pubkey of the notification recipient |
 | `receiverNpub` | bech32 | Bech32-encoded npub of the recipient |
-| `eventKind` | string | Nostr event kind as string (e.g. "7") |
-| `timestamp` | string | Unix timestamp of the event as string |
-| `referencedEventId` | hex | (optional) The event being reacted to or replied to |
+| `eventKind` | string | Triggering Nostr event kind as a string (e.g. "7") |
+| `timestamp` | string | Unix timestamp of the triggering event as a string |
+
+The `referenced*` coordinate fields are emitted only when the triggering event references an addressable event — currently kind 34236 videos via likes/reposts. Likes/reposts on non-video targets and follows/mentions omit them.
 
 ### iOS APNS shape
 
@@ -105,7 +130,7 @@ For a like, the APNS override the service emits is:
     "alert": { "title": "New like", "body": "Alice liked your post" },
     "mutable-content": 1
   },
-  "type": "Like",
+  "type": "like",
   "eventId": "abc123...",
   "...": "remaining data fields (title/body live in aps.alert, not duplicated here)"
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,7 @@ fn default_event_kinds() -> Vec<u64> {
         3,     // Contact list (follows)
         7,     // Reactions/likes (NIP-25)
         16,    // Generic reposts (NIP-18)
+        1111,  // NIP-22 comments
         30023, // Long-form content (mentions)
     ]
 }
@@ -247,6 +248,7 @@ mod tests {
         assert!(kinds.contains(&3)); // Contact list
         assert!(kinds.contains(&7)); // Reactions
         assert!(kinds.contains(&16)); // Reposts
+        assert!(kinds.contains(&1111)); // NIP-22 comments
         assert!(kinds.contains(&30023)); // Long-form
     }
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -766,15 +766,11 @@ async fn create_fcm_payload(
         event.created_at.as_secs().to_string(),
     );
 
-    // Add e-tag reference if present (for comments/reactions)
-    if let Some(e_tag) = event.tags.find(TagKind::e()) {
-        if let Some(referenced_event_id) = e_tag.content() {
-            data.insert(
-                "referencedEventId".to_string(),
-                referenced_event_id.to_string(),
-            );
-        }
-    }
+    // Add authoritative routing/attribution target fields: the referenced event
+    // id and, for addressable targets (e.g. kind 34236 videos), the signed
+    // coordinate (`referencedAddress` + components) so the client never has to
+    // guess the target's owner.
+    insert_reference_fields(&mut data, event);
 
     Ok(FcmPayload {
         notification: None, // Data-only message for better client control
@@ -782,6 +778,81 @@ async fn create_fcm_payload(
         android: None,
         webpush: None,
         apns: None,
+    })
+}
+
+/// Authoritative addressable target extracted from an event's `A`/`a` tag.
+///
+/// `address` is the full NIP-01 coordinate (`kind:pubkey:d-tag`); the remaining
+/// fields are its components. The owner pubkey comes from the coordinate signed
+/// into the actor's event, so consumers never have to infer ownership.
+struct ReferencedCoordinate {
+    address: String,
+    kind: String,
+    author_pubkey: String,
+    d_tag: String,
+}
+
+/// Insert routing/attribution target fields into the FCM data map.
+///
+/// Adds `referencedEventId` (root-aware: prefers the NIP-22 uppercase `E` root
+/// scope, else the lowercase `e` tag) and, when the event references an
+/// addressable event, the authoritative `referencedAddress` coordinate split
+/// into `referencedKind`, `referencedAuthorPubkey`, and `referencedDTag`.
+fn insert_reference_fields(data: &mut std::collections::HashMap<String, String>, event: &Event) {
+    if let Some(event_id) = referenced_event_id(event) {
+        data.insert("referencedEventId".to_string(), event_id);
+    }
+    if let Some(coord) = referenced_coordinate(event) {
+        data.insert("referencedAddress".to_string(), coord.address);
+        data.insert("referencedKind".to_string(), coord.kind);
+        data.insert("referencedAuthorPubkey".to_string(), coord.author_pubkey);
+        data.insert("referencedDTag".to_string(), coord.d_tag);
+    }
+}
+
+/// Root-aware referenced event id.
+///
+/// Prefers the NIP-22 uppercase `E` root scope when present (so a comment
+/// anchors to the root video, not the parent comment), otherwise the lowercase
+/// `e` tag used by reactions and reposts.
+fn referenced_event_id(event: &Event) -> Option<String> {
+    event
+        .tags
+        .find(TagKind::single_letter(Alphabet::E, true))
+        .or_else(|| event.tags.find(TagKind::e()))
+        .and_then(|tag| tag.content())
+        .map(str::to_string)
+}
+
+/// Authoritative addressable target from the event's `A` (NIP-22 root) tag,
+/// falling back to the lowercase `a` (parent) tag.
+///
+/// Returns `None` when there is no addressable reference, or when the
+/// coordinate is not a well-formed `kind:pubkey:d-tag` (numeric kind, non-empty
+/// pubkey and d-tag). A d-tag may itself contain `:`, so only the first two
+/// separators are split.
+fn referenced_coordinate(event: &Event) -> Option<ReferencedCoordinate> {
+    let address = event
+        .tags
+        .find(TagKind::single_letter(Alphabet::A, true))
+        .or_else(|| event.tags.find(TagKind::a()))
+        .and_then(|tag| tag.content())?;
+
+    let mut parts = address.splitn(3, ':');
+    let kind = parts.next()?;
+    let author_pubkey = parts.next()?;
+    let d_tag = parts.next()?;
+
+    if kind.parse::<u32>().is_err() || author_pubkey.is_empty() || d_tag.is_empty() {
+        return None;
+    }
+
+    Some(ReferencedCoordinate {
+        address: address.to_string(),
+        kind: kind.to_string(),
+        author_pubkey: author_pubkey.to_string(),
+        d_tag: d_tag.to_string(),
     })
 }
 
@@ -1039,5 +1110,130 @@ mod tests {
             .unwrap();
 
         assert!(is_event_for_service(&event, &service.public_key()));
+    }
+
+    // =========================================================================
+    // Authoritative Target Field Tests (referenced event id + addressable coord)
+    // =========================================================================
+
+    #[test]
+    fn test_insert_reference_fields_like_with_addressable_coordinate() {
+        let actor = Keys::generate();
+        let owner = Keys::generate();
+        let video_event_id = "c".repeat(64);
+        let address = format!("34236:{}:my-vine-id", owner.public_key().to_hex());
+
+        // A like (kind 7) on a video carries a lowercase `a` coordinate plus the
+        // video event id in `e` and the owner in `p`.
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .tag(Tag::parse(["e", video_event_id.as_str()]).unwrap())
+            .tag(Tag::parse(["a", address.as_str()]).unwrap())
+            .tag(Tag::public_key(owner.public_key()))
+            .tag(Tag::parse(["k", "34236"]).unwrap())
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let mut data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        insert_reference_fields(&mut data, &event);
+
+        assert_eq!(data.get("referencedEventId"), Some(&video_event_id));
+        assert_eq!(data.get("referencedAddress"), Some(&address));
+        assert_eq!(data.get("referencedKind"), Some(&"34236".to_string()));
+        assert_eq!(
+            data.get("referencedAuthorPubkey"),
+            Some(&owner.public_key().to_hex())
+        );
+        assert_eq!(data.get("referencedDTag"), Some(&"my-vine-id".to_string()));
+    }
+
+    #[test]
+    fn test_insert_reference_fields_prefers_nip22_root_scope() {
+        let actor = Keys::generate();
+        let owner = Keys::generate();
+        let root_video_id = "a".repeat(64);
+        let parent_comment_id = "b".repeat(64);
+        let address = format!("34236:{}:root-vine", owner.public_key().to_hex());
+
+        // A NIP-22 comment (kind 1111): the uppercase root scope (`A`/`E`) is the
+        // video; the lowercase parent (`a`/`e`) is the comment being replied to.
+        // The authoritative target must be the root video, not the parent comment.
+        let event = EventBuilder::new(Kind::from(1111), "nice!")
+            .tag(Tag::parse(["E", root_video_id.as_str()]).unwrap())
+            .tag(Tag::parse(["A", address.as_str()]).unwrap())
+            .tag(Tag::parse(["K", "34236"]).unwrap())
+            .tag(Tag::parse(["e", parent_comment_id.as_str()]).unwrap())
+            .tag(Tag::parse(["k", "1111"]).unwrap())
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let mut data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        insert_reference_fields(&mut data, &event);
+
+        // Anchors to the root video, NOT the parent comment.
+        assert_eq!(data.get("referencedEventId"), Some(&root_video_id));
+        assert_eq!(data.get("referencedAddress"), Some(&address));
+        assert_eq!(
+            data.get("referencedAuthorPubkey"),
+            Some(&owner.public_key().to_hex())
+        );
+        assert_eq!(data.get("referencedDTag"), Some(&"root-vine".to_string()));
+    }
+
+    #[test]
+    fn test_insert_reference_fields_event_id_only_when_no_coordinate() {
+        let actor = Keys::generate();
+        let comment_id = "d".repeat(64);
+
+        // A like on a comment (kind 1111 target) has an `e` tag but no `a` tag.
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .tag(Tag::parse(["e", comment_id.as_str()]).unwrap())
+            .tag(Tag::parse(["k", "1111"]).unwrap())
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let mut data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        insert_reference_fields(&mut data, &event);
+
+        assert_eq!(data.get("referencedEventId"), Some(&comment_id));
+        assert!(!data.contains_key("referencedAddress"));
+        assert!(!data.contains_key("referencedDTag"));
+        assert!(!data.contains_key("referencedAuthorPubkey"));
+        assert!(!data.contains_key("referencedKind"));
+    }
+
+    #[test]
+    fn test_insert_reference_fields_none_when_no_reference_tags() {
+        let actor = Keys::generate();
+        let target = Keys::generate();
+
+        // A mention carries only a `p` tag: no addressable target, no event ref.
+        let event = EventBuilder::text_note("hey @you")
+            .tag(Tag::public_key(target.public_key()))
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let mut data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        insert_reference_fields(&mut data, &event);
+
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_insert_reference_fields_preserves_colons_in_dtag() {
+        let actor = Keys::generate();
+        let owner = Keys::generate();
+        // A d-tag may itself contain ':'; the split must keep it intact.
+        let address = format!("34236:{}:weird:d:tag", owner.public_key().to_hex());
+
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .tag(Tag::parse(["a", address.as_str()]).unwrap())
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let mut data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        insert_reference_fields(&mut data, &event);
+
+        assert_eq!(data.get("referencedAddress"), Some(&address));
+        assert_eq!(data.get("referencedDTag"), Some(&"weird:d:tag".to_string()));
     }
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -395,6 +395,13 @@ async fn handle_content_event(
             NotificationType::Mention
         };
         (notification_type, recipients)
+    } else if kind_num == 1111 {
+        // Kind 1111: NIP-22 comment (diVine publishes video comments here, not
+        // as kind 1). Notify the root author (uppercase `P`, the video owner)
+        // and the direct parent author (lowercase `p`). create_fcm_payload
+        // attaches the authoritative root-video target from the uppercase `A`.
+        let recipients = find_comment_recipients(event);
+        (NotificationType::Comment, recipients)
     } else if kind_num == 3 {
         // Kind 3: Contact list - notify newly followed users
         // Note: This would require tracking previous contact list state
@@ -507,6 +514,35 @@ fn find_mentioned_pubkeys(event: &Event) -> Vec<PublicKey> {
         .filter_map(|t| t.content())
         .filter_map(|content| PublicKey::from_str(content).ok())
         .collect()
+}
+
+/// Find recipients for a NIP-22 comment event (kind 1111).
+///
+/// Per NIP-22 the uppercase `P` tag is the root-scope author (for a video
+/// comment, the video owner) and the lowercase `p` tag is the parent-item
+/// author (for a reply, the parent comment's author — *not* the owner). Both
+/// are notified so the owner hears about comments on their video and the
+/// replied-to author hears about the reply; the two coincide for a top-level
+/// comment, so the result is deduplicated. The authoritative routing target
+/// (the root video) is attached separately by `create_fcm_payload` from the
+/// uppercase `A`/`E` root scope.
+fn find_comment_recipients(event: &Event) -> Vec<PublicKey> {
+    let root_author = TagKind::single_letter(Alphabet::P, true);
+    let parent_author = TagKind::p();
+
+    let mut recipients: Vec<PublicKey> = Vec::new();
+    for tag in event.tags.iter() {
+        let tag_kind = tag.kind();
+        if tag_kind != root_author && tag_kind != parent_author {
+            continue;
+        }
+        if let Some(pubkey) = tag.content().and_then(|c| PublicKey::from_str(c).ok()) {
+            if !recipients.contains(&pubkey) {
+                recipients.push(pubkey);
+            }
+        }
+    }
+    recipients
 }
 
 /// Send a notification to a specific user
@@ -1014,6 +1050,61 @@ mod tests {
 
         let pubkeys = find_mentioned_pubkeys(&event);
         assert_eq!(pubkeys.len(), 3);
+    }
+
+    #[test]
+    fn test_find_comment_recipients_reply_notifies_root_and_parent_authors() {
+        let actor = Keys::generate();
+        let video_owner = Keys::generate();
+        let parent_comment_author = Keys::generate();
+
+        // A NIP-22 reply to a comment on a video: the uppercase `P` is the root
+        // author (the video owner) and the lowercase `p` is the parent comment's
+        // author. Both must be notified, and they are distinct pubkeys here.
+        let event = EventBuilder::new(Kind::from(1111), "replying")
+            .tag(Tag::parse(["P", video_owner.public_key().to_hex().as_str()]).unwrap())
+            .tag(Tag::public_key(parent_comment_author.public_key()))
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let recipients = find_comment_recipients(&event);
+        assert_eq!(recipients.len(), 2);
+        assert!(recipients.contains(&video_owner.public_key()));
+        assert!(recipients.contains(&parent_comment_author.public_key()));
+    }
+
+    #[test]
+    fn test_find_comment_recipients_top_level_dedups_root_and_parent() {
+        let actor = Keys::generate();
+        let video_owner = Keys::generate();
+
+        // A top-level comment on a video: the parent scope equals the root scope,
+        // so uppercase `P` and lowercase `p` both point at the video owner. The
+        // owner must be notified exactly once.
+        let event = EventBuilder::new(Kind::from(1111), "nice video")
+            .tag(Tag::parse(["P", video_owner.public_key().to_hex().as_str()]).unwrap())
+            .tag(Tag::public_key(video_owner.public_key()))
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let recipients = find_comment_recipients(&event);
+        assert_eq!(recipients, vec![video_owner.public_key()]);
+    }
+
+    #[test]
+    fn test_find_comment_recipients_none_without_author_tags() {
+        let actor = Keys::generate();
+
+        // A NIP-22 comment scoped to an external identity (`I`/`i`, e.g. a URL)
+        // carries no `P`/`p` author tags, so there is nobody to notify.
+        let event = EventBuilder::new(Kind::from(1111), "nice article")
+            .tag(Tag::parse(["I", "https://example.com/article"]).unwrap())
+            .tag(Tag::parse(["K", "web"]).unwrap())
+            .sign_with_keys(&actor)
+            .unwrap();
+
+        let recipients = find_comment_recipients(&event);
+        assert!(recipients.is_empty());
     }
 
     // =========================================================================

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -25,6 +25,7 @@ const KIND_TEXT_NOTE: u16 = 1;
 const KIND_CONTACT_LIST: u16 = 3;
 const KIND_REACTION: u16 = 7;
 const KIND_REPOST: u16 = 16;
+const KIND_COMMENT: u16 = 1111;
 const KIND_LONG_FORM: u16 = 30023;
 
 pub struct NostrListener {
@@ -179,6 +180,7 @@ impl NostrListener {
             Kind::from(KIND_CONTACT_LIST),
             Kind::from(KIND_REACTION),
             Kind::from(KIND_REPOST),
+            Kind::from(KIND_COMMENT),
             Kind::from(KIND_LONG_FORM),
         ];
 

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -20,14 +20,6 @@ const KIND_REGISTRATION: u16 = 3079;
 const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
 
-/// Content event kinds that trigger notifications
-const KIND_TEXT_NOTE: u16 = 1;
-const KIND_CONTACT_LIST: u16 = 3;
-const KIND_REACTION: u16 = 7;
-const KIND_REPOST: u16 = 16;
-const KIND_COMMENT: u16 = 1111;
-const KIND_LONG_FORM: u16 = 30023;
-
 pub struct NostrListener {
     state: Arc<AppState>,
 }
@@ -169,20 +161,29 @@ impl NostrListener {
     }
 
     async fn subscribe_to_live_events(&self, token: &CancellationToken) -> Result<()> {
-        // Subscribe to all relevant kinds for diVine
-        let all_kinds = vec![
+        let mut all_kinds = vec![
             // Control kinds
             Kind::from(KIND_REGISTRATION),
             Kind::from(KIND_DEREGISTRATION),
             Kind::from(KIND_PREFERENCES_UPDATE),
-            // Notification trigger kinds
-            Kind::from(KIND_TEXT_NOTE),
-            Kind::from(KIND_CONTACT_LIST),
-            Kind::from(KIND_REACTION),
-            Kind::from(KIND_REPOST),
-            Kind::from(KIND_COMMENT),
-            Kind::from(KIND_LONG_FORM),
         ];
+
+        for kind in &self.state.settings.notification.event_kinds {
+            match u16::try_from(*kind) {
+                Ok(kind) => {
+                    let kind = Kind::from(kind);
+                    if !all_kinds.contains(&kind) {
+                        all_kinds.push(kind);
+                    }
+                }
+                Err(_) => {
+                    warn!(
+                        kind,
+                        "Skipping notification event kind outside Nostr u16 range"
+                    );
+                }
+            }
+        }
 
         // Look back 1 hour to catch any recent events
         let since = Timestamp::now() - Duration::from_secs(60 * 60);


### PR DESCRIPTION
## Summary

Push notifications could point people at the wrong video, and comments on videos sent no push at all.

This change makes the FCM payload carry the video's real target: the full `kind:pubkey:d-tag` coordinate and its parts, taken from the triggering event's signed `a`/`A` tag. The owner now comes from the actor's event, not from whoever is being notified. It also starts sending pushes for NIP-22 video comments (kind 1111), which the service ignored before. The docs now spell out which payload fields are safe to route on and which are display-only.

## Motivation

Mobile (divinevideo/divine-mobile#4727, divinevideo/divine-mobile#4730) needs a payload it can route from without guessing who owns a video. Before, the payload named a d-tag but never the owner, so the client assumed the owner was the recipient. That is right only when you act on your own video, and wrong for a reply to someone else's comment. Video comments (kind 1111) were dropped entirely, which is exactly where wrong-owner guessing hurts most.

## Related Issue

Part of #21. The end-to-end fix also needs the mobile consumer (divinevideo/divine-mobile#5003), the funnelcake producer (divinevideo/divine-funnelcake#458), and kind-3 follow pushes (divinevideo/divine-funnelcake#432).

## Testing

`cargo test` (72 pass), `cargo clippy --all-targets --all-features` (clean), `cargo fmt --check`. Added unit tests for addressable-coordinate extraction (like/repost, NIP-22 root-scope preference, no-coordinate fallback, colons in d-tag) and for kind 1111 recipients (reply notifies root + parent authors, top-level dedup, no author tags). Verified real event shapes against relay.divine.video.

## Protocol / Ops Notes

Additive and non-breaking. New `data` keys are extra strings existing clients ignore: `referencedAddress`, `referencedKind`, `referencedAuthorPubkey`, `referencedDTag`; `referencedEventId` now prefers the NIP-22 root scope (`E`) over the parent `e`. The service now also subscribes to kind 1111 and notifies both the video owner (root `P`) and the parent comment author (parent `p`), deduplicated.

## Sensitive Information Check

No partner, customer, or brand names or other sensitive identities appear in the title, branch name, or description.
