### PR TITLE
ci: Fix CI: remove decommissioned TEST WIF pool from Build & Push step

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -115,18 +115,6 @@ jobs:
           repository: containers-poc
           region: ${{ env.GCP_REGION }}
 
-      - name: Push to Test
-        uses: divinevideo/divine-github-actions/docker-push-gcp@v1
-        with:
-          image-name: divine-push-service:local
-          registry-image: divine-push-service
-          tags: ${{ steps.tags.outputs.tags }}
-          wif-provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER_TEST }}
-          service-account: ${{ vars.SERVICE_ACCOUNT_TEST }}
-          project-id: ${{ vars.GCP_PROJECT_ID_TEST }}
-          repository: containers-test
-          region: ${{ env.GCP_REGION }}
-
       - name: Push to Staging
         uses: divinevideo/divine-github-actions/docker-push-gcp@v1
         with:
@@ -161,7 +149,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Environments:**" >> $GITHUB_STEP_SUMMARY
           echo "- POC: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_POC }}/containers-poc/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Test: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_TEST }}/containers-test/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
           echo "- Staging: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_STAGING }}/containers-staging/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ github.ref }}" == refs/tags/v* ]] || [[ "${{ inputs.include_production }}" == "true" ]]; then
             echo "- Production: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_PRODUCTION }}/containers-production/divine-push-service\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Build & Push stopped after POC because the workflow tried to authenticate with a retired Test Workload Identity provider.
This change removes the Test registry push and its summary entry, so the existing flow can continue to Staging and optional Production.

## Motivation

The Test environment no longer exists.
Keeping its authentication step made image publication fail before Staging and prevented the deploy dispatch.
The image is not redirected or retagged for another environment.

## Related Issue

Closes #31

## Testing

Local checks validate the workflow structure and the full Rust test job.

- `actionlint .github/workflows/publish-and-release.yml`
- Structural checks for removed Test references and unchanged publish/deploy paths
- `cargo test --verbose` with a local Redis service
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Protocol / Ops Notes

No notification or relay behavior changes.
POC, Staging, conditional Production, and both deploy environment arrays are unchanged.
Live cloud authentication and deploy dispatch require an Actions run; the older README deployment overview is outside this focused workflow change.

## Sensitive Information Check

Confirmed. No partner, customer, brand, or other sensitive external identity was added.