### PR TITLE
docs: plan new-post ("bell") push notifications

### DIFF
--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -210,7 +210,16 @@ the feature does nothing with no error anywhere.
 Handler requirements:
 1. Reject unless the `d` tag is exactly "notify" (defence in depth — the relay
    filter should guarantee it, but a buggy or hostile relay can send anything).
-2. Extract `p` values, parse as PublicKey, dedup, drop self-references.
+2. Extract `p` values, parse as PublicKey, dedup, drop self-references, then
+   truncate to config `notify_list_max_creators` (default 1000) with a warning
+   log. The Lua script below runs as one blocking unit and Redis is
+   single-threaded and shared with other services, so an unbounded list stalls
+   all of them. Truncate rather than reject — the user keeps the bells that fit
+   instead of losing every one, and `p` tags are client-ordered so which
+   survive is deterministic. Duplicates must not consume cap budget.
+   Keep this collection logic (dedup, self-filter, cap) in a PURE SYNC
+   function rather than inline in the async handler, or none of it is testable
+   without a live Redis and an AppState.
 3. Replaceable ordering guard: compare `event.created_at` against
    `notify_subs_ts:{author}`; drop and debug-log when stored >= incoming.
    Without this, a late-delivered older replacement resurrects an unbell.
@@ -226,8 +235,9 @@ declared in KEYS is not Redis-Cluster-safe; this deployment is single-instance
 
 Tests (all required): d-tag rejection; self-reference dropped; add/remove diff
 produces correct reverse-index membership; older created_at ignored; empty list
-clears everything. Follow tests/dedup_test.rs for the skip-cleanly-without-Redis
-convention.
+clears everything; the creator list truncates at the cap and duplicates do not
+consume cap budget. Follow tests/dedup_test.rs for the
+skip-cleanly-without-Redis convention.
 ```
 
 ---

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -238,13 +238,13 @@ Handler requirements:
 Redis: diff-and-apply must be atomic across replicas — use a Lua script keyed
 on the subscriber, re-checking the timestamp inside the script (the read in
 step 3 is advisory and racy alone). Writing `notify_watchers:*` keys not
-declared in KEYS is not Redis-Cluster-safe. That is acceptable, but cite the
-production topology in the comment, not docker-compose.yml: the deployment
-points at redis-replication-master.redis-clusters.svc.cluster.local:6379/2 and
-divine-iac-coreconfig's k8s/redis-clusters/base/cluster.yaml declares
-RedisReplication plus RedisSentinel — master/replica, one keyspace, no
-sharding. The namespace is called redis-clusters and is not Redis Cluster; say
-so, because that is what a future reader gets wrong in the unsafe direction.
+declared in KEYS is not Redis-Cluster-safe. That is acceptable, but justify it
+from the production topology in the comment, not from docker-compose.yml:
+production Redis is master/replica with Sentinel failover — a single keyspace,
+not a sharded Cluster — and is shared with other services on a dedicated
+logical database. Word the comment so the distinction survives: the manifests
+sit under a cluster-flavoured name while not being Redis Cluster, and that is
+what a future reader gets wrong in the unsafe direction.
 
 Tests (all required): d-tag rejection; self-reference dropped; add/remove diff
 produces correct reverse-index membership; older created_at ignored; empty list

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -238,8 +238,13 @@ Handler requirements:
 Redis: diff-and-apply must be atomic across replicas — use a Lua script keyed
 on the subscriber, re-checking the timestamp inside the script (the read in
 step 3 is advisory and racy alone). Writing `notify_watchers:*` keys not
-declared in KEYS is not Redis-Cluster-safe; this deployment is single-instance
-(docker-compose.yml), so that is acceptable — add a comment saying so.
+declared in KEYS is not Redis-Cluster-safe. That is acceptable, but cite the
+production topology in the comment, not docker-compose.yml: the deployment
+points at redis-replication-master.redis-clusters.svc.cluster.local:6379/2 and
+divine-iac-coreconfig's k8s/redis-clusters/base/cluster.yaml declares
+RedisReplication plus RedisSentinel — master/replica, one keyspace, no
+sharding. The namespace is called redis-clusters and is not Redis Cluster; say
+so, because that is what a future reader gets wrong in the unsafe direction.
 
 Tests (all required): d-tag rejection; self-reference dropped; add/remove diff
 produces correct reverse-index membership; older created_at ignored; empty list

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -244,8 +244,11 @@ declared in KEYS is not Redis-Cluster-safe; this deployment is single-instance
 Tests (all required): d-tag rejection; self-reference dropped; add/remove diff
 produces correct reverse-index membership; older created_at ignored; empty list
 clears everything; the creator list truncates at the cap and duplicates do not
-consume cap budget. Follow tests/dedup_test.rs for the
-skip-cleanly-without-Redis convention.
+consume cap budget. For the skip-cleanly-without-Redis convention copy
+`create_test_pool` from tests/dedup_test.rs, which PINGs before handing back
+the pool — NOT `get_test_pool` from tests/preferences_test.rs, which only
+checks that create_pool returned Ok and leaves the tests to panic on the bb8
+timeout when no server is listening.
 ```
 
 ---

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -13,24 +13,28 @@ Service status: **not started.**
 
 ## 1. Why this document exists
 
-The design doc was written *before* the mobile side was built, so several of
-its statements about the client were assumptions. They have now been
-implemented and verified. Three of the design's original assumptions were
-**wrong** and were corrected in mobile; one instruction in the design doc is
-now **stale** as a result.
+The design doc describes the service. This one carries the **client half of
+the contract**, verified against mobile code that now exists.
 
-**Read this section before task 4 in the design doc.** It contradicts it.
+**Read this section before task 4 in the design doc.** Task 4 currently says
+mobile *cannot* satisfy the preference dependency, and blocks on it. That is
+no longer true.
 
-### Corrected: the client-dependency in design task 4
+### Superseded: the client-dependency in design task 4
 
-The design said no server-side backfill is needed because "the client
-publishes kind 3083 including 34236 at the same moment it publishes the notify
-list," and asked the implementer to *confirm* that. At the time that work did
-not exist. `NotificationPreferences` was five fixed booleans and
-`toKindsList()` could only emit a subset of `{1,3,7,16}` — 34236 was
-structurally unpublishable.
+Design task 4 states, correctly as of 2026-07-29:
 
-It now works, but by a **different mechanism** than the design assumed:
+> **This is a hard dependency on mobile, and as of 2026-07-29 mobile cannot
+> satisfy it.** … `toKindsList()` can only emit a subset of `{1, 3, 7, 16}`,
+> so **34236 is never published today** and this check gates every new-post
+> push off.
+
+As of 2026-07-30 mobile **can** satisfy it. That paragraph is resolved — do not
+treat it as an open blocker.
+
+It works by a **different mechanism** than either version of the design
+assumed. The design expected the bell publish and the preference publish to
+happen together; they are in fact decoupled:
 
 - A sixth flag `newPostsEnabled` (default `true`) emits `34236`
   (`mobile/lib/models/notification_preferences.dart`).
@@ -50,6 +54,14 @@ Do not write one.
 - Kind 34236 is already subscribed (`config/settings.yaml:44`).
 - `insert_video_reference_fields` (`event_handler.rs:937`) already emits the
   exact routing payload. Do not add new payload fields.
+- Design task 4's other correction still holds: the `display_name` string is
+  matched in `notificationKindFromPushType`, not `parseFcmPayload`. Mobile now
+  knows `newPost`, so the tap route resolves — but only for that exact casing
+  (see [2.2](#22-fcm-payload-service-sends-client-reads)).
+- The `d=notify` / mobile list-UI collision the design flags as a risk is
+  **fixed in mobile** (`Nip51PeopleListCodec.reservedDTags`). The reason it
+  mattered to this service — treat an empty `p` list as legitimate, not
+  malformed — is unchanged and still required.
 
 ---
 

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -1,0 +1,397 @@
+# Agent handoff: new-post ("bell") notifications
+
+Companion to [`new-post-notifications.md`](new-post-notifications.md), which is
+the design. This file is the **execution packet**: verified cross-repo facts,
+then one copy-pasteable prompt per task.
+
+Date: 2026-07-30
+Mobile status: **built and tested**, branch `design/bell-notifications` in
+`divine-mobile` (6 commits, unpushed at time of writing).
+Service status: **not started.**
+
+---
+
+## 1. Why this document exists
+
+The design doc was written *before* the mobile side was built, so several of
+its statements about the client were assumptions. They have now been
+implemented and verified. Three of the design's original assumptions were
+**wrong** and were corrected in mobile; one instruction in the design doc is
+now **stale** as a result.
+
+**Read this section before task 4 in the design doc.** It contradicts it.
+
+### Corrected: the client-dependency in design task 4
+
+The design said no server-side backfill is needed because "the client
+publishes kind 3083 including 34236 at the same moment it publishes the notify
+list," and asked the implementer to *confirm* that. At the time that work did
+not exist. `NotificationPreferences` was five fixed booleans and
+`toKindsList()` could only emit a subset of `{1,3,7,16}` — 34236 was
+structurally unpublishable.
+
+It now works, but by a **different mechanism** than the design assumed:
+
+- A sixth flag `newPostsEnabled` (default `true`) emits `34236`
+  (`mobile/lib/models/notification_preferences.dart`).
+- Republishing is driven by a **persisted schema-version marker**, not by the
+  bell. On session readiness, if the last-published kind-list schema version
+  lags the current one, preferences are marked dirty and the existing drain
+  publishes them
+  (`mobile/lib/services/notification_preferences_service.dart`,
+  `publishedKindsSchemaVersion = 1`).
+
+Consequence for this service: **34236 arrives in kind 3083 on the upgraded
+client's first ready session**, not on first bell. Still no backfill needed.
+Do not write one.
+
+### Still true and load-bearing
+
+- Kind 34236 is already subscribed (`config/settings.yaml:44`).
+- `insert_video_reference_fields` (`event_handler.rs:937`) already emits the
+  exact routing payload. Do not add new payload fields.
+
+---
+
+## 2. Verified wire contract
+
+Every value below was read out of the built mobile code. These are exact.
+
+### 2.1 Subscription list event (client publishes, service reads)
+
+```
+kind:       30000
+tags:       ["d", "notify"]
+            ["title", "Notify"]
+            ["p", "<64-char-lowercase-hex>"]   × N
+content:    ""
+```
+
+- `d` tag is exactly `notify`. Source:
+  `Nip51PeopleListCodec.notifyDTag`.
+- `title` is exactly `Notify`.
+- An **empty `p` set is legitimate** — it is how a user clears every bell. The
+  client publishes a `d`/`title`-only event. Do not treat it as malformed.
+- Pubkeys are full 64-char hex, never truncated, deduped, and the client never
+  writes a self-reference.
+- `created_at` is **monotonic per client**: the client steps past the previous
+  event's `created_at` when two toggles land in the same second, because
+  NIP-33 tie-breaking is unspecified. Your ordering guard should still compare
+  `>=`, but you will not see equal timestamps from a well-behaved client.
+
+### 2.2 FCM payload (service sends, client reads)
+
+The `type` string is a **wire contract**, matched exactly by
+`notificationKindFromPushType` in
+`mobile/lib/notifications/routing/notification_tap_target.dart`.
+
+| key | value | required |
+|---|---|---|
+| `type` | `newPost` — **camelCase**, not `new_post`, not `newpost` | yes |
+| `body` | e.g. `Alice posted a new vine` | **yes — see below** |
+| `title` | e.g. `New vine` | no (falls back to `diVine`) |
+| `senderPubkey` | creator hex | yes |
+| `eventId` | the kind-34236 event id | yes |
+| `referencedAddress` | `34236:<creator-hex>:<d-tag>` | yes — this is the tap target |
+| `referencedEventId` | the video event id | yes |
+| `referencedKind`, `referencedAuthorPubkey`, `referencedDTag` | coordinate components | emitted already |
+
+**`body` must be non-empty or the notification is silently dropped.**
+`PushNotificationService.handleForegroundMessage`
+(`push_notification_service.dart:299`) returns early and logs
+`'Foreground message missing body — skipping local notification'` when `body`
+is absent. A payload that is otherwise perfect but has no `body` produces
+*nothing* on the device, with no user-visible error. This is the single
+easiest way to ship a silently broken feature.
+
+**Casing:** `notificationKindFromPushType('newpost')` and `'NewPost'` both
+return `null`. The push still displays (the parser is type-agnostic and
+`referencedAddress` is present), but the tap target degrades to a best-effort
+profile/inbox guess instead of opening the video. So a casing bug is
+*invisible in QA unless you tap the notification.*
+
+**Comments must not auto-open.** `notificationKindOpensComments` returns
+`false` for `newPost`, which is correct — a new video has no comment to open.
+Nothing to do; do not add a `hasCommentTarget` field for this type.
+
+### 2.3 Preference gating
+
+- Gate on kind `34236` present in the user's stored preference kind list.
+- `Mention` remains kind `1`, so the two are independently mutable even though
+  video mentions also arrive on kind-34236 events. Verified by a mobile test
+  (`toKindsList includes kind 34236 independently of mentions`).
+- Add `34236` to `UserPreferences::default()` **and** to
+  `notification.default_preferences.kinds` in both `config/settings.yaml` and
+  `config/settings.development.yaml`.
+
+---
+
+## 3. Task prompts
+
+Each prompt is self-contained. Run them in order — 1→2 and 3→4 have real
+dependencies. Prompts 5, 6, 7 are independent of each other once 3 lands.
+
+Every prompt assumes the agent has read `AGENTS.md` and
+`docs/plans/new-post-notifications.md` in this repo.
+
+---
+
+### Prompt 1 — subscribe to `d=notify` lists
+
+```
+Read docs/plans/new-post-notifications.md (task 1) and
+docs/plans/new-post-notifications-AGENT-PROMPTS.md (sections 1 and 2.1) first.
+
+Implement subscription to NIP-51 kind 30000 people lists carrying the exact
+`d` tag "notify", in src/nostr_listener.rs.
+
+Requirements:
+- Add `const KIND_NOTIFY_LIST: u16 = 30000;` and a `NOTIFY_LIST_D_TAG`
+  constant with value "notify".
+- Use a SECOND, SEPARATE filter — nostr-sdk 0.44 exposes the NIP-01 `#d`
+  filter as `Filter::identifier`. It must not be merged into the existing
+  `.kinds(all_kinds)` filter, because an identifier constraint there would
+  wrongly apply to every kind in that list. `subscribe` takes one filter per
+  call, so issue a second `subscribe`.
+- Add the filter to BOTH `process_historical_events` and
+  `subscribe_to_live_events`.
+- The historical notify-list query must use NO `since` bound. A replaceable
+  list published three months ago and untouched since is still current;
+  bounding it by `process_window_days` (7) would silently drop most
+  subscriptions on restart. Add config `notify_list_history_limit`
+  (default 5000) as a result-size safety valve instead.
+
+Verify: `cargo clippy --all-targets --all-features` and `cargo test` clean.
+Do not implement the handler yet — that is task 2. This task should compile
+with the events routed nowhere, or routed to a stub that logs and returns Ok.
+```
+
+---
+
+### Prompt 2 — ingest lists into the Redis reverse index
+
+```
+Read docs/plans/new-post-notifications.md (task 2, including the Redis schema
+table) and AGENT-PROMPTS section 2.1 first. Task 1 must be merged.
+
+Implement `handle_notify_list_update` in src/event_handler.rs plus
+`replace_notify_subscriptions` in src/redis_store.rs.
+
+CRITICAL — the most likely way to get this silently wrong:
+Route kind 30000 in `route_event` BEFORE the control-event block and OUTSIDE
+the `is_event_for_service` p-tag gate. These events are addressed to the world,
+not to this service. If they go through that gate, every list is dropped and
+the feature does nothing with no error anywhere.
+
+Handler requirements:
+1. Reject unless the `d` tag is exactly "notify" (defence in depth — the relay
+   filter should guarantee it, but a buggy or hostile relay can send anything).
+2. Extract `p` values, parse as PublicKey, dedup, drop self-references.
+3. Replaceable ordering guard: compare `event.created_at` against
+   `notify_subs_ts:{author}`; drop and debug-log when stored >= incoming.
+   Without this, a late-delivered older replacement resurrects an unbell.
+4. An EMPTY `p` set is legitimate — it is how a user clears every bell. It must
+   clear the forward set and remove the subscriber from every reverse index.
+   Do NOT treat empty as malformed-and-skip.
+
+Redis: diff-and-apply must be atomic across replicas — use a Lua script keyed
+on the subscriber, re-checking the timestamp inside the script (the read in
+step 3 is advisory and racy alone). Writing `notify_watchers:*` keys not
+declared in KEYS is not Redis-Cluster-safe; this deployment is single-instance
+(docker-compose.yml), so that is acceptable — add a comment saying so.
+
+Tests (all required): d-tag rejection; self-reference dropped; add/remove diff
+produces correct reverse-index membership; older created_at ignored; empty list
+clears everything. Follow tests/dedup_test.rs for the skip-cleanly-without-Redis
+convention.
+```
+
+---
+
+### Prompt 3 — resolve new-post recipients
+
+```
+Read docs/plans/new-post-notifications.md (task 3) and AGENT-PROMPTS section
+2.2 first. Task 2 must be merged.
+
+Add `NotificationType::NewPost` in src/preferences.rs with:
+- `display_name()` returning exactly "newPost" (camelCase — this string is a
+  wire contract matched by the mobile client; "new_post" or "newpost" degrades
+  the tap target to a profile guess, which QA will not notice unless someone
+  taps the notification)
+- `kind()` returning 34236
+
+STRUCTURAL CHANGE, unavoidable: `handle_content_event` currently computes a
+single `(NotificationType, Vec<PublicKey>)` tuple (event_handler.rs:384). A
+kind-34236 event can now produce BOTH Mention recipients (existing "Inspired
+by" behaviour) and NewPost recipients. Change the shape to a flat
+`Vec<NotificationTarget>` where `NotificationTarget { recipient, notification_type }`,
+and iterate targets in the send loop.
+
+`video_notification` becomes async and returns mention targets plus
+`SMEMBERS notify_watchers:{event.pubkey}` as NewPost targets.
+
+Dedup rule: MENTION WINS. If a user both watches the creator and is mentioned
+in the video, send exactly one push typed Mention. Build mention targets first
+and skip any watcher already present. (The mobile client has the same rule for
+its in-app rows, so the two stay consistent.)
+
+Filter out watchers equal to `event.pubkey` before the Redis round-trip.
+
+Tests: watcher yields a NewPost target; mentioned watcher yields exactly one
+Mention target and NO NewPost target; author watching themselves yields
+nothing; no watchers leaves existing mention-only behaviour byte-identical.
+```
+
+---
+
+### Prompt 4 — preference gating
+
+```
+Read AGENT-PROMPTS section 1 ("Corrected: the client-dependency in design task
+4") and section 2.3. NOTE: the design doc's task 4 is stale on how the client
+publishes 34236 — AGENT-PROMPTS supersedes it.
+
+Add 34236 to `UserPreferences::default()` and to
+`notification.default_preferences.kinds` in BOTH config/settings.yaml and
+config/settings.development.yaml.
+
+`NewPost.kind()` returning 34236 means the existing
+`notification_type.is_enabled(&prefs)` check at event_handler.rs:624 gates it
+with no further change.
+
+DO NOT write a Redis backfill migration for existing `user_preferences:*`
+entries. The mobile client republishes kind 3083 including 34236 on the first
+ready session after upgrade, driven by a persisted schema-version marker
+(NotificationPreferencesService.publishedKindsSchemaVersion). A backfill would
+be redundant and would overwrite preferences the client is about to restate.
+
+Tests: `NewPost.kind() == 34236`; `NewPost.is_enabled()` false when prefs omit
+34236; enabled under the shipped defaults; Mention still gates on kind 1 so the
+two are independent.
+```
+
+---
+
+### Prompt 5 — per-creator rate limit
+
+```
+Read docs/plans/new-post-notifications.md (task 5). Task 3 must be merged.
+
+Cap delivery at one push per (subscriber, creator) per window. Vines are cheap
+to make; an unthrottled prolific creator trains users to disable notifications
+entirely.
+
+Add `new_post_rate_limit_secs` to ServiceSettings, default 3600, following the
+`default_video_coordinate_dedup_ttl` pattern (config.rs:64).
+
+In `send_notification_to_user`, for NotificationType::NewPost only:
+- BEFORE building the payload (alongside the existing video-coordinate check at
+  event_handler.rs:634): `get_cached_string` on
+  `notify_rate:{recipient}:{creator}`, return early if present.
+- AFTER `success_count > 0` (alongside event_handler.rs:732):
+  `set_cached_string` with `new_post_rate_limit_secs`.
+
+Use check-then-set-on-success, NOT an atomic `SET NX EX`. Rationale that MUST
+go in a code comment so a future reader does not "fix" it: SET NX EX would burn
+the user's hour-long window on a failed FCM send. The cost is that two replicas
+processing different videos from one creator in the same instant can both pass
+the check and double-send — a rare, bounded, low-harm race. Silently eating an
+hour of notifications on an FCM blip is worse.
+
+The limit is PUSH-ONLY. The in-app feed shows every post; a user who gets one
+push for a six-post burst opens the app and sees all six. That asymmetry is
+intended, not a bug.
+
+Verify explicitly with a test rather than assuming: the existing per-recipient
+coordinate claim (`video_recipient_claim_key`, event_handler.rs:533) is keyed
+on {kind}:{author}:{d_tag}:{recipient} and should already prevent a NIP-33
+EDIT of the same video from re-notifying. Confirm that holds for NewPost
+targets.
+
+Tests: second video from same creator inside window suppressed; video from a
+DIFFERENT creator in the same window delivered; window marker NOT written when
+every FCM send fails; an edited video does not re-notify.
+```
+
+---
+
+### Prompt 6 — FCM copy
+
+```
+Read AGENT-PROMPTS section 2.2. Task 3 must be merged.
+
+Add the NotificationType::NewPost arm to `create_fcm_payload`
+(event_handler.rs:804):
+
+    NotificationType::NewPost => (
+        "New vine".to_string(),
+        format!("{} posted a new vine", sender_name),
+    ),
+
+`body` MUST be non-empty. The mobile client silently drops any notification
+without a `body` (push_notification_service.dart:299 — early return, warning
+log, no user-visible error). Assert this in a test.
+
+`sender_name` resolution via `mention_parser_service` already works for
+kind-34236 events; no change needed.
+
+The copy above is PROVISIONAL and matches what mobile currently renders for its
+in-app row. Both need sign-off against
+divine-mobile/brand-guidelines/TONE_OF_VOICE.md before release. Flag it in the
+PR description rather than treating it as approved.
+```
+
+---
+
+### Prompt 7 — docs
+
+```
+Update, in this repo:
+- README.md "Notification types" table: add the New post row (kind 34236,
+  triggered by a watched creator posting). The table currently ends at Repost.
+- docs/nip-xx-push-notifications.md: specify the d=notify kind-30000 list —
+  tag shape, replaceable semantics, empty-list-means-cleared, and that it is
+  PUBLIC (anyone can read who a user subscribes to; this was a deliberate
+  portability tradeoff, not an oversight).
+- docs/developer-guide.md: the four Redis key families, reverse-index
+  maintenance, and the rate-limit window. Include the FCM payload contract
+  from AGENT-PROMPTS section 2.2, since that is where clients will look.
+- AGENTS.md: add the new keys to "Redis Keys" and NewPost to "Notification
+  Types". Both tables go stale the moment task 2 lands.
+```
+
+---
+
+## 4. End-to-end verification
+
+Cannot be done from this repo alone — needs the mobile branch on a device.
+
+1. Bell creator B from account A in the app. Confirm a kind 30000 event with
+   `["d","notify"]` and B's full 64-char `p` tag reaches the relay.
+2. Confirm `notify_watchers:{B}` contains A.
+3. Confirm A's stored preferences in Redis contain 34236. **If they do not, the
+   client's schema-marker republish did not run — do not work around it here,
+   it is a mobile bug.**
+4. Post a video as B. Confirm A receives a push titled "New vine".
+5. **Tap it.** Confirm it opens the video, not A's profile or the inbox. This
+   is the only step that catches a `type` casing mismatch.
+6. Post again within the hour. Confirm no second push and a rate-limit skip in
+   the logs.
+7. Unbell B. Confirm the republished list drops B's `p` tag and pushes stop.
+8. Unfollow B while belled. Confirm the bell and subscription both clear — the
+   client publishes the teardown from a host above the bell, so this works even
+   though the bell unmounts.
+
+## 5. Known gaps outside this repo
+
+- **divine-funnelcake has no owner for the in-app row.** The push is
+  rate-limited; the in-app feed is not, so FunnelCake needs its own fan-out
+  rather than mirroring what this service sent. It would be the inbox's first
+  subscription-driven fan-out — every existing source resolves recipients from
+  tags on the event itself, whereas new-post rows have no `p` tag and need a
+  join against the `d=notify` lists. Mobile already accepts a `newPost` row
+  type; it renders nothing until FunnelCake emits one.
+- **Mobile ships a live bell and a live settings toggle for a feature with no
+  backend.** Until this service deploys, both are inert. Whether that merges
+  behind a feature flag is an open product decision.

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -56,7 +56,8 @@ Do not write one.
   exact routing payload. Do not add new payload fields.
 - Design task 4's other correction still holds: the `display_name` string is
   matched in `notificationKindFromPushType`, not `parseFcmPayload`. Mobile now
-  knows `newPost`, so the tap route resolves — but only for that exact casing
+  knows `newPost`. The tap route resolves to the video even for a value mobile
+  does not recognize, so casing drives in-app row typing rather than routing
   (see [2.2](#22-fcm-payload-service-sends-client-reads)).
 - The `d=notify` / mobile list-UI collision the design flags as a risk is
   **fixed in mobile** (`Nip51PeopleListCodec.reservedDTags`). The reason it
@@ -117,10 +118,17 @@ is absent. A payload that is otherwise perfect but has no `body` produces
 easiest way to ship a silently broken feature.
 
 **Casing:** `notificationKindFromPushType('newpost')` and `'NewPost'` both
-return `null`. The push still displays (the parser is type-agnostic and
-`referencedAddress` is present), but the tap target degrades to a best-effort
-profile/inbox guess instead of opening the video. So a casing bug is
-*invisible in QA unless you tap the notification.*
+return `null`. That does **not** break the tap route.
+`resolveNotificationTapTarget` routes any non-`follow`, non-`system` kind
+with a video target to `OpenVideoTarget`, and `null` is neither
+(`notification_tap_target.dart:145-166`), so with `referencedAddress` present
+the notification still opens the video — `autoOpenComments` false, which is
+what a new post wants. Degrading to a profile/inbox guess happens only when
+there is *no* video target, which is not this payload.
+
+What a miscased value costs is the `NotificationKind` mobile maps for in-app
+row typing. Match the casing mobile actually ships, and do not rely on step 5
+of the end-to-end check to catch a mismatch — the tap succeeds either way.
 
 **Comments must not auto-open.** `notificationKindOpensComments` returns
 `false` for `newPost`, which is correct — a new video has no comment to open.
@@ -250,9 +258,10 @@ Read docs/plans/new-post-notifications.md (task 3) and AGENT-PROMPTS section
 
 Add `NotificationType::NewPost` in src/preferences.rs with:
 - `display_name()` returning exactly "newPost" (camelCase — this string is a
-  wire contract matched by the mobile client; "new_post" or "newpost" degrades
-  the tap target to a profile guess, which QA will not notice unless someone
-  taps the notification)
+  wire contract matched by the mobile client. It does not affect tap routing:
+  an unrecognized value still opens the video because `referencedAddress` is
+  present. It does decide the `NotificationKind` mobile uses for in-app row
+  typing, so it has to match what mobile ships.)
 - `kind()` returning 34236
 
 STRUCTURAL CHANGE, unavoidable: `handle_content_event` currently computes a
@@ -409,7 +418,8 @@ Cannot be done from this repo alone — needs the mobile branch on a device.
    it is a mobile bug.**
 4. Post a video as B. Confirm A receives a push titled "New vine".
 5. **Tap it.** Confirm it opens the video, not A's profile or the inbox. This
-   is the only step that catches a `type` casing mismatch.
+   will pass even if `type` is miscased, so it does not verify the casing —
+   check the in-app row renders as a new-post row for that.
 6. Post again within the hour. Confirm no second push and a rate-limit skip in
    the logs.
 7. Unbell B. Confirm the republished list drops B's `p` tag and pushes stop.

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -294,7 +294,7 @@ nothing; no watchers leaves existing mention-only behaviour byte-identical.
 ### Prompt 4 — preference gating
 
 ```
-Read AGENT-PROMPTS section 1 ("Corrected: the client-dependency in design task
+Read AGENT-PROMPTS section 1 ("Superseded: the client-dependency in design task
 4") and section 2.3. NOTE: the design doc's task 4 is stale on how the client
 publishes 34236 — AGENT-PROMPTS supersedes it.
 

--- a/docs/plans/new-post-notifications-AGENT-PROMPTS.md
+++ b/docs/plans/new-post-notifications-AGENT-PROMPTS.md
@@ -170,8 +170,20 @@ Requirements:
 - The historical notify-list query must use NO `since` bound. A replaceable
   list published three months ago and untouched since is still current;
   bounding it by `process_window_days` (7) would silently drop most
-  subscriptions on restart. Add config `notify_list_history_limit`
-  (default 5000) as a result-size safety valve instead.
+  subscriptions when the index has to be rebuilt. Add config
+  `notify_list_history_limit` (default 5000) as a result-size safety valve
+  instead.
+- STOP before assuming the previous bullet is enough — it is not, and the
+  gap is unresolved in the design. `run()` calls `is_event_too_old(&event)`
+  on every event before `route_event` ever sees it (event_handler.rs:93),
+  against a hard-coded `REPLAY_HORIZON_DAYS = 7` (event_handler.rs:40). A
+  90-day-old d=notify event is dropped there regardless of the filter, so
+  removing `since` alone recovers nothing older than a week. Do not invent
+  the fix: raise it with the PR author, then implement whatever is decided
+  and add a boundary test either side of the horizon. Related, same loop:
+  `try_claim_event` (event_handler.rs:105) writes `dedup:{event_id}` with a
+  7-day TTL before routing, so an already-processed list event is dropped as
+  a duplicate on replay.
 
 Verify: `cargo clippy --all-targets --all-features` and `cargo test` clean.
 Do not implement the handler yet — that is task 2. This task should compile

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -250,11 +250,25 @@ with `display_name() == "newPost"` and `kind() == 34236`.
 
 The `display_name` string is a wire contract — `divine-mobile` matches on
 it in `notificationKindFromPushType`
-(`mobile/lib/notifications/routing/notification_tap_target.dart`), which
-returns `null` for unrecognized values and degrades the tap target. It
-does not yet know `newPost`. `parseFcmPayload` is type-agnostic, so the
-push still displays; only the tap route is wrong. Do not change this
-string casually.
+(`mobile/lib/notifications/routing/notification_tap_target.dart:90`),
+which recognizes exactly five lowercase values
+(`like`/`comment`/`follow`/`mention`/`repost`) and returns `null` for
+anything else.
+
+An unrecognized value is **non-fatal, and the tap still routes
+correctly.** `resolveNotificationTapTarget` sends any non-`follow`,
+non-`system` kind with a video target to `OpenVideoTarget`, and `null` is
+neither (`notification_tap_target.dart:145-166`). Because this service
+always emits `referencedAddress` for a kind-34236 trigger,
+`hasVideoTarget` is true, so the notification opens the video with
+`autoOpenComments` false — correct for a new post. No client change is
+needed for routing to work.
+
+What the string does drive is the `NotificationKind` mobile uses for
+in-app row typing, so still do not change it casually. Note every value
+mobile recognizes today is lowercase, which argues for `newpost` over
+`newPost`; that is a cross-repo contract decision, not a detail to settle
+by whichever repo lands first.
 
 **Structural change required.** `handle_content_event` currently
 computes a single `(NotificationType, Vec<PublicKey>)` tuple

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -153,7 +153,18 @@ if kind_num == KIND_NOTIFY_LIST {
 
 Add `redis_store::replace_notify_subscriptions(pool, subscriber, creators, created_at)`.
 The diff-and-apply must be atomic across replicas — do it in a **Lua
-script** keyed on the subscriber:
+script** keyed on the subscriber.
+
+Why atomic, concretely: production runs **2 replicas**
+(`divine-iac-coreconfig`, `k8s/applications/divine-push-service/overlays/production/kustomization.yaml`;
+staging and poc run 1, no HPA). `try_claim_event` only prevents two
+replicas handling the *same* event — two different list events from one
+subscriber can still land concurrently, and a read-then-write lets the
+older one win, resurrecting an unbell. `MULTI`/`EXEC` cannot express
+this: it queues blind writes, so the old set would have to be read
+outside the transaction. `WATCH` + retry would also work but is more
+code over pooled connections. A single-replica deployment needs none of
+this — the handler loop is sequential within a process.
 
 ```
 -- KEYS[1] = notify_subs:{sub}, KEYS[2] = notify_subs_ts:{sub}
@@ -170,13 +181,28 @@ subscriber from `notify_watchers:{removed}`, `SADD`s to
 (`docker-compose.yml`), so that is acceptable — **add a comment saying
 so** and gate on it if the deployment ever moves to Redis Cluster.
 
+**Bound the creator list before it reaches Redis.** The script runs as
+one blocking unit and Redis is single-threaded, so a list with thousands
+of `p` tags stalls the instance for every user. Add config
+`notify_list_max_creators` (default `1000`, well above any follow-gated
+bell list) and truncate with a warning rather than rejecting the list —
+the user keeps the bells that fit instead of losing all of them, and `p`
+tags are client-ordered so which survive is deterministic. This matters
+more than the cluster-safety note above: Cluster is hypothetical, an
+oversized list is something a user can do today.
+
 An empty `p` tag list is legitimate (user unbelled everyone) and must
 clear the forward set and remove them from every reverse index. Do not
 treat empty as "malformed, skip".
 
 **Tests:** `d`-tag rejection; self-reference dropped; add/remove diff
 produces the right reverse-index membership; an older `created_at` is
-ignored; empty list clears everything.
+ignored; empty list clears everything; the creator list truncates at the
+cap and duplicates do not consume cap budget.
+
+Keep the collection logic (dedup, self-filter, cap) in a **pure sync
+function** rather than inline in the async handler, or none of it is
+testable without a live Redis and an `AppState`.
 
 ### 3. Resolve new-post recipients
 

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -185,9 +185,13 @@ ignored; empty list clears everything.
 Add `NotificationType::NewPost` to the enum (`preferences.rs:50`),
 with `display_name() == "newPost"` and `kind() == 34236`.
 
-The `display_name` string is a wire contract — `divine-mobile` matches
-on it in `parseFcmPayload` (`mobile/lib/services/notification_helpers.dart`).
-Do not change it casually.
+The `display_name` string is a wire contract — `divine-mobile` matches on
+it in `notificationKindFromPushType`
+(`mobile/lib/notifications/routing/notification_tap_target.dart`), which
+returns `null` for unrecognized values and degrades the tap target. It
+does not yet know `newPost`. `parseFcmPayload` is type-agnostic, so the
+push still displays; only the tap route is wrong. Do not change this
+string casually.
 
 **Structural change required.** `handle_content_event` currently
 computes a single `(NotificationType, Vec<PublicKey>)` tuple
@@ -239,14 +243,25 @@ Add `34236` to `UserPreferences::default()` and to
 **No server-side backfill is needed, and none should be written.**
 Users with a stale `user_preferences:*` entry lacking 34236 would be
 silently gated off — but reaching this code path at all requires having
-belled someone, which requires the new mobile build, which publishes
-kind 3083 including 34236 at the same moment it publishes the notify
-list. The client-side ordering makes the migration unnecessary.
+belled someone, which requires the new mobile build. Provided that build
+publishes kind 3083 including 34236 alongside the notify list, the
+client-side ordering makes a migration unnecessary.
 
-**This is a hard dependency on the mobile side.** Confirm the mobile PR
-publishes preferences alongside the first bell before shipping this
-service change, or new-post pushes will be gated off for every existing
-user and the bug will look like a service failure.
+**This is a hard dependency on mobile, and as of 2026-07-29 mobile
+cannot satisfy it.** `NotificationPreferences`
+(`mobile/lib/models/notification_preferences.dart`) is five fixed
+booleans, and `toKindsList()` can only emit a subset of `{1, 3, 7, 16}`.
+`push_notification_service.dart:254` publishes exactly that list, so
+**34236 is never published today** and this check gates every new-post
+push off.
+
+That is not a rollout-timing risk to be confirmed before shipping — it
+is the current state, and it fails silently. Mobile needs a sixth
+preference flag mapping to 34236 before any bell can produce a push.
+Tracked in the mobile design doc
+(`divine-mobile/docs/plans/2026-07-29-bell-notifications-design.md`,
+finding 2). Shipping this service change first is still safe: it finds
+no watchers and does nothing.
 
 **Tests:** `NewPost.kind() == 34236`; `NewPost.is_enabled()` false when
 prefs omit 34236; enabled under the shipped defaults.
@@ -373,7 +388,18 @@ the content field — that would make the list unreadable to this service
 and break the feature entirely.
 
 **Client dependency.** Task 4 is gated on the mobile client publishing
-34236 in its preferences. Ship order matters: service first is safe (it
-simply finds no watchers), client-first is safe (pushes start when the
-service deploys). Only a *partial* client rollout that publishes notify
-lists without updating preferences produces silent failure.
+34236 in its preferences, which it does not do today (see task 4). Ship
+order between the repos is still safe in both directions: service first
+finds no watchers and does nothing, client-first starts delivering when
+the service deploys. The unsafe case is a *partial* client rollout that
+publishes notify lists without the preference change — pushes are gated
+off silently and it looks like a service failure. That is the current
+mobile state, so the mobile release must carry both.
+
+**Reserved `d` tag collides with the mobile list UI.** `d=notify` decodes
+as an ordinary user-editable people list in `divine-mobile`
+(`Nip51PeopleListCodec` excludes only `d=block`), so before the mobile
+fix lands a user can rename or delete the list and silently wipe their
+own subscriptions. Nothing the service can defend against — it just sees
+a replacement list — but it is why the service must treat an empty `p`
+list as legitimate (task 2) rather than assuming malformed input.

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -114,10 +114,8 @@ events when `context == EventContext::Historical`
 (`event_handler.rs:192`), but notify lists must be rebuilt from history
 or the reverse index cannot be recovered after Redis data loss — every
 subscription stays dark until each user happens to republish. (A process
-restart on its own is fine: Redis is external, so the index survives
-it. Defending the requirement on its real grounds makes it harder to
-argue away later.) Treat them like control events: process in both
-paths.
+restart on its own is fine — Redis is external, so the index survives
+it.) Treat them like control events: process in both paths.
 
 Make the historical lookback for notify lists independent of
 `process_window_days` (7 days). A list published 3 months ago and never

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -112,8 +112,12 @@ extra filter; `subscribe` accepts one filter per call, so issue a second
 **Historical processing is mandatory here.** `route_event` skips content
 events when `context == EventContext::Historical`
 (`event_handler.rs:192`), but notify lists must be rebuilt from history
-or a restart silently drops every subscription until each user happens
-to republish. Treat them like control events: process in both paths.
+or the reverse index cannot be recovered after Redis data loss — every
+subscription stays dark until each user happens to republish. (A process
+restart on its own is fine: Redis is external, so the index survives
+it. Defending the requirement on its real grounds makes it harder to
+argue away later.) Treat them like control events: process in both
+paths.
 
 Make the historical lookback for notify lists independent of
 `process_window_days` (7 days). A list published 3 months ago and never
@@ -121,6 +125,23 @@ touched since is still current — it is a replaceable event. Use no
 `since` bound at all for the historical notify-list query, and add
 config `notify_list_history_limit` (default `5000`) as a safety valve on
 result size.
+
+**Dropping `since` is not sufficient, and this is still unresolved.**
+`run()` calls `is_event_too_old(&event)` on *every* event before it
+reaches `route_event` (`event_handler.rs:93`), against a hard-coded
+`REPLAY_HORIZON_DAYS = 7` (`event_handler.rs:40`). A 90-day-old
+`d=notify` event is dropped in the handler loop whatever the filter says
+and whatever order `route_event` uses, so as written above the rebuild
+recovers nothing older than a week — exactly the case it exists to
+protect.
+
+The mechanism is the author's call: a kind-aware horizon, an explicit
+exemption for list events, or something else. Whichever way it goes,
+task 1 needs a boundary test either side of the horizon. Note also that
+`try_claim_event` (`event_handler.rs:105`) runs before `route_event` and
+writes `dedup:{event_id}` with a 7-day TTL, so replaying a list event
+that was already processed is dropped as a duplicate — the plan should
+say how the rebuild is meant to interact with that.
 
 ### 2. Ingest list events into the reverse index
 

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -196,23 +196,19 @@ The script reads the old set, computes added/removed, `SREM`s the
 subscriber from `notify_watchers:{removed}`, `SADD`s to
 `notify_watchers:{added}`, replaces `notify_subs`, and sets
 `notify_subs_ts`. Writing to `notify_watchers:*` keys not declared in
-`KEYS` is not Redis-Cluster-safe. That is acceptable here, but for a
-production reason rather than the local `docker-compose.yml`: the
-deployment points at
-`redis://redis-replication-master.redis-clusters.svc.cluster.local:6379/2`
-(`divine-iac-coreconfig`,
-`k8s/applications/divine-push-service/base/deployment.yaml:44`), and
-`k8s/redis-clusters/base/cluster.yaml` declares a `RedisReplication`
-plus a `RedisSentinel` — master/replica with Sentinel failover, one
-keyspace, no sharding. Cross-key writes are fine. **Add a comment saying
-so**, and say it in those terms: the namespace is called
-`redis-clusters` but is not Redis Cluster, which is exactly the sort of
-thing a future reader gets wrong in the unsafe direction. Gate on it if
-the deployment ever moves to real Cluster mode.
+`KEYS` is not Redis-Cluster-safe. That is acceptable here, but justify it
+from the production deployment rather than the local
+`docker-compose.yml`: production Redis is a **master/replica deployment
+with Sentinel failover — a single keyspace, not a sharded Cluster** (see
+the platform IaC repo for the manifests). Cross-key writes are fine.
+**Add a comment saying so**, and word it so the distinction survives:
+the manifests live under a *cluster*-flavoured name while not being
+Redis Cluster, which is what a future reader gets wrong in the unsafe
+direction. Gate on it if the deployment ever moves to real Cluster mode.
 
-That Redis is also **shared** — this service uses db index 2 of an
-instance other services key off, and Sentinel is watching its liveness.
-Anything that blocks it blocks them.
+That Redis is also **shared with other services**, on a dedicated
+logical database rather than a dedicated instance, with Sentinel
+watching its liveness. Anything that blocks it blocks them.
 
 **Bound the creator list before it reaches Redis.** The script runs as
 one blocking unit and Redis is single-threaded, so a list with thousands

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -198,13 +198,29 @@ The script reads the old set, computes added/removed, `SREM`s the
 subscriber from `notify_watchers:{removed}`, `SADD`s to
 `notify_watchers:{added}`, replaces `notify_subs`, and sets
 `notify_subs_ts`. Writing to `notify_watchers:*` keys not declared in
-`KEYS` is not cluster-safe; this deployment uses single-instance Redis
-(`docker-compose.yml`), so that is acceptable — **add a comment saying
-so** and gate on it if the deployment ever moves to Redis Cluster.
+`KEYS` is not Redis-Cluster-safe. That is acceptable here, but for a
+production reason rather than the local `docker-compose.yml`: the
+deployment points at
+`redis://redis-replication-master.redis-clusters.svc.cluster.local:6379/2`
+(`divine-iac-coreconfig`,
+`k8s/applications/divine-push-service/base/deployment.yaml:44`), and
+`k8s/redis-clusters/base/cluster.yaml` declares a `RedisReplication`
+plus a `RedisSentinel` — master/replica with Sentinel failover, one
+keyspace, no sharding. Cross-key writes are fine. **Add a comment saying
+so**, and say it in those terms: the namespace is called
+`redis-clusters` but is not Redis Cluster, which is exactly the sort of
+thing a future reader gets wrong in the unsafe direction. Gate on it if
+the deployment ever moves to real Cluster mode.
+
+That Redis is also **shared** — this service uses db index 2 of an
+instance other services key off, and Sentinel is watching its liveness.
+Anything that blocks it blocks them.
 
 **Bound the creator list before it reaches Redis.** The script runs as
 one blocking unit and Redis is single-threaded, so a list with thousands
-of `p` tags stalls the instance for every user. Add config
+of `p` tags stalls the instance — for every user of this service and,
+because the instance is shared, for every other service on it, with
+Sentinel watching. Add config
 `notify_list_max_creators` (default `1000`, well above any follow-gated
 bell list) and truncate with a warning rather than rejecting the list —
 the user keeps the bells that fit instead of losing all of them, and `p`

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -63,7 +63,7 @@ Out of scope here, listed so the contract is unambiguous:
 
 ## Redis schema
 
-Three new key families. All hex pubkeys, lowercase, full length — never
+Four new key families. All hex pubkeys, lowercase, full length — never
 truncate Nostr identifiers.
 
 | Key | Type | Purpose |
@@ -391,7 +391,14 @@ rather than treating the placeholder above as approved.
   index maintenance, and the rate-limit window.
 - `AGENTS.md`: add the new keys to the "Redis Keys" list and NewPost to
   the "Notification Types" table. Both are stale the moment task 2
-  lands.
+  lands. The existing "Redis Keys" entries are also **wrong today**:
+  they document `divine:token:{pubkey}`, `divine:preferences:{pubkey}`
+  and `divine:dedup:{pubkey}:{event_id}`, and no `divine:`-prefixed key
+  exists anywhere in `src/`. The real prefixes are `user_tokens:` and
+  `dedup:` (`redis_store.rs:21-27`), `user_preferences:`
+  (`preferences.rs:88`), plus the fixed `stale_tokens` and
+  `token_to_pubkey`. Correct them in the same pass instead of appending
+  four accurate rows to a list of three inaccurate ones.
 
 ---
 

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -1,0 +1,379 @@
+# Plan: new-post notifications ("bell" subscriptions)
+
+Status: ready for implementation
+Date: 2026-07-29
+Companion repos: `divine-mobile` (bell UI + list publishing), `divine-funnelcake` (in-app feed row)
+
+## Problem
+
+Every notification this service emits today is *"someone acted on your
+content"* — a like, comment, repost, or mention, all resolved from `p`
+tags on the trigger event. Users have asked for the inverse: **alert me
+when a creator I care about posts**, which is a subscription to someone
+else's output rather than a reaction to mine.
+
+Nothing in the current model supports per-creator targeting. Preferences
+are a flat list of event kinds (`preferences.rs:14`); the service has no
+notion of which creators a given user cares about.
+
+## Approach
+
+The subscription list lives on Nostr as a NIP-51 people list with a
+reserved `d` tag, published by the mobile client:
+
+```
+kind 30000
+["d", "notify"]
+["title", "Notify"]
+["p", "<creator-pubkey-hex>"]   × N
+```
+
+This mirrors the existing `d=block` reserved-list precedent already used
+by `divine-mobile`'s `content_blocklist_repository`. It is public and
+portable — any Nostr client can read and honor it.
+
+This service subscribes to those lists, maintains a reverse index in
+Redis (`creator → [subscribers]`), and on each incoming kind 34236 video
+notifies every subscriber of that video's author, rate-limited to one
+push per (subscriber, creator) per hour.
+
+### What already exists and needs no work
+
+Two things make this smaller than it looks. Verify both before starting:
+
+- **Kind 34236 is already subscribed** (`config/settings.yaml:44`,
+  landed in #29 for "Inspired by" mentions). Video events already reach
+  `handle_content_event` (`event_handler.rs:420`).
+- **The FCM routing payload already exists.**
+  `insert_video_reference_fields` (`event_handler.rs:937`) emits
+  `referencedAddress` = `34236:<creator>:<d-tag>`, `referencedEventId`,
+  `referencedKind`, `referencedAuthorPubkey`, and `referencedDTag` for
+  any kind-34236 trigger. The mobile tap router already prefers
+  `referencedAddress`. **Do not add new payload fields.**
+
+### What the client is responsible for
+
+Out of scope here, listed so the contract is unambiguous:
+
+- Publishing and maintaining the `d=notify` list (add on bell, remove on
+  unbell, remove on unfollow — the bell is follow-gated).
+- Including kind `34236` in its kind-3083 preferences event. See
+  [Preference gating](#4-preference-gating) for why this matters and why
+  no server-side backfill is needed.
+
+## Redis schema
+
+Three new key families. All hex pubkeys, lowercase, full length — never
+truncate Nostr identifiers.
+
+| Key | Type | Purpose |
+|---|---|---|
+| `notify_subs:{subscriber_hex}` | SET | Creators this user has belled. Needed to diff against an incoming replacement list. |
+| `notify_subs_ts:{subscriber_hex}` | STRING | `created_at` of the last applied list event. Guards against out-of-order relay delivery of a replaceable event. |
+| `notify_watchers:{creator_hex}` | SET | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
+| `notify_rate:{subscriber_hex}:{creator_hex}` | STRING w/ TTL | Rate-limit window marker. |
+
+`notify_subs` and `notify_watchers` are two views of the same relation;
+they must be updated together (see task 2).
+
+---
+
+## Tasks
+
+Each task is independently verifiable. Run `cargo check` after each,
+`cargo clippy --all-targets --all-features` and `cargo test` before
+moving on. Follow the repo's TDD expectation: write the failing test
+first where a test is called for.
+
+### 1. Subscribe to `d=notify` people lists
+
+**Files:** `src/nostr_listener.rs`, `src/config.rs`, `config/settings.yaml`
+
+Add `const KIND_NOTIFY_LIST: u16 = 30000;`.
+
+Subscribing to *all* kind 30000 would pull every people list on the
+relay. Narrow it with the NIP-01 `#d` filter — `nostr-sdk` 0.44 exposes
+this as `Filter::identifier`:
+
+```rust
+Filter::new()
+    .kind(Kind::from(KIND_NOTIFY_LIST))
+    .identifier(NOTIFY_LIST_D_TAG)   // "notify"
+    .since(since_timestamp)
+```
+
+This is a **second, separate filter** — it cannot be merged into the
+existing `.kinds(all_kinds)` filter, because an identifier constraint
+there would wrongly apply to every kind in the list. Both
+`process_historical_events` and `subscribe_to_live_events` need the
+extra filter; `subscribe` accepts one filter per call, so issue a second
+`subscribe` call.
+
+**Historical processing is mandatory here.** `route_event` skips content
+events when `context == EventContext::Historical`
+(`event_handler.rs:192`), but notify lists must be rebuilt from history
+or a restart silently drops every subscription until each user happens
+to republish. Treat them like control events: process in both paths.
+
+Make the historical lookback for notify lists independent of
+`process_window_days` (7 days). A list published 3 months ago and never
+touched since is still current — it is a replaceable event. Use no
+`since` bound at all for the historical notify-list query, and add
+config `notify_list_history_limit` (default `5000`) as a safety valve on
+result size.
+
+### 2. Ingest list events into the reverse index
+
+**Files:** `src/event_handler.rs`, `src/redis_store.rs`
+
+Route kind 30000 in `route_event` **before** the control-event block,
+and critically **outside** the `is_event_for_service` p-tag gate — these
+events are addressed to the world, not to this service. Getting this
+wrong means every list is silently dropped.
+
+```rust
+if kind_num == KIND_NOTIFY_LIST {
+    return handle_notify_list_update(state, event).await;
+}
+```
+
+`handle_notify_list_update`:
+
+1. Reject unless the `d` tag is exactly `"notify"` (defense in depth —
+   the relay filter should already guarantee this, but a malicious or
+   buggy relay can send anything).
+2. Extract `p` tag values, parse as `PublicKey`, dedup, drop
+   self-references (belling yourself is meaningless).
+3. **Replaceable ordering guard:** compare `event.created_at` against
+   `notify_subs_ts:{author}`. If the stored value is `>=` the incoming
+   one, drop the event and log at debug. Relays can deliver an older
+   replacement after a newer one; without this, an unbell can be
+   resurrected.
+4. Diff against `notify_subs:{author}` and apply.
+
+Add `redis_store::replace_notify_subscriptions(pool, subscriber, creators, created_at)`.
+The diff-and-apply must be atomic across replicas — do it in a **Lua
+script** keyed on the subscriber:
+
+```
+-- KEYS[1] = notify_subs:{sub}, KEYS[2] = notify_subs_ts:{sub}
+-- ARGV[1] = created_at, ARGV[2..] = creator hexes
+-- Re-check the timestamp inside the script; the read in step 3 is
+-- advisory and racy on its own.
+```
+
+The script reads the old set, computes added/removed, `SREM`s the
+subscriber from `notify_watchers:{removed}`, `SADD`s to
+`notify_watchers:{added}`, replaces `notify_subs`, and sets
+`notify_subs_ts`. Writing to `notify_watchers:*` keys not declared in
+`KEYS` is not cluster-safe; this deployment uses single-instance Redis
+(`docker-compose.yml`), so that is acceptable — **add a comment saying
+so** and gate on it if the deployment ever moves to Redis Cluster.
+
+An empty `p` tag list is legitimate (user unbelled everyone) and must
+clear the forward set and remove them from every reverse index. Do not
+treat empty as "malformed, skip".
+
+**Tests:** `d`-tag rejection; self-reference dropped; add/remove diff
+produces the right reverse-index membership; an older `created_at` is
+ignored; empty list clears everything.
+
+### 3. Resolve new-post recipients
+
+**Files:** `src/event_handler.rs`, `src/preferences.rs`
+
+Add `NotificationType::NewPost` to the enum (`preferences.rs:50`),
+with `display_name() == "newPost"` and `kind() == 34236`.
+
+The `display_name` string is a wire contract — `divine-mobile` matches
+on it in `parseFcmPayload` (`mobile/lib/services/notification_helpers.dart`).
+Do not change it casually.
+
+**Structural change required.** `handle_content_event` currently
+computes a single `(NotificationType, Vec<PublicKey>)` tuple
+(`event_handler.rs:384`). A video can now produce *both* Mention
+recipients (existing behavior) and NewPost recipients. Change the shape
+to a flat list of targets:
+
+```rust
+struct NotificationTarget {
+    recipient: PublicKey,
+    notification_type: NotificationType,
+}
+```
+
+Each `find_*` branch returns `Vec<NotificationTarget>`; the send loop
+iterates targets instead of `(type, recipients)`.
+
+`video_notification` becomes async and returns mention targets plus
+`SMEMBERS notify_watchers:{event.pubkey}` as NewPost targets.
+
+**Dedup rule: Mention wins.** If a user both watches the creator and is
+mentioned in the video, send one push, typed `Mention` — the more
+specific signal. Implement by building mention targets first and
+skipping any watcher already present.
+
+Also skip watchers equal to `event.pubkey` — the existing
+`recipient_pubkey == event.pubkey` check in the send loop covers this,
+but filtering earlier avoids a pointless Redis round-trip per video.
+
+**Tests:** watcher yields a NewPost target; mentioned watcher yields
+exactly one Mention target and no NewPost target; author watching
+themselves yields nothing; no watchers yields the existing
+mention-only behavior unchanged.
+
+### 4. Preference gating
+
+**Files:** `src/preferences.rs`, `config/settings.yaml`
+
+`NewPost.kind()` returns `34236`, so the existing
+`notification_type.is_enabled(&prefs)` check at `event_handler.rs:624`
+gates it with no changes. Note `Mention` returns `1` even for video
+mentions, so the two are cleanly separable — a user can mute new-post
+pushes without muting video mentions.
+
+Add `34236` to `UserPreferences::default()` and to
+`notification.default_preferences.kinds` in both
+`config/settings.yaml` and `config/settings.development.yaml`.
+
+**No server-side backfill is needed, and none should be written.**
+Users with a stale `user_preferences:*` entry lacking 34236 would be
+silently gated off — but reaching this code path at all requires having
+belled someone, which requires the new mobile build, which publishes
+kind 3083 including 34236 at the same moment it publishes the notify
+list. The client-side ordering makes the migration unnecessary.
+
+**This is a hard dependency on the mobile side.** Confirm the mobile PR
+publishes preferences alongside the first bell before shipping this
+service change, or new-post pushes will be gated off for every existing
+user and the bug will look like a service failure.
+
+**Tests:** `NewPost.kind() == 34236`; `NewPost.is_enabled()` false when
+prefs omit 34236; enabled under the shipped defaults.
+
+### 5. Per-creator rate limit
+
+**Files:** `src/redis_store.rs`, `src/event_handler.rs`, `src/config.rs`, `config/settings.yaml`
+
+Vines are cheap to make; an unthrottled prolific creator trains users to
+disable notifications entirely. Cap delivery at one push per
+(subscriber, creator) per window.
+
+Add config `new_post_rate_limit_secs` to `ServiceSettings`, default
+`3600`, following the `default_video_coordinate_dedup_ttl` pattern
+(`config.rs:64`).
+
+In `send_notification_to_user`, for `NotificationType::NewPost` only:
+
+- **Before** building the payload (alongside the existing video
+  coordinate check at `event_handler.rs:634`), `get_cached_string` on
+  `notify_rate:{recipient}:{creator}` and return early if present.
+- **After** `success_count > 0` (alongside `event_handler.rs:732`),
+  `set_cached_string` with `new_post_rate_limit_secs`.
+
+Use check-then-set-on-success rather than an atomic `SET NX EX`, to
+mirror the existing video-coordinate dedup and — more importantly — so
+a failed FCM send does not burn the user's hour-long window. The
+tradeoff is that two replicas processing different videos from the same
+creator within the same instant can both pass the check and double-send.
+That is a rare, bounded, low-harm race; silently eating an hour of
+notifications on an FCM blip is worse. **Write this rationale into a
+code comment** so a future reader does not "fix" it into `SET NX EX`.
+
+The rate limit is **push-only**. The in-app feed (FunnelCake) shows
+every post from belled creators. A user who receives one push for a
+six-post burst opens the app and sees all six — that is intended.
+
+**Interaction with existing video dedup, verify explicitly:** the
+per-recipient coordinate claim (`video_recipient_claim_key`,
+`event_handler.rs:533`) is keyed on
+`{kind}:{author}:{d_tag}:{recipient}` and already prevents a NIP-33
+*edit* of the same video from re-notifying. That protection applies to
+NewPost targets for free. Confirm with a test rather than assuming it.
+
+**Tests:** second video from the same creator inside the window is
+suppressed; a video from a *different* creator in the same window is
+delivered; the window marker is not written when every FCM send fails;
+an edited video does not re-notify.
+
+### 6. FCM copy
+
+**File:** `src/event_handler.rs` (`create_fcm_payload`, line 804)
+
+Add the `NotificationType::NewPost` match arm:
+
+```rust
+NotificationType::NewPost => (
+    "New vine".to_string(),
+    format!("{} posted a new vine", sender_name),
+),
+```
+
+`sender_name` resolution via `mention_parser_service` already works for
+kind-34236 events — no change needed.
+
+Copy is **provisional**. `divine-mobile/brand-guidelines/TONE_OF_VOICE.md`
+governs user-facing strings; get this string confirmed before release
+rather than treating the placeholder above as approved.
+
+### 7. Docs
+
+**Files:** `README.md`, `docs/nip-xx-push-notifications.md`, `docs/developer-guide.md`, `AGENTS.md`
+
+- README "Notification types" table: add the New post row (kind 34236,
+  triggered by a watched creator posting). The table currently ends at
+  Repost.
+- Protocol doc: specify the `d=notify` kind-30000 list — tag shape,
+  replaceable semantics, and that it is public.
+- Developer guide: document the four Redis key families, the reverse
+  index maintenance, and the rate-limit window.
+- `AGENTS.md`: add the new keys to the "Redis Keys" list and NewPost to
+  the "Notification Types" table. Both are stale the moment task 2
+  lands.
+
+---
+
+## Verification
+
+```bash
+cargo clippy --all-targets --all-features
+cargo test
+```
+
+Redis-backed integration tests follow the existing `tests/dedup_test.rs`
+convention (skip cleanly when Redis is unavailable). Add
+`tests/notify_subscriptions_test.rs` covering the index round-trip:
+publish list → assert reverse index → publish shrunken list → assert
+removal → assert the ordering guard rejects a replayed older event.
+
+Manual end-to-end, once the mobile branch is available:
+
+1. Bell creator B from account A; confirm the kind 30000 `d=notify`
+   event lands on the relay with B's `p` tag.
+2. Confirm `notify_watchers:{B}` contains A.
+3. Post a video as B; confirm A receives a push titled "New vine" and
+   that tapping it opens the video.
+4. Post a second video as B within the hour; confirm no second push and
+   that the log records the rate-limit skip.
+5. Unbell B; confirm `notify_watchers:{B}` no longer contains A and no
+   further pushes arrive.
+
+## Risks
+
+**Relay volume.** The `#d=notify` filter keeps list ingestion cheap, but
+the service already receives every kind-34236 event on the relay. This
+change adds one `SMEMBERS` per video. Should that become hot, cache
+`notify_watchers:{creator}` in-process with a short TTL — do not
+pre-optimize.
+
+**Public subscription lists.** The `d=notify` list is world-readable, so
+who you have belled is public. This was an accepted product decision in
+favor of portability, not an oversight. Do not "fix" it by encrypting
+the content field — that would make the list unreadable to this service
+and break the feature entirely.
+
+**Client dependency.** Task 4 is gated on the mobile client publishing
+34236 in its preferences. Ship order matters: service first is safe (it
+simply finds no watchers), client-first is safe (pushes start when the
+service deploys). Only a *partial* client rollout that publishes notify
+lists without updating preferences produces silent failure.

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -440,7 +440,12 @@ cargo test
 ```
 
 Redis-backed integration tests follow the existing `tests/dedup_test.rs`
-convention (skip cleanly when Redis is unavailable). Add
+convention (skip cleanly when Redis is unavailable). Copy **that**
+helper: `create_test_pool` (`tests/dedup_test.rs:6`) issues a `PING` and
+returns `None` when it fails. Do not copy `get_test_pool`
+(`tests/preferences_test.rs:10`), which only checks that `create_pool`
+returned `Ok` — it does with no server listening, and the tests then
+panic on the bb8 timeout instead of skipping. Add
 `tests/notify_subscriptions_test.rs` covering the index round-trip:
 publish list → assert reverse index → publish shrunken list → assert
 removal → assert the ordering guard rejects a replayed older event.

--- a/docs/plans/new-post-notifications.md
+++ b/docs/plans/new-post-notifications.md
@@ -216,9 +216,8 @@ Anything that blocks it blocks them.
 
 **Bound the creator list before it reaches Redis.** The script runs as
 one blocking unit and Redis is single-threaded, so a list with thousands
-of `p` tags stalls the instance — for every user of this service and,
-because the instance is shared, for every other service on it, with
-Sentinel watching. Add config
+of `p` tags stalls the instance — and per the paragraph above, that is
+every other service on it too, not just this one's users. Add config
 `notify_list_max_creators` (default `1000`, well above any follow-gated
 bell list) and truncate with a warning rather than rejecting the list —
 the user keeps the bells that fit instead of losing all of them, and `p`


### PR DESCRIPTION
## Summary

Adds `docs/plans/new-post-notifications.md`, an implementation plan for new-post ("bell") push notifications. **Docs only — no code, no behavior change.**

The plan breaks the feature into seven independently verifiable tasks, each with the files it touches, the specific pitfalls, and the tests it needs.

Closes #33 is *not* claimed here — this PR only lands the plan; the issue stays open to track implementation.

## Motivation

Every notification this service emits today is "someone acted on your content" — like, comment, repost, mention — all resolved from `p` tags on the trigger event. Users asked for the inverse: alert me when a creator I care about posts. That is a subscription to someone else's output, and nothing in the current model supports per-creator targeting.

Landing the plan as its own PR gets the design decisions reviewed before any code exists, and gives the `divine-mobile` and `divine-funnelcake` work a written contract to build against.

## Linked issue

Tracking issue: #33

## Approach in brief

- Subscription list is a NIP-51 kind 30000 people list with a reserved `d=notify` tag, published by the mobile client — mirroring the existing `d=block` precedent. Public and portable.
- This service subscribes with a `#d`-narrowed filter, maintains a `creator → [subscribers]` reverse index in Redis, and on each incoming kind 34236 video notifies that author's watchers.
- One push per (subscriber, creator) per hour.

Two things make this smaller than it looks, and both are already in `main`:

- Kind 34236 is already subscribed (landed in #29).
- `insert_video_reference_fields` already emits the exact routing payload the tap router needs — `referencedAddress`, `referencedEventId`, `referencedKind`, `referencedAuthorPubkey`, `referencedDTag`. **No new FCM fields.**

## Decisions worth reviewer attention

These are the parts where I'd most like a second opinion:

- **Public subscription lists.** `d=notify` is world-readable, so who you have belled is public. Accepted product tradeoff for portability, written into the Risks section so nobody later "fixes" it by encrypting the content field — that would make the list unreadable to this service and kill the feature.
- **Check-then-set rate limiting** rather than atomic `SET NX EX`. Mirrors the existing video-coordinate dedup, and means a failed FCM send does not burn the user's hour-long window. The cost is a rare double-send race across replicas. The plan requires this rationale in a code comment.
- **Non-cluster-safe Lua script.** The diff-and-apply writes `notify_watchers:*` keys not declared in `KEYS`. Fine on single-instance Redis (`docker-compose.yml`), and the plan requires a comment saying so.
- **No server-side backfill**, deliberately. Reaching the gated code path requires having belled someone, which requires the new mobile build, which publishes preferences and the notify list together.
- **Mention wins on dedup.** A user who both watches a creator and is mentioned in the video gets one push, typed `Mention`.

## Manual test plan

This PR is a Markdown file, so verification is review-level:

- [x] `git diff main...HEAD --stat` shows exactly one added file, `docs/plans/new-post-notifications.md` (379 insertions, 0 deletions)
- [x] No `src/`, `config/`, `tests/`, or CI paths touched — nothing to build or run
- [x] Every file:line reference in the plan checked against `main` (`preferences.rs:14`, `preferences.rs:50`, `event_handler.rs:192`, `:384`, `:420`, `:533`, `:624`, `:634`, `:732`, `:804`, `:937`, `config.rs:64`, `config/settings.yaml:44`)
- [ ] Reviewer confirms the four Redis key families don't collide with existing `divine:*` keys
- [ ] Reviewer sanity-checks the `Filter::identifier` claim against nostr-sdk 0.44

The end-to-end test plan for the *implementation* lives in the plan's Verification section: bell a creator, assert the reverse index, post a video, confirm the push and its tap target, post a second video and confirm the rate-limit skip, unbell and confirm delivery stops.

## Rollout notes

Ship order is safe in both directions on its own — service-first finds no watchers, client-first starts delivering when the service deploys. The one unsafe case is a *partial* mobile rollout that publishes notify lists without also including 34236 in its kind-3083 preferences: new-post pushes are silently gated off and it looks like a service failure. Called out in both the plan and #33.

Companion work: `divine-mobile` (bell UI + list publishing), `divine-funnelcake` (in-app feed row).
