### PR TITLE
docs: update divine-context template to include PR review rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,24 @@ Code reads it via an `@AGENTS.md` import in `CLAUDE.md`. Keep Claude-only notes 
 
 ## Divine Context And Brain
 
-Before broad product, architecture, protocol, cross-repo, or service-boundary work, read the shared Divine context primer.
+Before broad product, architecture, protocol, cross-repo, service-boundary, or pull-request authoring, review, or modification work, read the shared Divine context primer.
 
-Use `DIVINE_CONTEXT_ROOT` if set; otherwise look for `../divine-context`. If it is missing, try:
+Resolve the context directory and clone it there if it is missing:
 
-`gh repo clone divinevideo/divine-context ../divine-context`
+```bash
+CONTEXT_DIR="${DIVINE_CONTEXT_ROOT:-../divine-context}"
+[ -e "$CONTEXT_DIR/.git" ] || gh repo clone divinevideo/divine-context "$CONTEXT_DIR"
+```
+
+Use that value as `<context-dir>` below.
 
 The `divine-context` repo is private, so cloning requires GitHub access. If clone, network, or auth fails, continue from the local repo docs and avoid cross-repo assumptions.
 
 Before updating an existing context checkout, verify it is clean and on its default branch. If it is clean and on the default branch, update it with `git -C <context-dir> pull --ff-only`. If it is dirty, on another branch, cannot fast-forward, or network/auth fails, leave it untouched and say the context may be stale.
 
 Read `<context-dir>/AGENT_CONTEXT.md` and follow its instructions. If unavailable, continue from the local repo docs and avoid cross-repo assumptions.
+
+Before working on a pull request, follow `<context-dir>/PR_REVIEW.md` and use `<context-dir>/PR_REVIEW_TEAMS.md` to request the normal team and check takeover authority. Ordinary review remains open to any eligible Divine human. Before modifying a pull-request branch, enforce the mapping and every takeover gate; if the mapping cannot be read, feedback-only review may continue but automated takeover must stop. Request and verify required human review automatically when tooling permits. If the runbook is unavailable, leave the pull request open and report the blocker.
 
 If a Divine Brain search or ask tool is available, you may use it for company memory. Treat it as optional and credentialed: tool names vary by client, and work must continue when Brain is unavailable. When Brain results influence work, cite the returned document ids. Never commit Brain credentials or expose Brain-derived sensitive content in public PRs, issues, branch names, commit messages, code comments, logs, screenshots, release notes, or externally shared agent transcripts.
 


### PR DESCRIPTION
## Summary

The repository's Divine context instructions had fallen behind the canonical template.
This sync adds the shared pull-request runbook references and expands the trigger wording to cover pull-request authoring, review, and modification.

## What Changed

Only the `## Divine Context And Brain` block in `AGENTS.md` changed.
The repository-specific guidance after that block is unchanged.

## Testing

The 22-line block was compared directly with `/tmp/opencode/AGENTS_DIVINE_CONTEXT.md`.
The full Rust test suite passed with a local Redis instance.

- `cargo test`

## Linked Issue

No linked issue; this is a canonical template sync.

## Risks

Risk is low because this is a documentation-only change with no runtime impact.
