### PR TITLE
feat(push): deliver new-post pushes to bell subscribers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - `dedup:{event_id}` - Per-event processing claim with TTL. Notify lists are exempt: they are idempotent by `created_at`, so the claim prevents nothing and a failed handler would otherwise strand the list for the TTL
 - `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video. The scoping is one-directional: a delivered mention also writes the `newPost` record, because naming the video already tells the recipient it exists
 - `notify_subs:{subscriber}` - Creators this user has belled
-- `notify_subs_ts:{subscriber}` - `created_at` of the last applied notify list (out-of-order guard)
+- `notify_subs_ts:{subscriber}` - `created_at:event_id` of the last applied notify list (out-of-order guard). The id resolves a `created_at` tie by NIP-01's lowest-id rule; a bare integer from an earlier build still reads as a timestamp with no known id
 - `notify_watchers:{creator}` - Subscribers watching this creator (hot read path)
 - `notify_rate:{subscriber}:{creator}` - New-post rate-limit window marker
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,19 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - **3079**: Register push token (encrypted)
 - **3080**: Deregister push token (encrypted)
 - **3083**: Update notification preferences
+- **30000**: NIP-51 people list; `d=notify` carries new-post ("bell") subscriptions (public, unencrypted)
 
 ### Redis Keys
-- `divine:token:{pubkey}` - User's FCM token
-- `divine:preferences:{pubkey}` - User's notification preferences (JSON)
-- `divine:dedup:{pubkey}:{event_id}` - Deduplication with TTL
+- `user_tokens:{pubkey}` - Set of FCM tokens registered for a pubkey
+- `token_to_pubkey` - Hash mapping a token back to its owner
+- `stale_tokens` - Sorted set of token timestamps, for cleanup
+- `user_preferences:{pubkey}` - User's notification preferences (JSON)
+- `dedup:{event_id}` - Per-event processing claim with TTL
+- `dedup:{kind}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify
+- `notify_subs:{subscriber}` - Creators this user has belled
+- `notify_subs_ts:{subscriber}` - `created_at` of the last applied notify list (out-of-order guard)
+- `notify_watchers:{creator}` - Subscribers watching this creator (hot read path)
+- `notify_rate:{subscriber}:{creator}` - New-post rate-limit window marker
 
 ### Notification Types
 | Type | Kind | Description |
@@ -79,6 +87,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 | Follow | 3 | New followers |
 | Mention | 1 | Notes mentioning user |
 | Repost | 16 | Reposts of user's notes |
+| NewPost | 34236 | A belled creator published a video (recipients from `notify_watchers`, not `p` tags) |
 
 ## Unblocking Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - `token_to_pubkey` - Hash mapping a token back to its owner
 - `stale_tokens` - Sorted set of token timestamps, for cleanup
 - `user_preferences:{pubkey}` - User's notification preferences (JSON)
-- `dedup:{event_id}` - Per-event processing claim with TTL
+- `dedup:{event_id}` - Per-event processing claim with TTL. Notify lists are exempt: they are idempotent by `created_at`, so the claim prevents nothing and a failed handler would otherwise strand the list for the TTL
 - `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video
 - `notify_subs:{subscriber}` - Creators this user has belled
 - `notify_subs_ts:{subscriber}` - `created_at` of the last applied notify list (out-of-order guard)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - `stale_tokens` - Sorted set of token timestamps, for cleanup
 - `user_preferences:{pubkey}` - User's notification preferences (JSON)
 - `dedup:{event_id}` - Per-event processing claim with TTL
-- `dedup:{kind}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify
+- `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video
 - `notify_subs:{subscriber}` - Creators this user has belled
 - `notify_subs_ts:{subscriber}` - `created_at` of the last applied notify list (out-of-order guard)
 - `notify_watchers:{creator}` - Subscribers watching this creator (hot read path)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - `stale_tokens` - Sorted set of token timestamps, for cleanup
 - `user_preferences:{pubkey}` - User's notification preferences (JSON)
 - `dedup:{event_id}` - Per-event processing claim with TTL. Notify lists are exempt: they are idempotent by `created_at`, so the claim prevents nothing and a failed handler would otherwise strand the list for the TTL
-- `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video
+- `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video. The scoping is one-directional: a delivered mention also writes the `newPost` record, because naming the video already tells the recipient it exists
 - `notify_subs:{subscriber}` - Creators this user has belled
 - `notify_subs_ts:{subscriber}` - `created_at` of the last applied notify list (out-of-order guard)
 - `notify_watchers:{creator}` - Subscribers watching this creator (hot read path)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The service subscribes to trigger events on its relay and notifies the tagged re
 | Reply | 1 | Reply to a user's note |
 | Mention | 1 | Note mentioning a user |
 | Repost | 16 | Repost of a user's note (NIP-18) |
+| New post | 34236 | A creator the user subscribed to ("belled") published a video |
+
+New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour; the in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
 
 Divine video comments are NIP-22 `kind:1111` and notify both the root video author and the direct parent author (deduplicated when they coincide). Follows (kind 3) are defined in the protocol and subscribed to, but new-follow notifications are **not currently emitted** — that requires diffing contact-list state, which is not yet implemented.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The service subscribes to trigger events on its relay and notifies the tagged re
 | Repost | 16 | Repost of a user's note (NIP-18) |
 | New post | 34236 | A creator the user subscribed to ("belled") published a video |
 
-New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour; the in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
+New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour, and fan-out is paged and delivered with bounded concurrency so one popular creator cannot force one unbounded Redis read or sequential delivery loop. The in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
 
 Divine video comments are NIP-22 `kind:1111` and notify both the root video author and the direct parent author (deduplicated when they coincide). Follows (kind 3) are defined in the protocol and subscribed to, but new-follow notifications are **not currently emitted** — that requires diffing contact-list state, which is not yet implemented.
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -16,7 +16,7 @@ service:
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
   notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
-  notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
+  notify_list_history_limit: 5000  # Page size for historical notify-list replay
 
 redis:
   url: "redis://127.0.0.1:6379"

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -14,6 +14,8 @@ service:
   process_window_days: 7
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
+  new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
+  notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
 
 redis:
   url: "redis://127.0.0.1:6379"
@@ -49,6 +51,7 @@ notification:
       - 7      # Reactions/likes
       - 16     # Reposts
       - 30023  # Long-form content
+      - 34236  # Videos from subscribed creators (new-post "bells")
 
 server:
   listen_addr: "0.0.0.0:8000"

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -15,8 +15,10 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
-  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list cannot stall Redis
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
+  new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
+  new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
 
 redis:
   url: "redis://127.0.0.1:6379"

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -15,6 +15,7 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
   notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
 
 redis:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -15,8 +15,10 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
-  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list cannot stall Redis
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
+  new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
+  new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
   # allowed_pubkeys: [] — empty means no restriction (production default)
 
 redis:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -15,6 +15,7 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
   notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
   # allowed_pubkeys: [] — empty means no restriction (production default)
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -14,6 +14,8 @@ service:
   process_window_days: 7
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
+  new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
+  notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
   # allowed_pubkeys: [] — empty means no restriction (production default)
 
 redis:
@@ -50,6 +52,7 @@ notification:
       - 7      # Reactions/likes
       - 16     # Reposts
       - 30023  # Long-form content
+      - 34236  # Videos from subscribed creators (new-post "bells")
 
 server:
   listen_addr: "0.0.0.0:8000"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -16,7 +16,7 @@ service:
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
   notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
-  notify_list_history_limit: 5000  # Safety valve on the unbounded historical notify-list query
+  notify_list_history_limit: 5000  # Page size for historical notify-list replay
   # allowed_pubkeys: [] — empty means no restriction (production default)
 
 redis:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -190,7 +190,85 @@ Users can optionally send a Kind 3083 event to control which notification types 
 { "kinds": [1, 3, 7, 16] }
 ```
 
-This is a list of event kinds the user wants notifications for. If no preferences are set, the service uses defaults: text notes (1), follows (3), reactions (7), reposts (16), and long-form content (30023).
+This is a list of event kinds the user wants notifications for. If no preferences are set, the service uses defaults: text notes (1), follows (3), reactions (7), reposts (16), long-form content (30023), and videos from subscribed creators (34236).
+
+## New-post subscriptions ("bells")
+
+Every other notification type is triggered by someone acting on the recipient's
+content, so recipients are read off the trigger event's `p` tags. New-post
+notifications invert that: the recipient subscribed to a creator's output, and
+the trigger event says nothing about who wants it.
+
+### Source of truth
+
+The subscription list is a public NIP-51 people list published by the client,
+identified by a reserved `d` tag:
+
+```json
+{
+  "kind": 30000,
+  "tags": [
+    ["d", "notify"],
+    ["title", "Notify"],
+    ["p", "<creator-pubkey-hex>"]
+  ]
+}
+```
+
+It is replaceable and unencrypted — the service has to be able to read it, so
+there is no decryption step, unlike the kind 3079/3080/3083 control events. Any
+kind 30000 arriving without exactly `d=notify` is ignored.
+
+### Ingestion
+
+`handle_notify_list_update` is routed **before** the control-event block and
+deliberately outside its `p`-tag gate: these events are addressed to the world,
+not to this service.
+
+Two properties are load-bearing:
+
+- **Notify lists are exempt from the replay horizon.** A list published three
+  months ago and never touched since is still the user's current subscription
+  set, so `is_notify_list` carves it out of the `is_event_too_old` check. The
+  historical query is likewise unbounded in time, with
+  `notify_list_history_limit` as the size safety valve instead. Without
+  historical replay, a restart against a fresh Redis silently drops every bell
+  until each user republishes.
+- **An empty `p` list is legitimate**, not malformed. It means the user unbelled
+  everyone, and it must clear the forward set and remove them from every reverse
+  index.
+
+`replace_notify_subscriptions` applies the diff in a single Lua script keyed on
+the subscriber, because `notify_subs` and `notify_watchers` are two views of one
+relation and must move together. The script re-checks the stored `created_at`
+internally — a relay can deliver an older replacement after a newer one, and an
+advisory check in the caller would still race.
+
+The script writes `notify_watchers:*` keys that are not declared in `KEYS`, so it
+is **not Redis Cluster safe**. This deployment uses single-instance Redis; moving
+to Cluster requires resharding into one call per creator slot or a hash-tagged
+key layout.
+
+### Delivery
+
+On each incoming kind 34236, `video_notification_targets` unions the video's
+mention targets with `SMEMBERS notify_watchers:{author}`.
+
+**Mention wins on overlap.** A user who both watches the creator and is mentioned
+in the video gets one push, typed `mention`, because that is the more specific
+signal.
+
+Delivery is capped at one push per (subscriber, creator) per
+`new_post_rate_limit_secs`. The window is opened only on a *delivered* push
+(check-then-set-on-success, mirroring the video-coordinate dedup) so a failed FCM
+send does not burn the user's hour. The cost is that two replicas handling
+different videos from the same creator in the same instant can both pass the
+check and double-send — rare, bounded, and preferable to silently eating an hour
+of notifications on an FCM blip.
+
+The rate limit is push-only. The in-app feed shows every post from belled
+creators, so a user who receives one push for a six-post burst opens the app and
+sees all six. That is intended.
 
 ## Redis Keys
 
@@ -201,4 +279,8 @@ This is a list of event kinds the user wants notifications for. If no preference
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
 | `dedup:{event_id}` | String | Deduplication lock with TTL |
 | `dedup:34236:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default) |
-| `divine:preferences:{pubkey}` | String | JSON notification preferences |
+| `user_preferences:{pubkey}` | String | JSON notification preferences |
+| `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
+| `notify_subs_ts:{subscriber}` | String | `created_at` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event. |
+| `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
+| `notify_rate:{subscriber}:{creator}` | String | New-post rate-limit window marker, TTL `new_post_rate_limit_secs` (one hour by default). |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -258,6 +258,26 @@ relation and must move together. The script re-checks the stored `created_at`
 internally — a relay can deliver an older replacement after a newer one, and an
 advisory check in the caller would still race.
 
+The write order inside the script is deliberate. Redis runs a script without
+interleaving anything else, but it does not roll one back, so a script that dies
+partway keeps what it already wrote. Removals therefore clear the reverse index
+before the forward one and additions write the forward index first, which keeps
+`notify_subs` a *superset* of the true relation at every intermediate step. That
+matters because `notify_subs` is the only record of which `notify_watchers:*`
+keys name a subscriber, and removals are computed from it: a superset is
+reconciled by the next list, while a forward index that is missing entries the
+reverse index still holds cannot be repaired by anything the user can publish.
+Do not "simplify" the diff back into a `DEL` and rebuild.
+
+This covers the script failing on its own. It does not cover the index being
+lost some other way, and the startup replay only partly does. A *total* loss
+rebuilds: `notify_subs_ts` goes with everything else, so every replayed list
+passes the guard and re-applies. A *partial* loss does not: if the index is gone
+but `notify_subs_ts` survives, the replay re-fetches the same replaceable event
+and the guard rejects it on exact-id match, leaving those bells dead until the
+user next publishes a genuinely newer list. Deleting `notify_subs_ts` for the
+affected subscribers is currently the only lever.
+
 Ties on `created_at` resolve by NIP-01's rule, retaining the lowest event id.
 The protocol requires clients to publish the complete list on every change, so
 belling two creators in quick succession produces two full-list publishes that

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -270,13 +270,19 @@ reverse index still holds cannot be repaired by anything the user can publish.
 Do not "simplify" the diff back into a `DEL` and rebuild.
 
 This covers the script failing on its own. It does not cover the index being
-lost some other way, and the startup replay only partly does. A *total* loss
-rebuilds: `notify_subs_ts` goes with everything else, so every replayed list
-passes the guard and re-applies. A *partial* loss does not: if the index is gone
-but `notify_subs_ts` survives, the replay re-fetches the same replaceable event
-and the guard rejects it on exact-id match, leaving those bells dead until the
-user next publishes a genuinely newer list. Deleting `notify_subs_ts` for the
-affected subscribers is currently the only lever.
+lost some other way, and the startup replay covers that in one direction only.
+A *total* loss rebuilds: `notify_subs_ts` goes with everything else, so every
+replayed list passes the guard and re-applies. A lost *reverse* index rebuilds
+as well, even with `notify_subs_ts` intact, because an exact-id replay is
+applied rather than rejected (see the tie-break note below) and re-asserts every
+`notify_watchers:*` entry the list implies.
+
+The mirror case is the one the replay cannot repair: if `notify_subs` is lost
+while the reverse index survives, the removal loop has nothing to diff against,
+so watcher entries for creators the subscriber has since unbelled stay behind
+and keep delivering. Republishing does not clear them — a new list only adds —
+which is the same asymmetry the write ordering above exists to avoid creating.
+Removing those `notify_watchers:*` entries directly is the only lever.
 
 Ties on `created_at` resolve by NIP-01's rule, retaining the lowest event id.
 The protocol requires clients to publish the complete list on every change, so

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -258,6 +258,15 @@ relation and must move together. The script re-checks the stored `created_at`
 internally — a relay can deliver an older replacement after a newer one, and an
 advisory check in the caller would still race.
 
+Ties on `created_at` resolve by NIP-01's rule, retaining the lowest event id.
+The protocol requires clients to publish the complete list on every change, so
+belling two creators in quick succession produces two full-list publishes that
+can share a second; resolving those by arrival order would leave this service
+holding a different list than the relay does, permanently. Watch the direction
+when reading the script: an equal-timestamp event is applied only when its id
+sorts *below* the stored one, which reads backwards from "newer wins", and an
+exact replay is still rejected.
+
 Because the script runs as one blocking unit and Redis is single-threaded, the
 creator list is bounded by `notify_list_max_creators` before it reaches Redis —
 otherwise one user with an absurd number of bells stalls the instance for
@@ -317,6 +326,6 @@ sees all six. That is intended.
 | `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered bell writes only its own |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
-| `notify_subs_ts:{subscriber}` | String | `created_at` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event. |
+| `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |
 | `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
 | `notify_rate:{subscriber}:{creator}` | String | New-post rate-limit window marker, TTL `new_post_rate_limit_secs` (one hour by default). |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -291,7 +291,7 @@ sees all six. That is intended.
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
 | `dedup:{event_id}` | String | Deduplication lock with TTL |
-| `dedup:34236:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default) |
+| `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
 | `notify_subs_ts:{subscriber}` | String | `created_at` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -37,6 +37,7 @@ sequenceDiagram
 | 3079 | Client → Relay → Service | Register FCM push token (NIP-44 encrypted) |
 | 3080 | Client → Relay → Service | Deregister push token (NIP-44 encrypted) |
 | 3083 | Client → Relay → Service | Update notification preferences (optional) |
+| 30000 | Client → Relay → Service | NIP-51 people list; `d=notify` carries new-post ("bell") subscriptions. Public and unencrypted, and addressed to the world rather than `p`-tagged to the service |
 
 See [NIP-XX Push Notifications](nip-xx-push-notifications.md) for the full protocol specification.
 
@@ -53,8 +54,9 @@ The service watches for these event kinds and notifies the tagged recipient:
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Mention | 34236 | Addressable video tagging user (p-tag) |
 | Repost | 16 | Repost of user's note (p-tag) |
+| NewPost | 34236 | A creator the user belled published a video. The only type whose recipients do not come from a `p` tag — see [New-post subscriptions](#new-post-subscriptions-bells) |
 
-> **Note:** Follow (kind 3) is defined but **not currently emitted** — the handler skips kind 3 because new-follow detection requires diffing contact-list state, which is not yet implemented. Likes, comments, mentions, and reposts are the types actually delivered today.
+> **Note:** Follow (kind 3) is defined but **not currently emitted** — the handler skips kind 3 because new-follow detection requires diffing contact-list state, which is not yet implemented. Likes, comments, mentions, reposts, and new posts are the types actually delivered today.
 
 > **Note:** diVine video comments are NIP-22 `kind:1111`, not `kind:1`. They notify both the **root author** (uppercase `P` — the video owner, so they hear about comments on their video) and the **direct parent author** (lowercase `p` — for a reply, the parent comment's author). The two coincide for a top-level comment and are deduplicated. Every such push carries the authoritative root-video coordinate (see [Routing & attribution contract](#routing--attribution-contract)), so a reply to someone else's comment still routes to the correct video instead of a guessed one.
 
@@ -103,7 +105,7 @@ When the triggering event is not addressable and carries no addressable referenc
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | string | `like`, `comment`, `follow`, `mention`, or `repost` (lowercase) |
+| `type` | string | `like`, `comment`, `follow`, `mention`, `repost`, or `newPost`. Match the exact string: the first five are lowercase, `newPost` is camelCase |
 | `eventId` | hex | The Nostr event that triggered the notification (the like/comment/repost/follow event itself); stable id for dedup and a routing fallback |
 | `senderPubkey` | hex | Pubkey of the actor who triggered the event; routes follows and otherwise-unresolved taps |
 | `receiverPubkey` | hex | Pubkey of the notification recipient |
@@ -180,7 +182,9 @@ Clients use this pubkey to:
 
 ## Deduplication
 
-The service uses atomic Redis `SET NX EX` per-event keys to prevent duplicate notifications across multiple replicas. Each event is claimed exactly once with a 7-day TTL.
+The service uses atomic Redis `SET NX EX` per-event keys to prevent duplicate notifications across multiple replicas. Each event that sends a push is claimed exactly once with a 7-day TTL.
+
+Notify lists (kind 30000, `d=notify`) are the exception: they send no push, and claiming them would strand a subscriber's bells for the TTL if the handler failed. See [Ingestion](#ingestion) for why the claim buys nothing there.
 
 ## User Preferences
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -356,6 +356,31 @@ The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and
 sees all six. That is intended.
 
+### Subscription retention on deregistration
+
+Nothing removes a subscriber. `notify_subs:*`, `notify_subs_ts:*` and
+`notify_watchers:*` carry no TTL, `handle_deregistration` does not touch them,
+and the cleanup service does not sweep them. A user who deregisters their push
+token leaves their bell subscriptions in place indefinitely.
+
+This is accepted for now, not overlooked:
+
+- It is not a data-exposure question. The bell list is a kind 30000 `d=notify`
+  event and deliberately unencrypted, so it is already public on relays; the
+  reverse index holds nothing the relay does not.
+- It sends nothing. A deregistered user has no tokens, so
+  `send_notification_to_user` returns before any push.
+- The real cost is wasted fan-out iteration: those pubkeys stay in
+  `notify_watchers:{creator}` and are read, paged and gated on every video from
+  a creator they will never hear from.
+
+The obvious fix has a trap, which is why it is not a one-line addition to
+`handle_deregistration`. Deleting the subscriptions on deregistration means they
+do not come back when the same user re-registers, because the historical
+notify-list replay that would rebuild them runs only at startup. Deregistration
+cleanup therefore belongs with rebuild-on-registration, and both are tracked in
+the fan-out follow-up rather than done by halves here.
+
 ## Redis Keys
 
 | Key Pattern | Type | Description |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -234,6 +234,16 @@ Two properties are load-bearing:
   `notify_list_history_limit` as the size safety valve instead. Without
   historical replay, a restart against a fresh Redis silently drops every bell
   until each user republishes.
+- **Notify lists are exempt from the event claim.** `run()` claims every other
+  event before routing it, so two replicas cannot send the same push twice.
+  Notify lists send nothing, and `replace_notify_subscriptions` already rejects
+  any list not strictly newer than the stored one, so the claim prevents nothing
+  here. It does cost something: the claim is taken before routing and never
+  released, so a transient Redis error inside the handler leaves it standing and
+  the replay on the next restart skips the event as already-claimed. That
+  subscriber's bells stay dark for the full `processed_event_ttl_secs`.
+  `requires_event_claim` scopes the exemption with `is_notify_list`, the same
+  kind-plus-`d`-tag check the horizon exemption uses.
 - **An empty `p` list is legitimate**, not malformed. It means the user unbelled
   everyone, and it must clear the forward set and remove them from every reverse
   index.
@@ -290,7 +300,7 @@ sees all six. That is intended.
 | `user_tokens:{pubkey}` | Set | FCM tokens registered for a pubkey |
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
-| `dedup:{event_id}` | String | Deduplication lock with TTL |
+| `dedup:{event_id}` | String | Per-event processing claim with TTL. Not taken for notify lists, which are idempotent by `created_at` and would be lost for the TTL if a failed handler left a claim standing |
 | `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -244,6 +244,19 @@ relation and must move together. The script re-checks the stored `created_at`
 internally — a relay can deliver an older replacement after a newer one, and an
 advisory check in the caller would still race.
 
+Because the script runs as one blocking unit and Redis is single-threaded, the
+creator list is bounded by `notify_list_max_creators` before it reaches Redis —
+otherwise one user with an absurd number of bells stalls the instance for
+everyone. Excess creators are dropped with a warning rather than the whole list
+being rejected, so the user keeps the bells that fit instead of losing all of
+them.
+
+Atomicity here is not theoretical: production runs more than one replica, and the
+event-level claim (`try_claim_event`) only stops two replicas processing *the same*
+event — it does nothing about two different list events from the same subscriber
+landing concurrently. Within a single replica the handler loop is sequential, so
+this is purely a cross-replica concern.
+
 The script writes `notify_watchers:*` keys that are not declared in `KEYS`, so it
 is **not Redis Cluster safe**. This deployment uses single-instance Redis; moving
 to Cluster requires resharding into one call per creator slot or a hash-tagged

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -281,6 +281,15 @@ mention targets with `SMEMBERS notify_watchers:{author}`.
 in the video gets one push, typed `mention`, because that is the more specific
 signal.
 
+The rule also holds across edits, which takes an extra step because the
+per-recipient coordinate record is scoped by notification type. A delivered
+mention writes the `newPost` record as well as its own: naming the video already
+tells the recipient it exists, which is the whole content of a bell. A delivered
+bell writes only its own, since "X posted a vine" says nothing about being
+mentioned. Without the one-directional carry, a watcher who was `p`-tagged in
+the original and dropped from an edit would be told "posted a new vine" about a
+video they were already pushed about.
+
 Delivery is capped at one push per (subscriber, creator) per
 `new_post_rate_limit_secs`. The window is opened only on a *delivered* push
 (check-then-set-on-success, mirroring the video-coordinate dedup) so a failed FCM
@@ -301,7 +310,7 @@ sees all six. That is intended.
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
 | `dedup:{event_id}` | String | Per-event processing claim with TTL. Not taken for notify lists, which are idempotent by `created_at` and would be lost for the TTL if a failed handler left a claim standing |
-| `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records |
+| `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered bell writes only its own |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
 | `notify_subs_ts:{subscriber}` | String | `created_at` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -234,10 +234,10 @@ Two properties are load-bearing:
 - **Notify lists are exempt from the replay horizon.** A list published three
   months ago and never touched since is still the user's current subscription
   set, so `is_notify_list` carves it out of the `is_event_too_old` check. The
-  historical query is likewise unbounded in time, with
-  `notify_list_history_limit` as the size safety valve instead. Without
-  historical replay, a restart against a fresh Redis silently drops every bell
-  until each user republishes.
+  historical query is likewise unbounded by `since` and pages backward with
+  `until`, using `notify_list_history_limit` as the per-page size valve.
+  Without historical replay, a restart against a fresh Redis silently drops
+  every bell until each user republishes.
 - **Notify lists are exempt from the event claim.** `run()` claims every other
   event before routing it, so two replicas cannot send the same push twice.
   Notify lists send nothing, and `replace_notify_subscriptions` already rejects
@@ -283,9 +283,11 @@ The protocol requires clients to publish the complete list on every change, so
 belling two creators in quick succession produces two full-list publishes that
 can share a second; resolving those by arrival order would leave this service
 holding a different list than the relay does, permanently. Watch the direction
-when reading the script: an equal-timestamp event is applied only when its id
-sorts *below* the stored one, which reads backwards from "newer wins", and an
-exact replay is still rejected.
+when reading the script: an equal-timestamp event is applied when its id sorts
+*below* the stored one, which reads backwards from "newer wins". An exact replay
+is also applied as an idempotent repair path, so startup replay can reassert
+`notify_watchers:*` entries if Redis lost the reverse index while the timestamp
+guard survived.
 
 Because the script runs as one blocking unit and Redis is single-threaded, the
 creator list is bounded by `notify_list_max_creators` before it reaches Redis —
@@ -331,6 +333,10 @@ different videos from the same creator in the same instant can both pass the
 check and double-send — rare, bounded, and preferable to silently eating an hour
 of notifications on an FCM blip.
 
+When the rate limit suppresses a new-post push, the video-coordinate record is
+still written. That video has been intentionally dropped for that watcher, and a
+later NIP-33 edit should not re-announce it as a fresh post.
+
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and
 sees all six. That is intended.
@@ -343,9 +349,9 @@ sees all six. That is intended.
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
 | `dedup:{event_id}` | String | Per-event processing claim with TTL. Not taken for notify lists, which are idempotent by `created_at` and would be lost for the TTL if a failed handler left a claim standing |
-| `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Successful per-recipient video delivery, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered bell writes only its own |
+| `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Per-recipient video delivery decision, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered or rate-limited bell writes its own |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
-| `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |
+| `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. Exact-id replays apply idempotently for repair. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |
 | `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
 | `notify_rate:{subscriber}:{creator}` | String | New-post rate-limit window marker, TTL `new_post_rate_limit_secs` (one hour by default). |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -315,8 +315,9 @@ key layout.
 
 ### Delivery
 
-On each incoming kind 34236, `video_notification_targets` unions the video's
-mention targets with `SMEMBERS notify_watchers:{author}`.
+On each incoming kind 34236, the handler sends the video's mention targets first,
+then walks `notify_watchers:{author}` with paged `SSCAN` reads and bounded
+delivery for each page.
 
 **Mention wins on overlap.** A user who both watches the creator and is mentioned
 in the video gets one push, typed `mention`, because that is the more specific
@@ -343,6 +344,14 @@ When the rate limit suppresses a new-post push, the video-coordinate record is
 still written. That video has been intentionally dropped for that watcher, and a
 later NIP-33 edit should not re-announce it as a fresh post.
 
+New-post fan-out is paged by `new_post_fanout_page_size` and each page is
+delivered with at most `new_post_delivery_concurrency` concurrent recipient
+sends. This is separate from the notify-list write cap: one user's list cannot
+stall Redis on write, and one popular creator's audience cannot turn a single
+video into one unbounded Redis read or unbounded sequential delivery loop. The
+page size is not a recipient cap; the handler continues until Redis returns
+cursor 0.
+
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and
 sees all six. That is intended.
@@ -359,5 +368,5 @@ sees all six. That is intended.
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
 | `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. Exact-id replays apply idempotently for repair. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |
-| `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
+| `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path walks this set with paged `SSCAN` reads. |
 | `notify_rate:{subscriber}:{creator}` | String | New-post rate-limit window marker, TTL `new_post_rate_limit_secs` (one hour by default). |

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -26,6 +26,11 @@ Avoid always-on connections (battery), deliver timely alerts, and enable secure 
 
 All event content fields MUST contain NIP-44 ciphertext strings. The decrypted payload structure is defined below.
 
+A service MAY additionally read a public NIP-51 list to support per-author
+subscriptions; see [Author subscriptions](#author-subscriptions-kind-30000).
+That list is deliberately **not** encrypted, because the service must be able to
+read it. It is not one of the control kinds above and carries no ciphertext.
+
 ### Registration (kind 3079)
 
 ```json
@@ -96,11 +101,56 @@ The decrypted content is a JSON object with a `kinds` array listing the event ki
 
 An empty `kinds` array disables all notifications. Services SHOULD define sensible defaults for users who have not sent a preferences event.
 
+### Author subscriptions (kind 30000)
+
+Every trigger described so far is *someone acted on your content*, resolved from
+`p` tags on the trigger event. A service MAY also support the inverse — notify a
+user when an author they subscribed to publishes — by reading a NIP-51 people
+list with a reserved `d` identifier:
+
+```json
+{
+  "kind": 30000,
+  "tags": [
+    ["d", "notify"],
+    ["title", "Notify"],
+    ["p", "<author-pubkey-hex>"],
+    ["p", "<author-pubkey-hex>"]
+  ],
+  "content": ""
+}
+```
+
+Requirements:
+
+- The list is a parameterised replaceable event: the tuple (pubkey, `30000`,
+  `notify`) identifies it, and each publish REPLACES the previous set. Clients
+  MUST publish the complete list on every change, never a delta.
+- `content` MUST be empty. Encrypting it would make the list unreadable to the
+  service and defeat the mechanism.
+- `p` tags MUST carry full-length hex pubkeys.
+- An empty `p` set is **valid** and means "no subscriptions". Services MUST treat
+  it as a clearing update, not as a malformed event.
+- Services MUST ignore kind 30000 events whose `d` tag is not exactly `notify`.
+- Services MUST NOT age these events out on a replay horizon. A list published
+  long ago and never edited is still current.
+- Services SHOULD guard against out-of-order delivery by tracking the
+  `created_at` of the last applied list and rejecting older or equal values;
+  relays may deliver a stale replacement after a newer one.
+
+Because the list is public, **who a user subscribes to is public**. Clients
+SHOULD surface that rather than implying the subscription is private.
+
+Notifications generated this way SHOULD be rate-limited per (subscriber, author);
+a prolific author otherwise trains users into disabling notifications entirely.
+
 ## Notification Triggers
 
 Services define which events trigger notifications. A typical single-app service watches for specific event kinds (reactions, replies, follows, mentions, reposts) and notifies users who are tagged or referenced.
 
-Services MAY support additional trigger logic beyond kind matching.
+Services MAY support additional trigger logic beyond kind matching, including
+recipient sets that come from subscriber-published state rather than from tags
+on the trigger event (see [Author subscriptions](#author-subscriptions-kind-30000)).
 
 ## Implementation Requirements
 

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -134,9 +134,15 @@ Requirements:
 - Services MUST ignore kind 30000 events whose `d` tag is not exactly `notify`.
 - Services MUST NOT age these events out on a replay horizon. A list published
   long ago and never edited is still current.
-- Services SHOULD guard against out-of-order delivery by tracking the
-  `created_at` of the last applied list and rejecting older or equal values;
-  relays may deliver a stale replacement after a newer one.
+- Services SHOULD guard against out-of-order delivery by tracking the last
+  applied list and rejecting anything older; relays may deliver a stale
+  replacement after a newer one.
+- Services MUST resolve a `created_at` tie the way NIP-01 resolves it, by
+  retaining the event with the lowest id. Resolving by arrival order instead
+  makes the service's state diverge permanently from the relay's, so a rebuild
+  from relay history answers differently than what was served live. Tracking the
+  last applied `created_at` alone is not enough for this; the id has to be kept
+  alongside it.
 
 Because the list is public, **who a user subscribes to is public**. Clients
 SHOULD surface that rather than implying the subscription is private.

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,12 +78,22 @@ pub struct ServiceSettings {
     /// stall the instance for everyone.
     #[serde(default = "default_notify_list_max_creators")]
     pub notify_list_max_creators: usize,
-    /// Cap on notify lists pulled during historical replay.
+    /// Page size for notify lists pulled during historical replay.
     ///
     /// The historical notify-list query is deliberately unbounded in time, so
     /// this is the safety valve on result size instead.
     #[serde(default = "default_notify_list_history_limit")]
     pub notify_list_history_limit: usize,
+    /// Watcher page size for one video event.
+    ///
+    /// New-post recipients are follower-count-shaped, not p-tag-shaped. Paging
+    /// keeps Redis reads and delivery batches bounded without dropping bell
+    /// subscribers past an arbitrary cap.
+    #[serde(default = "default_new_post_fanout_page_size")]
+    pub new_post_fanout_page_size: usize,
+    /// Maximum concurrent new-post deliveries for one watcher page.
+    #[serde(default = "default_new_post_delivery_concurrency")]
+    pub new_post_delivery_concurrency: usize,
     /// When set, only send notifications to these pubkeys (hex). Empty means no restriction.
     /// Accepts a comma-separated string (from env vars) or a YAML list.
     #[serde(default, deserialize_with = "deserialize_comma_separated")]
@@ -106,6 +116,14 @@ fn default_notify_list_max_creators() -> usize {
 
 fn default_notify_list_history_limit() -> usize {
     5000
+}
+
+fn default_new_post_fanout_page_size() -> usize {
+    1000
+}
+
+fn default_new_post_delivery_concurrency() -> usize {
+    50
 }
 
 fn default_new_post_rate_limit() -> u64 {
@@ -272,20 +290,21 @@ impl Settings {
 
     /// Reject values that deserialize cleanly but cannot work at runtime.
     ///
-    /// Every field here is a bound the service writes to Redis or counts
-    /// against, and every one of them fails *quietly* at zero. Redis rejects an
-    /// expiry of 0, but nothing downstream treats that rejection as fatal, so
-    /// the throttle simply never engages, the cache never caches, the claim
-    /// never lands. The two caps are worse still: they are read as "nothing
-    /// allowed" and take a subscriber's bells with them. A startup error is the
-    /// only place an operator would find out.
+    /// Every field here is a bound the service writes to Redis, counts against,
+    /// or uses to size bounded fan-out work, and every one of them fails
+    /// *quietly* at zero. Redis rejects an expiry of 0, but nothing downstream
+    /// treats that rejection as fatal, so the throttle simply never engages,
+    /// the cache never caches, the claim never lands. The caps and page sizes
+    /// are worse still: they are read as "nothing allowed" and take a
+    /// subscriber's bells with them. A startup error is the only place an
+    /// operator would find out.
     ///
     /// This is reachable without editing `settings.yaml`. The config crate
     /// layers `NOSTR_PUSH__*` over the file, and production already sets
     /// `NOSTR_PUSH__SERVICE__ALLOWED_PUBKEYS` that way, so the same mechanism
     /// reaches every field below.
     fn validate(&self) -> Result<(), ConfigError> {
-        let must_be_positive: [(&str, u64, &str); 6] = [
+        let must_be_positive: [(&str, u64, &str); 8] = [
             (
                 "nostr.profile_cache_ttl_secs",
                 self.nostr.profile_cache_ttl_secs,
@@ -315,6 +334,16 @@ impl Settings {
                 "service.notify_list_history_limit",
                 self.service.notify_list_history_limit as u64,
                 "the startup replay fetches nothing",
+            ),
+            (
+                "service.new_post_fanout_page_size",
+                self.service.new_post_fanout_page_size as u64,
+                "new-post fan-out never reads bell subscribers",
+            ),
+            (
+                "service.new_post_delivery_concurrency",
+                self.service.new_post_delivery_concurrency as u64,
+                "new-post fan-out cannot start delivery work",
             ),
         ];
 
@@ -407,7 +436,7 @@ mod tests {
 
         // One case per field, because a loop over the same setter would pass
         // just as well against a `validate` that only checks the first.
-        let cases: [ZeroCase; 6] = [
+        let cases: [ZeroCase; 8] = [
             ("nostr.profile_cache_ttl_secs", |s| {
                 s.nostr.profile_cache_ttl_secs = 0
             }),
@@ -425,6 +454,12 @@ mod tests {
             }),
             ("service.notify_list_history_limit", |s| {
                 s.service.notify_list_history_limit = 0
+            }),
+            ("service.new_post_fanout_page_size", |s| {
+                s.service.new_post_fanout_page_size = 0
+            }),
+            ("service.new_post_delivery_concurrency", |s| {
+                s.service.new_post_delivery_concurrency = 0
             }),
         ];
 
@@ -453,6 +488,19 @@ mod tests {
                 settings.service.video_coordinate_dedup_ttl_secs
                     > settings.service.processed_event_ttl_secs,
                 "video-coordinate delivery records must outlive event-id claims"
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_post_fanout_limits_are_bounded() {
+        for filename in ["settings.yaml", "settings.development.yaml"] {
+            let settings = load_runtime_settings(filename);
+            assert!(settings.service.new_post_fanout_page_size > 0);
+            assert!(settings.service.new_post_delivery_concurrency > 0);
+            assert!(
+                settings.service.new_post_delivery_concurrency
+                    <= settings.service.new_post_fanout_page_size
             );
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,7 +265,68 @@ impl Settings {
             )
             .build()?;
 
-        s.try_deserialize()
+        let settings: Settings = s.try_deserialize()?;
+        settings.validate()?;
+        Ok(settings)
+    }
+
+    /// Reject values that deserialize cleanly but cannot work at runtime.
+    ///
+    /// Every field here is a bound the service writes to Redis or counts
+    /// against, and every one of them fails *quietly* at zero. Redis rejects an
+    /// expiry of 0, but nothing downstream treats that rejection as fatal, so
+    /// the throttle simply never engages, the cache never caches, the claim
+    /// never lands. The two caps are worse still: they are read as "nothing
+    /// allowed" and take a subscriber's bells with them. A startup error is the
+    /// only place an operator would find out.
+    ///
+    /// This is reachable without editing `settings.yaml`. The config crate
+    /// layers `NOSTR_PUSH__*` over the file, and production already sets
+    /// `NOSTR_PUSH__SERVICE__ALLOWED_PUBKEYS` that way, so the same mechanism
+    /// reaches every field below.
+    fn validate(&self) -> Result<(), ConfigError> {
+        let must_be_positive: [(&str, u64, &str); 6] = [
+            (
+                "nostr.profile_cache_ttl_secs",
+                self.nostr.profile_cache_ttl_secs,
+                "cache writes fail silently, so every event refetches profiles from the relays",
+            ),
+            (
+                "service.processed_event_ttl_secs",
+                self.service.processed_event_ttl_secs,
+                "the event claim errors, so no claimed event is ever processed",
+            ),
+            (
+                "service.video_coordinate_dedup_ttl_secs",
+                self.service.video_coordinate_dedup_ttl_secs,
+                "no delivery is recorded, so every video edit re-notifies",
+            ),
+            (
+                "service.new_post_rate_limit_secs",
+                self.service.new_post_rate_limit_secs,
+                "the window never opens, so new-post pushes are never throttled",
+            ),
+            (
+                "service.notify_list_max_creators",
+                self.service.notify_list_max_creators as u64,
+                "every notify list reads as empty, clearing that subscriber's bells",
+            ),
+            (
+                "service.notify_list_history_limit",
+                self.service.notify_list_history_limit as u64,
+                "the startup replay fetches nothing",
+            ),
+        ];
+
+        for (name, value, consequence) in must_be_positive {
+            if value == 0 {
+                return Err(ConfigError::Message(format!(
+                    "{name} must be greater than zero: at 0, {consequence}"
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     /// Get service keys for relay auth and NIP-44 encryption
@@ -323,6 +384,59 @@ mod tests {
             assert_eq!(
                 settings.notification.event_kinds, expected,
                 "{filename} must stay in sync with default_event_kinds()"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shipped_config_passes_validation() {
+        // `load_runtime_settings` deserializes without validating, so this is
+        // the only thing asserting the files we actually ship would boot.
+        for filename in ["settings.yaml", "settings.development.yaml"] {
+            assert!(
+                load_runtime_settings(filename).validate().is_ok(),
+                "{filename} must load"
+            );
+        }
+    }
+
+    #[test]
+    fn test_every_degenerate_zero_is_rejected_at_load() {
+        /// A field name and the setter that zeroes it.
+        type ZeroCase = (&'static str, fn(&mut Settings));
+
+        // One case per field, because a loop over the same setter would pass
+        // just as well against a `validate` that only checks the first.
+        let cases: [ZeroCase; 6] = [
+            ("nostr.profile_cache_ttl_secs", |s| {
+                s.nostr.profile_cache_ttl_secs = 0
+            }),
+            ("service.processed_event_ttl_secs", |s| {
+                s.service.processed_event_ttl_secs = 0
+            }),
+            ("service.video_coordinate_dedup_ttl_secs", |s| {
+                s.service.video_coordinate_dedup_ttl_secs = 0
+            }),
+            ("service.new_post_rate_limit_secs", |s| {
+                s.service.new_post_rate_limit_secs = 0
+            }),
+            ("service.notify_list_max_creators", |s| {
+                s.service.notify_list_max_creators = 0
+            }),
+            ("service.notify_list_history_limit", |s| {
+                s.service.notify_list_history_limit = 0
+            }),
+        ];
+
+        for (field, zero_it) in cases {
+            let mut settings = load_runtime_settings("settings.yaml");
+            zero_it(&mut settings);
+            let error = settings
+                .validate()
+                .expect_err(&format!("{field} at zero must be rejected"));
+            assert!(
+                error.to_string().contains(field),
+                "the error must name the field an operator has to fix, got: {error}"
             );
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,15 @@ pub struct ServiceSettings {
     /// Retention for successful per-recipient video-coordinate deliveries.
     #[serde(default = "default_video_coordinate_dedup_ttl")]
     pub video_coordinate_dedup_ttl_secs: u64,
+    /// Minimum gap between new-post pushes for one (subscriber, creator) pair.
+    #[serde(default = "default_new_post_rate_limit")]
+    pub new_post_rate_limit_secs: u64,
+    /// Cap on notify lists pulled during historical replay.
+    ///
+    /// The historical notify-list query is deliberately unbounded in time, so
+    /// this is the safety valve on result size instead.
+    #[serde(default = "default_notify_list_history_limit")]
+    pub notify_list_history_limit: usize,
     /// When set, only send notifications to these pubkeys (hex). Empty means no restriction.
     /// Accepts a comma-separated string (from env vars) or a YAML list.
     #[serde(default, deserialize_with = "deserialize_comma_separated")]
@@ -75,6 +84,17 @@ fn default_process_window_days() -> i64 {
 
 fn default_processed_event_ttl() -> u64 {
     604800 // 7 days
+}
+
+fn default_notify_list_history_limit() -> usize {
+    5000
+}
+
+fn default_new_post_rate_limit() -> u64 {
+    // Vines are cheap to make. An unthrottled prolific creator trains users to
+    // disable notifications entirely, so cap new-post pushes at one per hour
+    // per creator. The in-app feed is deliberately not throttled.
+    3600
 }
 
 fn default_video_coordinate_dedup_ttl() -> u64 {
@@ -186,6 +206,7 @@ fn default_preference_kinds() -> Vec<u16> {
         7,     // Reactions/likes
         16,    // Reposts
         30023, // Long-form content
+        34236, // Videos from subscribed creators (new-post "bells")
     ]
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,13 @@ pub struct ServiceSettings {
     /// Minimum gap between new-post pushes for one (subscriber, creator) pair.
     #[serde(default = "default_new_post_rate_limit")]
     pub new_post_rate_limit_secs: u64,
+    /// Cap on creators honored from a single notify list.
+    ///
+    /// `replace_notify_subscriptions` applies the whole diff in one Lua script
+    /// and Redis is single-threaded, so an unbounded list would let one user
+    /// stall the instance for everyone.
+    #[serde(default = "default_notify_list_max_creators")]
+    pub notify_list_max_creators: usize,
     /// Cap on notify lists pulled during historical replay.
     ///
     /// The historical notify-list query is deliberately unbounded in time, so
@@ -84,6 +91,12 @@ fn default_process_window_days() -> i64 {
 
 fn default_processed_event_ttl() -> u64 {
     604800 // 7 days
+}
+
+fn default_notify_list_max_creators() -> usize {
+    // The bell is follow-gated on the client, so this is well above any
+    // legitimate list while still bounding the Lua script's work.
+    1000
 }
 
 fn default_notify_list_history_limit() -> usize {

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,11 @@ pub struct NostrSettings {
     pub profile_relays: Vec<String>,
     #[serde(default = "default_profile_cache_ttl")]
     pub profile_cache_ttl_secs: u64,
+    /// Currently inert: no code reads this. The profile fetch that an operator
+    /// would reach for it to bound is hard-coded to five seconds in
+    /// `MentionParser::fetch_from_relays`. Left in place rather than removed
+    /// because deleting it would break existing config files, but do not expect
+    /// changing it to affect anything.
     #[serde(default = "default_query_timeout")]
     pub query_timeout_secs: u64,
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1015,6 +1015,22 @@ fn video_recipient_claim_key(
     ))
 }
 
+/// Legacy video-coordinate key written before the claim was scoped by type.
+///
+/// Those keys live for `video_coordinate_dedup_ttl_secs`, one year by default,
+/// so a deploy must keep reading them for one full TTL cycle. A legacy record
+/// came from a video mention, which also satisfies a bell for the same
+/// coordinate; see `satisfied_video_claims`.
+fn legacy_video_recipient_claim_key(event: &Event, recipient: &PublicKey) -> Option<String> {
+    let d_tag = event.tags.identifier()?;
+    Some(format!(
+        "{}:{}:{d_tag}:{}",
+        event.kind.as_u16(),
+        event.pubkey.to_hex(),
+        recipient.to_hex()
+    ))
+}
+
 /// The video-coordinate records a delivered push satisfies.
 ///
 /// Type-scoping the claim key made the two directions independent, but they are
@@ -1045,6 +1061,95 @@ fn satisfied_video_claims(notification_type: NotificationType) -> Vec<Notificati
         NotificationType::Mention => vec![NotificationType::Mention, NotificationType::NewPost],
         other => vec![other],
     }
+}
+
+async fn has_video_claim(
+    state: &AppState,
+    event: &Event,
+    target_pubkey: &PublicKey,
+    notification_type: NotificationType,
+    token: &CancellationToken,
+) -> Result<bool> {
+    let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, notification_type) else {
+        warn!(
+            event_id = %event.id,
+            target_pubkey = %target_pubkey,
+            "Skipping video notification without an addressable d-tag"
+        );
+        return Ok(true);
+    };
+    let redis_key = format!("dedup:{claim_key}");
+    let already_notified = tokio::select! {
+        biased;
+        _ = token.cancelled() => {
+            info!(event_id = %event.id, target_pubkey = %target_pubkey, "Cancelled while checking video recipient delivery.");
+            return Err(crate::error::ServiceError::Cancelled);
+        }
+        lookup_result = redis_store::get_cached_string(&state.redis_pool, &redis_key) => {
+            lookup_result?.is_some()
+        }
+    };
+    if already_notified {
+        return Ok(true);
+    }
+
+    let Some(legacy_claim_key) = legacy_video_recipient_claim_key(event, target_pubkey) else {
+        return Ok(false);
+    };
+    let legacy_redis_key = format!("dedup:{legacy_claim_key}");
+    tokio::select! {
+        biased;
+        _ = token.cancelled() => {
+            info!(event_id = %event.id, target_pubkey = %target_pubkey, "Cancelled while checking legacy video recipient delivery.");
+            Err(crate::error::ServiceError::Cancelled)
+        }
+        lookup_result = redis_store::get_cached_string(&state.redis_pool, &legacy_redis_key) => {
+            Ok(lookup_result?.is_some())
+        }
+    }
+}
+
+async fn record_video_claims(
+    state: &AppState,
+    event: &Event,
+    target_pubkey: &PublicKey,
+    notification_type: NotificationType,
+    log_message: &'static str,
+) -> Result<()> {
+    if event.kind.as_u16() != KIND_VIDEO {
+        return Ok(());
+    }
+
+    for satisfied in satisfied_video_claims(notification_type) {
+        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, satisfied) else {
+            warn!(
+                event_id = %event.id,
+                target_pubkey = %target_pubkey,
+                "Video notification lacked an addressable d-tag"
+            );
+            return Ok(());
+        };
+        let redis_key = format!("dedup:{claim_key}");
+        if let Err(e) = redis_store::set_cached_string(
+            &state.redis_pool,
+            &redis_key,
+            "1",
+            state.settings.service.video_coordinate_dedup_ttl_secs,
+        )
+        .await
+        {
+            error!(
+                event_id = %event.id,
+                target_pubkey = %target_pubkey,
+                claim = %redis_key,
+                error = %e,
+                message = log_message,
+                "Failed to record a video-coordinate claim"
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Find recipients for a NIP-22 comment event (kind 1111).
@@ -1129,49 +1234,59 @@ async fn send_notification_to_user(
     )
     .await?;
 
-    if !notification_type.is_enabled(&prefs) {
-        info!(
-            event_id = %event_id,
-            target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
-            notification_type = ?notification_type,
-            "Notification type disabled by user preferences - skipping"
-        );
-        return Ok(());
-    }
+    let mut delivery_type = notification_type;
+    if !delivery_type.is_enabled(&prefs) {
+        let can_fall_back_to_bell = if event.kind.as_u16() == KIND_VIDEO
+            && delivery_type == NotificationType::Mention
+            && NotificationType::NewPost.is_enabled(&prefs)
+        {
+            match redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await {
+                Ok(watchers) => watchers.contains(target_pubkey),
+                Err(e) => {
+                    error!(
+                        event_id = %event_id,
+                        target_pubkey = %target_pubkey,
+                        creator = %event.pubkey,
+                        error = %e,
+                        "Failed to check bell fallback for muted video mention"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
 
-    if event.kind.as_u16() == KIND_VIDEO {
-        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, notification_type)
-        else {
-            warn!(
+        if can_fall_back_to_bell {
+            delivery_type = NotificationType::NewPost;
+            info!(
                 event_id = %event_id,
-                target_pubkey = %target_pubkey,
-                "Skipping video notification without an addressable d-tag"
+                target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
+                "Video mention disabled but bell enabled for watcher - delivering new-post notification"
             );
-            return Ok(());
-        };
-        let redis_key = format!("dedup:{claim_key}");
-        let already_notified = tokio::select! {
-            biased;
-            _ = token.cancelled() => {
-                info!(event_id = %event_id, target_pubkey = %target_pubkey, "Cancelled while checking video recipient delivery.");
-                return Err(crate::error::ServiceError::Cancelled);
-            }
-            lookup_result = redis_store::get_cached_string(&state.redis_pool, &redis_key) => {
-                lookup_result?.is_some()
-            }
-        };
-
-        if already_notified {
-            trace!(
+        } else {
+            info!(
                 event_id = %event_id,
-                target_pubkey = %target_pubkey,
-                "Skipping video recipient already notified for this coordinate"
+                target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
+                notification_type = ?delivery_type,
+                "Notification type disabled by user preferences - skipping"
             );
             return Ok(());
         }
     }
 
-    if notification_type == NotificationType::NewPost {
+    if event.kind.as_u16() == KIND_VIDEO
+        && has_video_claim(state, event, target_pubkey, delivery_type, &token).await?
+    {
+        trace!(
+            event_id = %event_id,
+            target_pubkey = %target_pubkey,
+            "Skipping video recipient already notified for this coordinate"
+        );
+        return Ok(());
+    }
+
+    if delivery_type == NotificationType::NewPost {
         let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
         let within_window = tokio::select! {
             biased;
@@ -1191,6 +1306,14 @@ async fn send_notification_to_user(
                 creator = %event.pubkey,
                 "Skipping new-post notification inside the per-creator rate-limit window"
             );
+            record_video_claims(
+                state,
+                event,
+                target_pubkey,
+                delivery_type,
+                "Failed to record a rate-limited video-coordinate claim; an edit may re-notify",
+            )
+            .await?;
             return Ok(());
         }
     }
@@ -1214,7 +1337,7 @@ async fn send_notification_to_user(
     };
 
     // Create FCM payload
-    let payload = create_fcm_payload(event, target_pubkey, notification_type, copy);
+    let payload = create_fcm_payload(event, target_pubkey, delivery_type, copy);
 
     // Send to all tokens
     info!(
@@ -1282,7 +1405,7 @@ async fn send_notification_to_user(
     // same instant can both pass the check and double-send. That race is rare,
     // bounded, and low-harm; silently eating an hour of notifications on an FCM
     // blip is worse. Do not "fix" this into `SET NX EX`.
-    if notification_type == NotificationType::NewPost && success_count > 0 {
+    if delivery_type == NotificationType::NewPost && success_count > 0 {
         let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
         // Log and continue rather than `?`. Everything from here down is
         // bookkeeping about a push that has already shipped, so propagating
@@ -1306,43 +1429,19 @@ async fn send_notification_to_user(
         }
     }
 
-    if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
-        for satisfied in satisfied_video_claims(notification_type) {
-            // Unreachable today: the pre-send gate above already returned if
-            // the d-tag were missing. `break` rather than `return` regardless —
-            // the d-tag does not depend on `satisfied`, so there is nothing for
-            // a second pass to find, and invalid-token removal below this block
-            // still has to run.
-            let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, satisfied) else {
-                warn!(
-                    event_id = %event_id,
-                    target_pubkey = %target_pubkey,
-                    "Successful video notification lacked an addressable d-tag"
-                );
-                break;
-            };
-            let redis_key = format!("dedup:{claim_key}");
-            // Same reasoning as the rate-limit write above, and it matters more
-            // here: `satisfied_video_claims` can yield two records, and `?` on
-            // the first left the second unwritten. That is exactly the
-            // half-written state the type-scoped claim exists to prevent.
-            if let Err(e) = redis_store::set_cached_string(
-                &state.redis_pool,
-                &redis_key,
-                "1",
-                state.settings.service.video_coordinate_dedup_ttl_secs,
-            )
-            .await
-            {
-                error!(
-                    event_id = %event_id,
-                    target_pubkey = %target_pubkey,
-                    claim = %redis_key,
-                    error = %e,
-                    "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify"
-                );
-            }
-        }
+    if success_count > 0 {
+        // Same reasoning as the rate-limit write above, and it matters more
+        // here: `satisfied_video_claims` can yield two records, and `?` on
+        // the first left the second unwritten. That is exactly the
+        // half-written state the type-scoped claim exists to prevent.
+        record_video_claims(
+            state,
+            event,
+            target_pubkey,
+            delivery_type,
+            "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify",
+        )
+        .await?;
     }
 
     // Remove invalid tokens
@@ -1642,6 +1741,12 @@ mod tests {
             sender_name: "tester".to_string(),
             formatted_content: None,
         })
+    }
+
+    fn test_event_id(seed: u64) -> EventId {
+        let mut bytes = [0u8; 32];
+        bytes[24..].copy_from_slice(&seed.to_be_bytes());
+        EventId::from_slice(&bytes).expect("32 bytes is a valid event id")
     }
 
     #[test]
@@ -2600,6 +2705,235 @@ mod tests {
                 &watcher.public_key(),
                 &owner.public_key(),
             ))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_legacy_video_claim_suppresses_type_scoped_delivery() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("legacy-claim-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "edited version")
+            .tag(Tag::identifier("legacy-claim"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        let legacy_key = legacy_video_recipient_claim_key(&event, &watcher.public_key()).unwrap();
+        redis_store::set_cached_string(&pool, &format!("dedup:{legacy_key}"), "1", 3600)
+            .await
+            .unwrap();
+
+        send_notification_to_user(
+            &state,
+            &event,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "a one-year legacy coordinate record must survive the key-format rollout"
+        );
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{legacy_key}"))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_muted_video_mention_falls_back_to_enabled_bell_for_watcher() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("mention-fallback-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        preferences::set_user_preferences(
+            &pool,
+            &watcher.public_key().to_hex(),
+            &UserPreferences { kinds: vec![34236] },
+        )
+        .await
+        .unwrap();
+        redis_store::replace_notify_subscriptions(
+            &pool,
+            &watcher.public_key(),
+            &[owner.public_key()],
+            1000,
+            &test_event_id(1000),
+        )
+        .await
+        .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "mentioned watcher")
+            .tag(Tag::identifier("mention-fallback"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+
+        send_notification_to_user(
+            &state,
+            &event,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let sent = mock_sender.get_sent_messages();
+        assert_eq!(sent.len(), 1);
+        let payload_type = sent[0].1.data.as_ref().and_then(|data| data.get("type"));
+        assert_eq!(
+            payload_type,
+            Some(&"newPost".to_string()),
+            "the muted mention should deliver the bell the watcher enabled"
+        );
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        preferences::delete_user_preferences(&pool, &watcher.public_key().to_hex())
+            .await
+            .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        let bell_key =
+            video_recipient_claim_key(&event, &watcher.public_key(), NotificationType::NewPost)
+                .unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{bell_key}"))
+            .arg(redis_store::build_notify_rate_key(
+                &watcher.public_key(),
+                &owner.public_key(),
+            ))
+            .arg(format!("notify_subs:{}", watcher.public_key().to_hex()))
+            .arg(format!("notify_subs_ts:{}", watcher.public_key().to_hex()))
+            .arg(format!("notify_watchers:{}", owner.public_key().to_hex()))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_rate_limited_bell_records_the_video_coordinate() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("rate-limited-claim-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let rate_key =
+            redis_store::build_notify_rate_key(&watcher.public_key(), &owner.public_key());
+        redis_store::set_cached_string(&pool, &rate_key, "1", 3600)
+            .await
+            .unwrap();
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "inside the window")
+            .tag(Tag::identifier("rate-limited-claim"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &event,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let claim_key =
+            video_recipient_claim_key(&event, &watcher.public_key(), NotificationType::NewPost)
+                .unwrap();
+        let record = redis_store::get_cached_string(&pool, &format!("dedup:{claim_key}"))
+            .await
+            .unwrap();
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "the rate-limited video itself is suppressed"
+        );
+        assert!(
+            record.is_some(),
+            "a suppressed new-post push must still mark the coordinate"
+        );
+
+        let edit = EventBuilder::new(Kind::from(KIND_VIDEO), "later edit")
+            .tag(Tag::identifier("rate-limited-claim"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(&rate_key)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &edit,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "a later edit of the suppressed video must stay quiet"
+        );
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{claim_key}"))
             .query_async::<()>(&mut *conn)
             .await
             .unwrap();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -68,6 +68,30 @@ pub fn is_beyond_replay_horizon(event: &Event) -> bool {
     is_event_too_old(event) && !is_notify_list(event)
 }
 
+/// Whether the handler loop should claim this event before routing it.
+///
+/// The claim exists to stop two replicas sending the same push twice, and for
+/// every handler that sends a push it is the only thing standing between a
+/// duplicate and the user. Notify lists send nothing. They build persistent
+/// state through `replace_notify_subscriptions`, a single atomic Lua script that
+/// already rejects any list not strictly newer than the stored one, so
+/// concurrent replicas applying the same list are a no-op with or without the
+/// claim.
+///
+/// Meanwhile the claim is taken *before* routing and never released, so a
+/// transient Redis error inside the handler leaves it standing: the historical
+/// replay on the next restart skips the event as already-claimed, and that
+/// subscriber's bells stay dark until `processed_event_ttl_secs` expires, seven
+/// days by default. So the claim trades an outage of a user's subscriptions for
+/// deduplication the Lua script performs anyway.
+///
+/// Scoped by `is_notify_list` rather than kind alone, symmetric with
+/// `is_beyond_replay_horizon`: the idempotency argument rests on the Lua script,
+/// which only runs for `d=notify`.
+pub fn requires_event_claim(event: &Event) -> bool {
+    !is_notify_list(event)
+}
+
 /// Check if event is targeted to this service via p tag
 fn is_event_for_service(event: &Event, service_pubkey: &PublicKey) -> bool {
     event
@@ -127,31 +151,36 @@ pub async fn run(
                     continue;
                 }
 
-                // Atomically claim the event to prevent duplicate processing across replicas
-                let claimed = tokio::select! {
-                    biased;
-                    _ = token.cancelled() => {
-                        info!("Event handler cancelled while claiming event {}.", event_id);
-                        break;
-                    }
-                    claim_result = redis_store::try_claim_event(
-                        &state.redis_pool,
-                        &event_id,
-                        state.settings.service.processed_event_ttl_secs,
-                    ) => {
-                        match claim_result {
-                            Ok(claimed) => claimed,
-                            Err(e) => {
-                                error!(event_id = %event_id, error = %e, "Failed to claim event");
-                                continue;
+                // Atomically claim the event to prevent duplicate processing across
+                // replicas. Notify lists are exempt: the claim prevents nothing for
+                // them and turns a transient Redis error into days of lost
+                // subscriptions. See `requires_event_claim`.
+                if requires_event_claim(&event) {
+                    let claimed = tokio::select! {
+                        biased;
+                        _ = token.cancelled() => {
+                            info!("Event handler cancelled while claiming event {}.", event_id);
+                            break;
+                        }
+                        claim_result = redis_store::try_claim_event(
+                            &state.redis_pool,
+                            &event_id,
+                            state.settings.service.processed_event_ttl_secs,
+                        ) => {
+                            match claim_result {
+                                Ok(claimed) => claimed,
+                                Err(e) => {
+                                    error!(event_id = %event_id, error = %e, "Failed to claim event");
+                                    continue;
+                                }
                             }
                         }
-                    }
-                };
+                    };
 
-                if !claimed {
-                    trace!(event_id = %event_id, "Skipping already claimed event");
-                    continue;
+                    if !claimed {
+                        trace!(event_id = %event_id, "Skipping already claimed event");
+                        continue;
+                    }
                 }
 
                 // Route the event based on its type

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -794,9 +794,12 @@ fn renders_event_content(notification_type: NotificationType) -> bool {
 ///
 /// An eager resolve therefore pays `get_display_name` for events that deliver
 /// nothing. That is a Redis GET plus, on a cache miss, a relay `fetch_events`
-/// bounded by `query_timeout_secs` — and misses are never written back, so an
-/// author with no kind-0 pays it on every event forever. All of it on the single
-/// sequential handler task, ahead of every other user's notifications.
+/// bounded by the five seconds hard-coded in `MentionParser::fetch_from_relays`
+/// — not by `query_timeout_secs`, which is declared in config and read nowhere,
+/// so it is not a knob an operator can turn on this path. Misses are never
+/// written back either, so an author with no kind-0 pays it on every event
+/// forever. All of it on the single sequential handler task, ahead of every
+/// other user's notifications.
 ///
 /// Deferring the resolve to the first recipient that actually reaches payload
 /// construction keeps the once-per-event property and restores the property the

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1109,15 +1109,24 @@ async fn has_video_claim(
     }
 }
 
+/// Record the video-coordinate claims a decision about `target_pubkey` settles.
+///
+/// Infallible on purpose. Every caller reaches this after the delivery decision
+/// is final — the push has shipped, or the rate limit has deliberately dropped
+/// it — so a failed write here is bookkeeping loss, not a reason to abandon the
+/// work that follows. `a10a02b`'s `return` in the old inline loop skipped
+/// invalid-token removal for the same reason `726bd1e` had to make it a
+/// `break`; returning `()` keeps that class of bug from coming back through a
+/// `?` at a call site.
 async fn record_video_claims(
     state: &AppState,
     event: &Event,
     target_pubkey: &PublicKey,
     notification_type: NotificationType,
     log_message: &'static str,
-) -> Result<()> {
+) {
     if event.kind.as_u16() != KIND_VIDEO {
-        return Ok(());
+        return;
     }
 
     for satisfied in satisfied_video_claims(notification_type) {
@@ -1127,7 +1136,7 @@ async fn record_video_claims(
                 target_pubkey = %target_pubkey,
                 "Video notification lacked an addressable d-tag"
             );
-            return Ok(());
+            return;
         };
         let redis_key = format!("dedup:{claim_key}");
         if let Err(e) = redis_store::set_cached_string(
@@ -1148,8 +1157,6 @@ async fn record_video_claims(
             );
         }
     }
-
-    Ok(())
 }
 
 /// Find recipients for a NIP-22 comment event (kind 1111).
@@ -1315,7 +1322,7 @@ async fn send_notification_to_user(
                 delivery_type,
                 "Failed to record a rate-limited video-coordinate claim; an edit may re-notify",
             )
-            .await?;
+            .await;
             return Ok(());
         }
     }
@@ -1443,7 +1450,7 @@ async fn send_notification_to_user(
             delivery_type,
             "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify",
         )
-        .await?;
+        .await;
     }
 
     // Remove invalid tokens
@@ -3079,6 +3086,89 @@ mod tests {
         assert!(
             result.is_ok(),
             "a bookkeeping write failing is not a delivery failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_claim_write_still_removes_the_invalid_token() {
+        // The consequence the test above only implies. Invalid-token removal
+        // runs after the claim writes, so a `?` on them strands a token FCM has
+        // already rejected: every later push to this user pays for a delivery
+        // that cannot land, and nothing retries the removal.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        // Two tokens: one has to succeed, or `success_count` stays 0 and the
+        // claim write this test needs to fail never runs at all.
+        let live_token = format!("live-{}", watcher.public_key().to_hex());
+        let stale_token = format!("stale-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &live_token)
+            .await
+            .unwrap();
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &stale_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        mock_sender.set_error_for_token(&stale_token, FcmError::TokenNotRegistered);
+        let mut settings = crate::config::Settings::new().unwrap();
+        // Makes both coordinate `SETEX` calls error while the send succeeds.
+        settings.service.video_coordinate_dedup_ttl_secs = 0;
+        let state = test_app_state(
+            settings,
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("stale-token-vid"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        let result = send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        let claim_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::Mention)
+                .unwrap();
+        let record = redis_store::get_cached_string(&pool, &format!("dedup:{claim_key}"))
+            .await
+            .unwrap();
+        let remaining = redis_store::get_tokens_for_pubkey(&pool, &watcher.public_key())
+            .await
+            .unwrap();
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &live_token)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &watcher.public_key(), &stale_token)
+            .await
+            .unwrap();
+
+        assert!(
+            record.is_none(),
+            "the claim write must actually have failed, or this test proves nothing"
+        );
+        assert!(
+            result.is_ok(),
+            "a bookkeeping failure is not a send failure"
+        );
+        assert!(
+            !remaining.contains(&stale_token),
+            "a token FCM reported as unregistered must be removed even when the claim write failed"
+        );
+        assert!(
+            remaining.contains(&live_token),
+            "the token that delivered must survive"
         );
     }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1308,13 +1308,18 @@ async fn send_notification_to_user(
 
     if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
         for satisfied in satisfied_video_claims(notification_type) {
+            // Unreachable today: the pre-send gate above already returned if
+            // the d-tag were missing. `break` rather than `return` regardless —
+            // the d-tag does not depend on `satisfied`, so there is nothing for
+            // a second pass to find, and invalid-token removal below this block
+            // still has to run.
             let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, satisfied) else {
                 warn!(
                     event_id = %event_id,
                     target_pubkey = %target_pubkey,
                     "Successful video notification lacked an addressable d-tag"
                 );
-                return Ok(());
+                break;
             };
             let redis_key = format!("dedup:{claim_key}");
             // Same reasoning as the rate-limit write above, and it matters more

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -54,6 +54,15 @@ pub fn is_notify_list(event: &Event) -> bool {
     event.kind.as_u16() == KIND_NOTIFY_LIST
 }
 
+/// Whether the handler loop should drop this event as beyond the replay horizon.
+///
+/// Extracted from `run()` so the exemption is covered by a test. Getting this
+/// composition wrong is silent: bells set more than `REPLAY_HORIZON_DAYS` ago
+/// simply never rebuild, and nothing logs an error.
+pub fn is_beyond_replay_horizon(event: &Event) -> bool {
+    is_event_too_old(event) && !is_notify_list(event)
+}
+
 /// Check if event is targeted to this service via p tag
 fn is_event_for_service(event: &Event, service_pubkey: &PublicKey) -> bool {
     event
@@ -108,7 +117,7 @@ pub async fn run(
                 // Notify lists are exempt: they are replaceable subscription
                 // state, not a timely trigger, so age says nothing about
                 // whether they are current.
-                if is_event_too_old(&event) && !is_notify_list(&event) {
+                if is_beyond_replay_horizon(&event) {
                     debug!(event_id = %event_id, created_at = %event.created_at, "Ignoring old event beyond replay horizon");
                     continue;
                 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -396,6 +396,46 @@ async fn handle_preferences_update(state: &AppState, event: &Event) -> Result<()
     Ok(())
 }
 
+/// Extract the subscribed creators from a notify list, deduplicated.
+///
+/// Drops self-references (belling yourself is meaningless) and unparseable `p`
+/// tags, preserving the client's tag order otherwise.
+///
+/// Bounded at `max_creators`. `replace_notify_subscriptions` applies the whole
+/// diff in a single Lua script and Redis is single-threaded, so an unbounded
+/// list would let one user with an absurd number of bells stall the instance for
+/// everyone. Truncating rather than rejecting degrades gracefully: the excess
+/// bells simply do not deliver, instead of the user losing all of them. `p` tags
+/// are ordered by the client, so which ones survive is deterministic and under
+/// the client's control.
+fn collect_notify_creators(event: &Event, max_creators: usize) -> Vec<PublicKey> {
+    let mut creators: Vec<PublicKey> = Vec::new();
+
+    for tag in event.tags.iter().filter(|t| t.kind() == TagKind::p()) {
+        let Some(pubkey) = tag.content().and_then(|c| PublicKey::from_str(c).ok()) else {
+            continue;
+        };
+        if pubkey == event.pubkey {
+            continue;
+        }
+        if creators.contains(&pubkey) {
+            continue;
+        }
+        if creators.len() == max_creators {
+            warn!(
+                event_id = %event.id,
+                pubkey = %event.pubkey,
+                max_creators,
+                "Notify list exceeds the creator cap; ignoring the remainder"
+            );
+            break;
+        }
+        creators.push(pubkey);
+    }
+
+    creators
+}
+
 /// Handle a notify-list update (kind 30000, `d=notify`).
 ///
 /// Rebuilds this subscriber's slice of the reverse index from the replacement
@@ -420,20 +460,7 @@ async fn handle_notify_list_update(state: &AppState, event: &Event) -> Result<()
         return Ok(());
     }
 
-    let mut creators: Vec<PublicKey> = Vec::new();
-    for tag in event.tags.iter().filter(|t| t.kind() == TagKind::p()) {
-        let Some(pubkey) = tag.content().and_then(|c| PublicKey::from_str(c).ok()) else {
-            continue;
-        };
-        // Belling yourself is meaningless, and the send loop would drop it
-        // anyway.
-        if pubkey == event.pubkey {
-            continue;
-        }
-        if !creators.contains(&pubkey) {
-            creators.push(pubkey);
-        }
-    }
+    let creators = collect_notify_creators(event, state.settings.service.notify_list_max_creators);
 
     // An empty list is legitimate: the user unbelled everyone. It must clear
     // the index rather than be treated as malformed and skipped.
@@ -1434,6 +1461,90 @@ mod tests {
             .unwrap();
 
         assert!(video_mention_targets(&event).is_empty());
+    }
+
+    /// Build a `d=notify` list event tagging `creators`.
+    fn notify_list_event(author: &Keys, creators: &[PublicKey]) -> Event {
+        let mut builder =
+            EventBuilder::new(Kind::from(30000), "").tag(Tag::identifier(NOTIFY_LIST_D_TAG));
+        for creator in creators {
+            builder = builder.tag(Tag::public_key(*creator));
+        }
+        builder.sign_with_keys(author).unwrap()
+    }
+
+    #[test]
+    fn test_collect_notify_creators_reads_p_tags_in_order() {
+        let author = Keys::generate();
+        let first = Keys::generate().public_key();
+        let second = Keys::generate().public_key();
+
+        let event = notify_list_event(&author, &[first, second]);
+
+        assert_eq!(collect_notify_creators(&event, 1000), vec![first, second]);
+    }
+
+    #[test]
+    fn test_collect_notify_creators_deduplicates() {
+        let author = Keys::generate();
+        let creator = Keys::generate().public_key();
+
+        let event = notify_list_event(&author, &[creator, creator, creator]);
+
+        assert_eq!(collect_notify_creators(&event, 1000), vec![creator]);
+    }
+
+    #[test]
+    fn test_collect_notify_creators_drops_self_reference() {
+        let author = Keys::generate();
+        let other = Keys::generate().public_key();
+
+        let event = notify_list_event(&author, &[author.public_key(), other]);
+
+        assert_eq!(
+            collect_notify_creators(&event, 1000),
+            vec![other],
+            "belling yourself is meaningless"
+        );
+    }
+
+    #[test]
+    fn test_collect_notify_creators_handles_empty_list() {
+        let author = Keys::generate();
+
+        let event = notify_list_event(&author, &[]);
+
+        assert!(
+            collect_notify_creators(&event, 1000).is_empty(),
+            "an empty list is legitimate, not malformed"
+        );
+    }
+
+    #[test]
+    fn test_collect_notify_creators_truncates_at_the_cap() {
+        let author = Keys::generate();
+        let creators: Vec<PublicKey> = (0..5).map(|_| Keys::generate().public_key()).collect();
+
+        let event = notify_list_event(&author, &creators);
+        let collected = collect_notify_creators(&event, 3);
+
+        // Redis is single-threaded and the diff runs in one Lua script, so an
+        // unbounded list would let one user stall the instance.
+        assert_eq!(collected.len(), 3);
+        assert_eq!(collected, creators[..3].to_vec(), "tag order is preserved");
+    }
+
+    #[test]
+    fn test_collect_notify_creators_counts_unique_against_the_cap() {
+        let author = Keys::generate();
+        let a = Keys::generate().public_key();
+        let b = Keys::generate().public_key();
+
+        // Duplicates must not consume cap budget, or a list padded with repeats
+        // would starve the real entries behind it.
+        let event = notify_list_event(&author, &[a, a, a, b]);
+
+        assert_eq!(collect_notify_creators(&event, 2), vec![a, b]);
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -36,8 +36,23 @@ const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
 const KIND_VIDEO: u16 = 34236;
 
+/// NIP-51 people list carrying new-post ("bell") subscriptions.
+const KIND_NOTIFY_LIST: u16 = 30000;
+
+/// Reserved `d` tag identifying a notify list among the user's kind 30000 lists.
+pub const NOTIFY_LIST_D_TAG: &str = "notify";
+
 // Replay horizon: ignore events older than this
 const REPLAY_HORIZON_DAYS: u64 = 7;
+
+/// Whether this event is a notify list, which is exempt from the replay horizon.
+///
+/// Notify lists are replaceable: a list published three months ago and never
+/// touched since is still the user's current subscription set. Aging one out
+/// would silently drop every bell on it until the user happened to republish.
+pub fn is_notify_list(event: &Event) -> bool {
+    event.kind.as_u16() == KIND_NOTIFY_LIST
+}
 
 /// Check if event is targeted to this service via p tag
 fn is_event_for_service(event: &Event, service_pubkey: &PublicKey) -> bool {
@@ -89,8 +104,11 @@ pub async fn run(
 
                 debug!(event_id = %event_id, kind = %event_kind, pubkey = %pubkey, context = ?context, "Event handler received event");
 
-                // Check replay horizon - ignore events that are too old
-                if is_event_too_old(&event) {
+                // Check replay horizon - ignore events that are too old.
+                // Notify lists are exempt: they are replaceable subscription
+                // state, not a timely trigger, so age says nothing about
+                // whether they are current.
+                if is_event_too_old(&event) && !is_notify_list(&event) {
                     debug!(event_id = %event_id, created_at = %event.created_at, "Ignoring old event beyond replay horizon");
                     continue;
                 }
@@ -156,6 +174,15 @@ async fn route_event(
     let event_kind = event.kind;
     let event_id = event.id;
     let kind_num = event_kind.as_u16();
+
+    // Notify lists are addressed to the world, not to this service, so they are
+    // routed before the control-event block and deliberately outside its p-tag
+    // gate. They are also processed in both the historical and live paths: the
+    // reverse index must be rebuilt from history or a restart drops every
+    // subscription until each user happens to republish.
+    if kind_num == KIND_NOTIFY_LIST {
+        return handle_notify_list_update(state, event).await;
+    }
 
     // Check for push notification management events (3079/3080/3083)
     let is_control_event = kind_num == KIND_REGISTRATION
@@ -369,6 +396,74 @@ async fn handle_preferences_update(state: &AppState, event: &Event) -> Result<()
     Ok(())
 }
 
+/// Handle a notify-list update (kind 30000, `d=notify`).
+///
+/// Rebuilds this subscriber's slice of the reverse index from the replacement
+/// list. The list is public and unencrypted by design — the service has to be
+/// able to read it — so there is no decryption step here, unlike the control
+/// events above.
+async fn handle_notify_list_update(state: &AppState, event: &Event) -> Result<()> {
+    assert!(event.kind.as_u16() == KIND_NOTIFY_LIST);
+
+    // Defense in depth. The relay-side `#d` filter should already guarantee
+    // this, but a buggy or hostile relay can send any kind 30000 it likes, and
+    // applying someone's unrelated people list as their bell list would be
+    // both wrong and destructive.
+    let d_tag = event.tags.identifier();
+    if d_tag != Some(NOTIFY_LIST_D_TAG) {
+        debug!(
+            event_id = %event.id,
+            pubkey = %event.pubkey,
+            d_tag = ?d_tag,
+            "Ignoring kind 30000 list without the reserved notify d tag"
+        );
+        return Ok(());
+    }
+
+    let mut creators: Vec<PublicKey> = Vec::new();
+    for tag in event.tags.iter().filter(|t| t.kind() == TagKind::p()) {
+        let Some(pubkey) = tag.content().and_then(|c| PublicKey::from_str(c).ok()) else {
+            continue;
+        };
+        // Belling yourself is meaningless, and the send loop would drop it
+        // anyway.
+        if pubkey == event.pubkey {
+            continue;
+        }
+        if !creators.contains(&pubkey) {
+            creators.push(pubkey);
+        }
+    }
+
+    // An empty list is legitimate: the user unbelled everyone. It must clear
+    // the index rather than be treated as malformed and skipped.
+    let applied = redis_store::replace_notify_subscriptions(
+        &state.redis_pool,
+        &event.pubkey,
+        &creators,
+        event.created_at.as_secs(),
+    )
+    .await?;
+
+    if applied {
+        info!(
+            event_id = %event.id,
+            pubkey = %event.pubkey,
+            creator_count = creators.len(),
+            "Applied notify list update"
+        );
+    } else {
+        debug!(
+            event_id = %event.id,
+            pubkey = %event.pubkey,
+            created_at = %event.created_at,
+            "Ignoring notify list update older than the applied one"
+        );
+    }
+
+    Ok(())
+}
+
 /// Handle content events that may trigger notifications
 async fn handle_content_event(
     state: &AppState,
@@ -381,10 +476,9 @@ async fn handle_content_event(
     // Determine notification type and find recipients based on event kind
     let kind_num = event_kind.as_u16();
 
-    let (notification_type, recipients) = if kind_num == 7 {
+    let targets = if kind_num == 7 {
         // Kind 7: Reaction/Like - notify the author of the liked event
-        let recipients = find_reaction_recipients(event);
-        (NotificationType::Like, recipients)
+        targets_of(NotificationType::Like, find_reaction_recipients(event))
     } else if kind_num == 1 {
         // Kind 1: Text note - could be a comment or mention
         let recipients = find_text_note_recipients(event);
@@ -395,14 +489,13 @@ async fn handle_content_event(
         } else {
             NotificationType::Mention
         };
-        (notification_type, recipients)
+        targets_of(notification_type, recipients)
     } else if kind_num == 1111 {
         // Kind 1111: NIP-22 comment (diVine publishes video comments here, not
         // as kind 1). Notify the root author (uppercase `P`, the video owner)
         // and the direct parent author (lowercase `p`). create_fcm_payload
         // attaches the authoritative root-video target from the uppercase `A`.
-        let recipients = find_comment_recipients(event);
-        (NotificationType::Comment, recipients)
+        targets_of(NotificationType::Comment, find_comment_recipients(event))
     } else if kind_num == 3 {
         // Kind 3: Contact list - notify newly followed users
         // Note: This would require tracking previous contact list state
@@ -411,20 +504,18 @@ async fn handle_content_event(
         return Ok(());
     } else if kind_num == 16 {
         // Kind 16: Repost - notify the author of the reposted event
-        let recipients = find_repost_recipients(event);
-        (NotificationType::Repost, recipients)
+        targets_of(NotificationType::Repost, find_repost_recipients(event))
     } else if kind_num == 30023 {
         // Kind 30023: Long-form content - check for mentions
-        let recipients = find_mentioned_pubkeys(event);
-        (NotificationType::Mention, recipients)
+        targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
     } else if kind_num == KIND_VIDEO {
-        video_notification(event)
+        video_notification_targets(state, event).await?
     } else {
         trace!(event_id = %event_id, kind = %event_kind, "Ignoring event kind - no notification handler");
         return Ok(());
     };
 
-    if recipients.is_empty() {
+    if targets.is_empty() {
         debug!(event_id = %event_id, kind = %event_kind, "No recipients found for event");
         return Ok(());
     }
@@ -432,17 +523,18 @@ async fn handle_content_event(
     info!(
         event_id = %event_id,
         kind = %event_kind,
-        notification_type = ?notification_type,
-        recipient_count = recipients.len(),
+        recipient_count = targets.len(),
         "Processing notification event"
     );
 
-    // Send notifications to each recipient
-    for recipient_pubkey in recipients {
+    // Send notifications to each target
+    for target in targets {
         if token.is_cancelled() {
             info!(event_id = %event_id, "Notification sending cancelled");
             return Err(crate::error::ServiceError::Cancelled);
         }
+
+        let recipient_pubkey = target.recipient;
 
         // Skip if recipient is the sender
         if recipient_pubkey == event.pubkey {
@@ -454,7 +546,7 @@ async fn handle_content_event(
             state,
             event,
             &recipient_pubkey,
-            notification_type,
+            target.notification_type,
             token.clone(),
         )
         .await
@@ -519,14 +611,84 @@ fn find_mentioned_pubkeys(event: &Event) -> Vec<PublicKey> {
         .collect()
 }
 
-/// Build a mention notification for a video event.
-fn video_notification(event: &Event) -> (NotificationType, Vec<PublicKey>) {
-    let recipients = find_mentioned_pubkeys(event)
+/// One notification to deliver: who gets it, and what kind it is.
+///
+/// A single event can now yield more than one notification *type* — a video both
+/// mentions someone and reaches the author's bell subscribers — so recipients
+/// carry their own type rather than sharing one for the whole event.
+#[derive(Debug, Clone, Copy)]
+struct NotificationTarget {
+    recipient: PublicKey,
+    notification_type: NotificationType,
+}
+
+/// Give every recipient the same notification type.
+fn targets_of(
+    notification_type: NotificationType,
+    recipients: Vec<PublicKey>,
+) -> Vec<NotificationTarget> {
+    recipients
+        .into_iter()
+        .map(|recipient| NotificationTarget {
+            recipient,
+            notification_type,
+        })
+        .collect()
+}
+
+/// Mention targets for a video event: p-tagged users other than the author.
+fn video_mention_targets(event: &Event) -> Vec<NotificationTarget> {
+    find_mentioned_pubkeys(event)
         .into_iter()
         .filter(|recipient| *recipient != event.pubkey)
-        .collect();
+        .map(|recipient| NotificationTarget {
+            recipient,
+            notification_type: NotificationType::Mention,
+        })
+        .collect()
+}
 
-    (NotificationType::Mention, recipients)
+/// Merge bell watchers into a video's mention targets.
+///
+/// Mention wins on overlap: someone who both watches `author` and is mentioned
+/// in the video gets exactly one push, typed `Mention`, because that is the more
+/// specific signal. Watchers already present as mention targets are therefore
+/// skipped rather than added.
+///
+/// Kept separate from the Redis read so the dedup rule is testable on its own.
+fn merge_watcher_targets(
+    mut targets: Vec<NotificationTarget>,
+    author: &PublicKey,
+    watchers: Vec<PublicKey>,
+) -> Vec<NotificationTarget> {
+    for watcher in watchers {
+        // The send loop skips self-notifications too, but filtering here avoids
+        // a pointless token lookup and preferences read per video.
+        if watcher == *author {
+            continue;
+        }
+        if targets.iter().any(|t| t.recipient == watcher) {
+            continue;
+        }
+        targets.push(NotificationTarget {
+            recipient: watcher,
+            notification_type: NotificationType::NewPost,
+        });
+    }
+    targets
+}
+
+/// Build the notification targets for a video event: mentions plus bells.
+async fn video_notification_targets(
+    state: &AppState,
+    event: &Event,
+) -> Result<Vec<NotificationTarget>> {
+    let watchers = redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await?;
+    Ok(merge_watcher_targets(
+        video_mention_targets(event),
+        &event.pubkey,
+        watchers,
+    ))
 }
 
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
@@ -662,6 +824,30 @@ async fn send_notification_to_user(
         }
     }
 
+    if notification_type == NotificationType::NewPost {
+        let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
+        let within_window = tokio::select! {
+            biased;
+            _ = token.cancelled() => {
+                info!(event_id = %event_id, target_pubkey = %target_pubkey, "Cancelled while checking the new-post rate limit.");
+                return Err(crate::error::ServiceError::Cancelled);
+            }
+            lookup_result = redis_store::get_cached_string(&state.redis_pool, &rate_key) => {
+                lookup_result?.is_some()
+            }
+        };
+
+        if within_window {
+            info!(
+                event_id = %event_id,
+                target_pubkey = %target_pubkey,
+                creator = %event.pubkey,
+                "Skipping new-post notification inside the per-creator rate-limit window"
+            );
+            return Ok(());
+        }
+    }
+
     info!(
         event_id = %event_id,
         target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
@@ -728,6 +914,26 @@ async fn send_notification_to_user(
         failed_count = tokens_to_remove.len(),
         "FCM notification send summary"
     );
+
+    // Open the rate-limit window only on a delivered push.
+    //
+    // This is check-then-set-on-success rather than an atomic `SET NX EX`, both
+    // to mirror the video-coordinate dedup above and — more importantly — so a
+    // failed FCM send does not burn the user's hour-long window. The tradeoff is
+    // that two replicas handling different videos from the same creator in the
+    // same instant can both pass the check and double-send. That race is rare,
+    // bounded, and low-harm; silently eating an hour of notifications on an FCM
+    // blip is worse. Do not "fix" this into `SET NX EX`.
+    if notification_type == NotificationType::NewPost && success_count > 0 {
+        let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
+        redis_store::set_cached_string(
+            &state.redis_pool,
+            &rate_key,
+            "1",
+            state.settings.service.new_post_rate_limit_secs,
+        )
+        .await?;
+    }
 
     if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
         let Some(claim_key) = video_recipient_claim_key(event, target_pubkey) else {
@@ -851,6 +1057,13 @@ async fn create_fcm_payload(
         NotificationType::Repost => {
             let title = "New repost".to_string();
             let body = format!("{} reposted your post", sender_name);
+            (title, body)
+        }
+        NotificationType::NewPost => {
+            // Provisional copy. divine-mobile/brand-guidelines/TONE_OF_VOICE.md
+            // governs user-facing strings; confirm before release.
+            let title = "New vine".to_string();
+            let body = format!("{} posted a new vine", sender_name);
             (title, body)
         }
     };
@@ -1199,11 +1412,14 @@ mod tests {
             .sign_with_keys(&sender)
             .unwrap();
 
-        let (notification_type, recipients) = video_notification(&event);
+        let targets = video_mention_targets(&event);
 
-        assert_eq!(notification_type, NotificationType::Mention);
-        assert_eq!(notification_type.display_name(), "mention");
-        assert_eq!(recipients.len(), 2);
+        assert_eq!(targets.len(), 2);
+        assert!(targets
+            .iter()
+            .all(|t| t.notification_type == NotificationType::Mention));
+        assert_eq!(NotificationType::Mention.display_name(), "mention");
+        let recipients: Vec<PublicKey> = targets.iter().map(|t| t.recipient).collect();
         assert!(recipients.contains(&mentioned1.public_key()));
         assert!(recipients.contains(&mentioned2.public_key()));
     }
@@ -1217,9 +1433,78 @@ mod tests {
             .sign_with_keys(&sender)
             .unwrap();
 
-        let (_, recipients) = video_notification(&event);
+        assert!(video_mention_targets(&event).is_empty());
+    }
 
-        assert!(recipients.is_empty());
+    #[test]
+    fn test_watcher_yields_a_new_post_target() {
+        let author = Keys::generate().public_key();
+        let watcher = Keys::generate().public_key();
+
+        let targets = merge_watcher_targets(Vec::new(), &author, vec![watcher]);
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, watcher);
+        assert_eq!(targets[0].notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn test_mentioned_watcher_yields_exactly_one_mention_target() {
+        let author = Keys::generate().public_key();
+        let both = Keys::generate().public_key();
+
+        let mentions = vec![NotificationTarget {
+            recipient: both,
+            notification_type: NotificationType::Mention,
+        }];
+        let targets = merge_watcher_targets(mentions, &author, vec![both]);
+
+        assert_eq!(targets.len(), 1, "mention wins, so no second push");
+        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+    }
+
+    #[test]
+    fn test_author_watching_themselves_yields_nothing() {
+        let author = Keys::generate().public_key();
+
+        let targets = merge_watcher_targets(Vec::new(), &author, vec![author]);
+
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn test_no_watchers_leaves_mention_targets_unchanged() {
+        let author = Keys::generate().public_key();
+        let mentioned = Keys::generate().public_key();
+
+        let mentions = vec![NotificationTarget {
+            recipient: mentioned,
+            notification_type: NotificationType::Mention,
+        }];
+        let targets = merge_watcher_targets(mentions, &author, Vec::new());
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, mentioned);
+        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+    }
+
+    #[test]
+    fn test_watcher_and_separate_mention_both_get_their_own_type() {
+        let author = Keys::generate().public_key();
+        let mentioned = Keys::generate().public_key();
+        let watcher = Keys::generate().public_key();
+
+        let mentions = vec![NotificationTarget {
+            recipient: mentioned,
+            notification_type: NotificationType::Mention,
+        }];
+        let targets = merge_watcher_targets(mentions, &author, vec![watcher]);
+
+        assert_eq!(targets.len(), 2);
+        let mention = targets.iter().find(|t| t.recipient == mentioned).unwrap();
+        let bell = targets.iter().find(|t| t.recipient == watcher).unwrap();
+        assert_eq!(mention.notification_type, NotificationType::Mention);
+        assert_eq!(bell.notification_type, NotificationType::NewPost);
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -536,7 +536,7 @@ async fn handle_content_event(
         // Kind 30023: Long-form content - check for mentions
         targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
     } else if kind_num == KIND_VIDEO {
-        video_notification_targets(state, event).await?
+        video_notification_targets(state, event).await
     } else {
         trace!(event_id = %event_id, kind = %event_kind, "Ignoring event kind - no notification handler");
         return Ok(());
@@ -716,17 +716,39 @@ fn merge_watcher_targets(
     targets
 }
 
+/// Resolve a watcher lookup into the watchers to notify, degrading to none.
+///
+/// Bells are enrichment layered on top of mentions, and they are the only part
+/// of a video's targets that needs Redis. A failed lookup must therefore cost
+/// the bells and nothing else. Propagating it would discard the mention
+/// notifications the same event produced before this feature existed, from
+/// tags that were already in hand.
+///
+/// Kept separate from the read so the degradation is testable without an
+/// `AppState`.
+fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<PublicKey> {
+    match lookup {
+        Ok(watchers) => watchers,
+        Err(e) => {
+            error!(
+                event_id = %event.id,
+                creator = %event.pubkey,
+                error = %e,
+                "Failed to read notify watchers - delivering mentions without bells"
+            );
+            Vec::new()
+        }
+    }
+}
+
 /// Build the notification targets for a video event: mentions plus bells.
-async fn video_notification_targets(
-    state: &AppState,
-    event: &Event,
-) -> Result<Vec<NotificationTarget>> {
-    let watchers = redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await?;
-    Ok(merge_watcher_targets(
+async fn video_notification_targets(state: &AppState, event: &Event) -> Vec<NotificationTarget> {
+    let lookup = redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await;
+    merge_watcher_targets(
         video_mention_targets(event),
         &event.pubkey,
-        watchers,
-    ))
+        watchers_or_degrade(event, lookup),
+    )
 }
 
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
@@ -1614,6 +1636,35 @@ mod tests {
             notification_type: NotificationType::Mention,
         }];
         let targets = merge_watcher_targets(mentions, &author, Vec::new());
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, mentioned);
+        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+    }
+
+    #[test]
+    fn test_failed_watcher_lookup_still_delivers_mentions() {
+        let author = Keys::generate();
+        let mentioned = Keys::generate().public_key();
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
+            .tag(Tag::identifier("vid-1"))
+            .tag(Tag::public_key(mentioned))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        // Redis is down. The bells are lost; the mentions must not be, because
+        // they came from the event's own tags and needed no lookup at all.
+        let lookup = Err(crate::error::ServiceError::Internal(
+            "redis down".to_string(),
+        ));
+        let watchers = watchers_or_degrade(&event, lookup);
+        assert!(watchers.is_empty());
+
+        let targets = merge_watcher_targets(
+            video_mention_targets(&event),
+            &author.public_key(),
+            watchers,
+        );
 
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].recipient, mentioned);

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -561,10 +561,24 @@ async fn handle_content_event(
         return Ok(());
     }
 
+    // A single event can now yield more than one notification type, so the log
+    // carries the per-type breakdown rather than one type for the whole event.
+    // A bare count would leave the type most likely to need operational
+    // attention -- NewPost, with its fan-out and rate limiting -- invisible.
+    let mut type_counts: Vec<(&str, usize)> = Vec::new();
+    for target in &targets {
+        let name = target.notification_type.display_name();
+        match type_counts.iter_mut().find(|(n, _)| *n == name) {
+            Some((_, count)) => *count += 1,
+            None => type_counts.push((name, 1)),
+        }
+    }
+
     info!(
         event_id = %event_id,
         kind = %event_kind,
         recipient_count = targets.len(),
+        notification_types = ?type_counts,
         "Processing notification event"
     );
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -556,6 +556,15 @@ async fn handle_content_event(
         return Ok(());
     };
 
+    // Drop self-targets before anything downstream reads the list. Several of
+    // the `find_*` helpers return the author when an event `p`-tags its own
+    // sender, and the send loop used to skip those one at a time — which was
+    // free while the payload was built per recipient, but now sits after the
+    // event-scoped copy has been resolved. Filtering here keeps a self-only
+    // event from paying for a profile lookup it can never use, and makes the
+    // count and per-type breakdown logged below describe real deliveries.
+    let targets = deliverable_targets(targets, &event.pubkey);
+
     if targets.is_empty() {
         debug!(event_id = %event_id, kind = %event_kind, "No recipients found for event");
         return Ok(());
@@ -593,12 +602,6 @@ async fn handle_content_event(
         }
 
         let recipient_pubkey = target.recipient;
-
-        // Skip if recipient is the sender
-        if recipient_pubkey == event.pubkey {
-            trace!(event_id = %event_id, "Skipping notification to sender");
-            continue;
-        }
 
         if let Err(e) = send_notification_to_user(
             state,
@@ -679,6 +682,22 @@ fn find_mentioned_pubkeys(event: &Event) -> Vec<PublicKey> {
 struct NotificationTarget {
     recipient: PublicKey,
     notification_type: NotificationType,
+}
+
+/// Drop targets that are the event's own author.
+///
+/// An event that `p`-tags its own sender — a self-reaction, a self-repost —
+/// resolves to the author as a recipient, and nobody should be notified about
+/// their own activity. Kept as a pure function, like `merge_watcher_targets`,
+/// so the rule is testable without an `AppState`.
+fn deliverable_targets(
+    targets: Vec<NotificationTarget>,
+    author: &PublicKey,
+) -> Vec<NotificationTarget> {
+    targets
+        .into_iter()
+        .filter(|target| target.recipient != *author)
+        .collect()
 }
 
 /// Give every recipient the same notification type.
@@ -820,8 +839,8 @@ fn merge_watcher_targets(
     watchers: Vec<PublicKey>,
 ) -> Vec<NotificationTarget> {
     for watcher in watchers {
-        // The send loop skips self-notifications too, but filtering here avoids
-        // a pointless token lookup and preferences read per video.
+        // `deliverable_targets` drops self-targets for every event kind, but
+        // filtering here keeps the merge rule complete on its own terms.
         if watcher == *author {
             continue;
         }
@@ -1728,6 +1747,50 @@ mod tests {
         assert!(
             !body.trim().is_empty(),
             "mobile silently drops foreground pushes without a body"
+        );
+    }
+
+    #[test]
+    fn test_deliverable_targets_drops_the_author() {
+        let author = Keys::generate().public_key();
+        let other = Keys::generate().public_key();
+
+        // A self-reaction p-tags its own sender, so the author arrives as a
+        // recipient. Dropping them here rather than mid-loop keeps a self-only
+        // event from resolving an event-scoped copy it cannot use.
+        let targets = deliverable_targets(
+            vec![
+                NotificationTarget {
+                    recipient: author,
+                    notification_type: NotificationType::Like,
+                },
+                NotificationTarget {
+                    recipient: other,
+                    notification_type: NotificationType::Like,
+                },
+            ],
+            &author,
+        );
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, other);
+    }
+
+    #[test]
+    fn test_deliverable_targets_empties_a_self_only_event() {
+        let author = Keys::generate().public_key();
+
+        let targets = deliverable_targets(
+            vec![NotificationTarget {
+                recipient: author,
+                notification_type: NotificationType::Repost,
+            }],
+            &author,
+        );
+
+        assert!(
+            targets.is_empty(),
+            "a self-only event must resolve to nothing deliverable"
         );
     }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -872,11 +872,29 @@ async fn video_notification_targets(state: &AppState, event: &Event) -> Vec<Noti
 }
 
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
-fn video_recipient_claim_key(event: &Event, recipient: &PublicKey) -> Option<String> {
+///
+/// Scoped by notification type as well as coordinate, because the two are
+/// orthogonal: an edit does not change which *kind* of notification a recipient
+/// is owed, so keying on type keeps the stable-across-edits property while
+/// stopping one type from consuming another's record.
+///
+/// Without the type, a watcher who got a NewPost push for a video and was then
+/// `p`-tagged in an edit of that same video had the mention suppressed for
+/// `video_coordinate_dedup_ttl_secs` — a year by default. Belling a creator
+/// quietly cost you mention notifications from them. `merge_watcher_targets`
+/// already makes mention win over bell within a single event; this extends the
+/// same rule across edits, where the two pushes carry genuinely different
+/// information ("X posted a vine" versus "X mentioned you").
+fn video_recipient_claim_key(
+    event: &Event,
+    recipient: &PublicKey,
+    notification_type: NotificationType,
+) -> Option<String> {
     let d_tag = event.tags.identifier()?;
     Some(format!(
-        "{}:{}:{d_tag}:{}",
+        "{}:{}:{}:{d_tag}:{}",
         event.kind.as_u16(),
+        notification_type.display_name(),
         event.pubkey.to_hex(),
         recipient.to_hex()
     ))
@@ -975,7 +993,8 @@ async fn send_notification_to_user(
     }
 
     if event.kind.as_u16() == KIND_VIDEO {
-        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey) else {
+        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, notification_type)
+        else {
             warn!(
                 event_id = %event_id,
                 target_pubkey = %target_pubkey,
@@ -1117,7 +1136,8 @@ async fn send_notification_to_user(
     }
 
     if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
-        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey) else {
+        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, notification_type)
+        else {
             warn!(
                 event_id = %event_id,
                 target_pubkey = %target_pubkey,
@@ -1899,21 +1919,61 @@ mod tests {
 
         assert_ne!(first_event.id, edited_event.id);
         assert_eq!(
-            video_recipient_claim_key(&first_event, &recipient.public_key()),
-            video_recipient_claim_key(&edited_event, &recipient.public_key())
+            video_recipient_claim_key(
+                &first_event,
+                &recipient.public_key(),
+                NotificationType::Mention
+            ),
+            video_recipient_claim_key(
+                &edited_event,
+                &recipient.public_key(),
+                NotificationType::Mention
+            )
         );
         assert_eq!(
-            video_recipient_claim_key(&first_event, &recipient.public_key()),
+            video_recipient_claim_key(
+                &first_event,
+                &recipient.public_key(),
+                NotificationType::Mention
+            ),
             Some(format!(
-                "34236:{}:video:d-tag:{}",
+                "34236:mention:{}:video:d-tag:{}",
                 owner.public_key().to_hex(),
                 recipient.public_key().to_hex()
             ))
         );
         assert_ne!(
-            video_recipient_claim_key(&edited_event, &recipient.public_key()),
-            video_recipient_claim_key(&edited_event, &added_recipient.public_key()),
+            video_recipient_claim_key(
+                &edited_event,
+                &recipient.public_key(),
+                NotificationType::Mention
+            ),
+            video_recipient_claim_key(
+                &edited_event,
+                &added_recipient.public_key(),
+                NotificationType::Mention
+            ),
             "a newly added recipient must have an independent delivery record"
+        );
+    }
+
+    #[test]
+    fn test_video_recipient_claim_key_separates_notification_types() {
+        let owner = Keys::generate();
+        let recipient = Keys::generate();
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("video:d-tag"))
+            .tag(Tag::public_key(recipient.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+
+        // A bell and a mention for the same coordinate are different pushes
+        // carrying different information, so one must not consume the other's
+        // record for the coordinate TTL — a year by default.
+        assert_ne!(
+            video_recipient_claim_key(&event, &recipient.public_key(), NotificationType::NewPost),
+            video_recipient_claim_key(&event, &recipient.public_key(), NotificationType::Mention),
+            "a bell must not suppress a later mention on the same video"
         );
     }
 
@@ -1941,7 +2001,12 @@ mod tests {
             .tag(Tag::public_key(recipient.public_key()))
             .sign_with_keys(&owner)
             .unwrap();
-        let claim_key = video_recipient_claim_key(&first_event, &recipient.public_key()).unwrap();
+        let claim_key = video_recipient_claim_key(
+            &first_event,
+            &recipient.public_key(),
+            NotificationType::Mention,
+        )
+        .unwrap();
         let redis_key = format!("dedup:{claim_key}");
 
         send_notification_to_user(
@@ -2017,6 +2082,115 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         redis::cmd("DEL")
             .arg(redis_key)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_bell_does_not_suppress_a_later_mention_on_the_same_video() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("bell-then-mention-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        // The bell fires first: the watcher is not `p`-tagged on the original.
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "first version")
+            .tag(Tag::identifier("bell-then-mention"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the bell delivers"
+        );
+
+        // The creator then edits the video and `p`-tags the watcher. That is a
+        // different notification carrying different information, so it must not
+        // be eaten by the bell's record for the same coordinate.
+        let edit_adding_mention = EventBuilder::new(Kind::from(KIND_VIDEO), "edited version")
+            .tag(Tag::identifier("bell-then-mention"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &edit_adding_mention,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            2,
+            "a delivered bell must not suppress a later mention on the same video"
+        );
+
+        // The per-type record still works within its own type: a second edit
+        // does not re-notify the mention.
+        let further_edit = EventBuilder::new(Kind::from(KIND_VIDEO), "second edit")
+            .tag(Tag::identifier("bell-then-mention"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &further_edit,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            2,
+            "the mention's own record still suppresses a repeat edit"
+        );
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        let bell_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::NewPost)
+                .unwrap();
+        let mention_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::Mention)
+                .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{bell_key}"))
+            .arg(format!("dedup:{mention_key}"))
+            .arg(redis_store::build_notify_rate_key(
+                &watcher.public_key(),
+                &owner.public_key(),
+            ))
             .query_async::<()>(&mut *conn)
             .await
             .unwrap();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1240,8 +1240,10 @@ async fn send_notification_to_user(
             && delivery_type == NotificationType::Mention
             && NotificationType::NewPost.is_enabled(&prefs)
         {
-            match redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await {
-                Ok(watchers) => watchers.contains(target_pubkey),
+            match redis_store::is_notify_watcher(&state.redis_pool, &event.pubkey, target_pubkey)
+                .await
+            {
+                Ok(is_watcher) => is_watcher,
                 Err(e) => {
                     error!(
                         event_id = %event_id,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -2178,6 +2178,60 @@ mod tests {
         assert_eq!(targets[0].notification_type, NotificationType::Mention);
     }
 
+    #[tokio::test]
+    async fn test_a_real_watcher_lookup_failure_still_delivers_mentions() {
+        // The test above proves `watchers_or_degrade` degrades. It does not
+        // prove anything calls it: it never reaches `video_notification_targets`,
+        // where the degradation is actually wired in, so replacing that call
+        // with `lookup.expect(...)` leaves the whole suite green. This drives a
+        // genuine `get_notify_watchers` failure through the real function, by
+        // leaving a string where the watcher set belongs so `SMEMBERS` fails
+        // with WRONGTYPE.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let mentioned = Keys::generate().public_key();
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
+            .tag(Tag::identifier("wrongtype-vid"))
+            .tag(Tag::public_key(mentioned))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        let watchers_key = format!("notify_watchers:{}", author.public_key().to_hex());
+        let mut conn = pool.get().await.unwrap();
+        let _: () = redis::cmd("SET")
+            .arg(&watchers_key)
+            .arg("not-a-set")
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+
+        // Without this the test could pass vacuously, by the lookup succeeding
+        // and simply finding no watchers.
+        let lookup_failed = redis_store::get_notify_watchers(&pool, &author.public_key())
+            .await
+            .is_err();
+
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(MockFcmSender::new())),
+        );
+        let targets = video_notification_targets(&state, &event).await;
+
+        let _: () = redis::cmd("DEL")
+            .arg(&watchers_key)
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+
+        assert!(lookup_failed, "the seeded key must make the lookup fail");
+        assert_eq!(targets.len(), 1, "the mention survives the failed lookup");
+        assert_eq!(targets[0].recipient, mentioned);
+        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+    }
+
     #[test]
     fn test_watcher_and_separate_mention_both_get_their_own_type() {
         let author = Keys::generate().public_key();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -691,10 +691,30 @@ async fn send_notifications_bounded(
         })
         .buffer_unordered(concurrency);
 
+    // Drain on cancellation rather than returning at the first `Cancelled`.
+    //
+    // Returning early drops the `buffer_unordered` stream, and with it every
+    // still-running delivery, at whatever await point it had reached. Up to
+    // `concurrency - 1` of them can be sitting between the FCM send and the
+    // bookkeeping that follows it: the rate-limit window, the coordinate claim,
+    // invalid-token removal. Those pushes have already shipped, so dropping
+    // them there double-pushes on restart and leaves tokens FCM has already
+    // rejected registered — the same failure the post-send writes were made
+    // log-and-continue to avoid, arriving through the other door. Sequential
+    // delivery could strand one recipient this way; bounded delivery strands a
+    // page's worth, and silently, because a dropped future logs nothing.
+    //
+    // Draining costs little on shutdown: every in-flight delivery holds the
+    // same token and bails at its own next checkpoint, so the ones that have
+    // not sent yet return immediately. It does not close the window inside
+    // `send_notification_to_user`, which still returns `Cancelled` between the
+    // FCM send and the writes below it; that one predates this branch.
+    let mut cancelled = None;
     while let Some((recipient, result)) = deliveries.next().await {
         if let Err(e) = result {
             if matches!(e, crate::error::ServiceError::Cancelled) {
-                return Err(e);
+                cancelled.get_or_insert(e);
+                continue;
             }
             error!(
                 event_id = %event.id,
@@ -705,7 +725,10 @@ async fn send_notifications_bounded(
         }
     }
 
-    Ok(())
+    match cancelled {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 async fn deliver_notification_target(
@@ -791,7 +814,8 @@ async fn handle_video_content_event(
                     creator = %event.pubkey,
                     cursor,
                     error = %e,
-                    "Failed to read notify watcher page - delivering mentions without remaining bells"
+                    delivered_so_far = target_count,
+                    "Failed to read notify watcher page - abandoning the rest of the bell fan-out for this video"
                 );
                 break;
             }
@@ -2465,6 +2489,56 @@ mod tests {
             mock_sender.get_sent_messages().len(),
             1,
             "the mention survives the failed watcher page lookup"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_cancelled_bell_page_reports_cancellation() {
+        // Deleting the `Cancelled` arm from `send_notifications_bounded` left
+        // the suite green, so shutdown on the bell path was propagating by
+        // nobody's assertion. The page must report cancellation upward rather
+        // than returning Ok and letting the walk advance to the next cursor.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
+            .tag(Tag::identifier("cancelled-page-vid"))
+            .sign_with_keys(&author)
+            .unwrap();
+        let targets: Vec<NotificationTarget> = (0..3)
+            .map(|_| NotificationTarget {
+                recipient: Keys::generate().public_key(),
+                notification_type: NotificationType::NewPost,
+            })
+            .collect();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = send_notifications_bounded(
+            &state,
+            &event,
+            targets,
+            &LazyEventCopy::for_targets(&[]),
+            token,
+            4,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(crate::error::ServiceError::Cancelled)),
+            "a cancelled page must not report success"
+        );
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "nothing ships after cancellation"
         );
     }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -835,15 +835,6 @@ async fn handle_video_content_event(
     Ok(())
 }
 
-#[cfg(test)]
-fn split_delivery_targets(
-    targets: Vec<NotificationTarget>,
-) -> (Vec<NotificationTarget>, Vec<NotificationTarget>) {
-    targets
-        .into_iter()
-        .partition(|target| target.notification_type != NotificationType::NewPost)
-}
-
 /// Find recipients for a reaction event (kind 7)
 /// Returns the author of the event being reacted to
 fn find_reaction_recipients(event: &Event) -> Vec<PublicKey> {
@@ -904,7 +895,7 @@ struct NotificationTarget {
 ///
 /// An event that `p`-tags its own sender — a self-reaction, a self-repost —
 /// resolves to the author as a recipient, and nobody should be notified about
-/// their own activity. Kept as a pure function, like `merge_watcher_targets`,
+/// their own activity. Kept as a pure function, like `watcher_page_targets`,
 /// so the rule is testable without an `AppState`.
 fn deliverable_targets(
     targets: Vec<NotificationTarget>,
@@ -1106,37 +1097,14 @@ fn video_mention_targets(event: &Event) -> Vec<NotificationTarget> {
         .collect()
 }
 
-/// Merge bell watchers into a video's mention targets.
+/// Turn one page of bell watchers into new-post targets.
 ///
 /// Mention wins on overlap: someone who both watches `author` and is mentioned
 /// in the video gets exactly one push, typed `Mention`, because that is the more
-/// specific signal. Watchers already present as mention targets are therefore
-/// skipped rather than added.
+/// specific signal. The mention pass runs first and hands its recipients here as
+/// `mentioned`, so watchers it already covered are dropped rather than belled.
 ///
-/// Kept separate from the Redis read so the dedup rule is testable on its own.
-#[cfg(test)]
-fn merge_watcher_targets(
-    mut targets: Vec<NotificationTarget>,
-    author: &PublicKey,
-    watchers: Vec<PublicKey>,
-) -> Vec<NotificationTarget> {
-    for watcher in watchers {
-        // `deliverable_targets` drops self-targets for every event kind, but
-        // filtering here keeps the merge rule complete on its own terms.
-        if watcher == *author {
-            continue;
-        }
-        if targets.iter().any(|t| t.recipient == watcher) {
-            continue;
-        }
-        targets.push(NotificationTarget {
-            recipient: watcher,
-            notification_type: NotificationType::NewPost,
-        });
-    }
-    targets
-}
-
+/// Kept separate from the Redis read so the rule is testable on its own.
 fn watcher_page_targets(
     watchers: Vec<PublicKey>,
     author: &PublicKey,
@@ -1153,32 +1121,6 @@ fn watcher_page_targets(
         .collect()
 }
 
-/// Resolve a watcher lookup into the watchers to notify, degrading to none.
-///
-/// Bells are enrichment layered on top of mentions, and they are the only part
-/// of a video's targets that needs Redis. A failed lookup must therefore cost
-/// the bells and nothing else. Propagating it would discard the mention
-/// notifications the same event produced before this feature existed, from
-/// tags that were already in hand.
-///
-/// Kept separate from the read so the degradation is testable without an
-/// `AppState`.
-#[cfg(test)]
-fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<PublicKey> {
-    match lookup {
-        Ok(watchers) => watchers,
-        Err(e) => {
-            error!(
-                event_id = %event.id,
-                creator = %event.pubkey,
-                error = %e,
-                "Failed to read notify watchers - delivering mentions without bells"
-            );
-            Vec::new()
-        }
-    }
-}
-
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
 ///
 /// Scoped by notification type as well as coordinate, because the two are
@@ -1189,7 +1131,7 @@ fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<Pub
 /// Without the type, a watcher who got a NewPost push for a video and was then
 /// `p`-tagged in an edit of that same video had the mention suppressed for
 /// `video_coordinate_dedup_ttl_secs` — a year by default. Belling a creator
-/// quietly cost you mention notifications from them. `merge_watcher_targets`
+/// quietly cost you mention notifications from them. `watcher_page_targets`
 /// already makes mention win over bell within a single event; this extends the
 /// same rule across edits, where the two pushes carry genuinely different
 /// information ("X posted a vine" versus "X mentioned you").
@@ -1233,7 +1175,7 @@ fn legacy_video_recipient_claim_key(event: &Event, recipient: &PublicKey) -> Opt
 /// "X posted a vine" says nothing about being mentioned, and that asymmetry is
 /// why the key carries the type at all.
 ///
-/// This is `merge_watcher_targets`'s "mention wins on overlap" rule extended
+/// This is `watcher_page_targets`'s "mention wins on overlap" rule extended
 /// across edits. Without it, a watcher who was `p`-tagged in the original and
 /// dropped from an edit resolves to a bare `NewPost` target on the edit and is
 /// told "posted a new vine" about a video they were already pushed about.
@@ -2205,18 +2147,6 @@ mod tests {
     }
 
     #[test]
-    fn test_watcher_yields_a_new_post_target() {
-        let author = Keys::generate().public_key();
-        let watcher = Keys::generate().public_key();
-
-        let targets = merge_watcher_targets(Vec::new(), &author, vec![watcher]);
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].recipient, watcher);
-        assert_eq!(targets[0].notification_type, NotificationType::NewPost);
-    }
-
-    #[test]
     fn test_new_post_copy_has_required_non_empty_body() {
         let (title, body) = new_post_copy("Alice");
 
@@ -2474,75 +2404,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_mentioned_watcher_yields_exactly_one_mention_target() {
-        let author = Keys::generate().public_key();
-        let both = Keys::generate().public_key();
-
-        let mentions = vec![NotificationTarget {
-            recipient: both,
-            notification_type: NotificationType::Mention,
-        }];
-        let targets = merge_watcher_targets(mentions, &author, vec![both]);
-
-        assert_eq!(targets.len(), 1, "mention wins, so no second push");
-        assert_eq!(targets[0].notification_type, NotificationType::Mention);
-    }
-
-    #[test]
-    fn test_author_watching_themselves_yields_nothing() {
-        let author = Keys::generate().public_key();
-
-        let targets = merge_watcher_targets(Vec::new(), &author, vec![author]);
-
-        assert!(targets.is_empty());
-    }
-
-    #[test]
-    fn test_no_watchers_leaves_mention_targets_unchanged() {
-        let author = Keys::generate().public_key();
-        let mentioned = Keys::generate().public_key();
-
-        let mentions = vec![NotificationTarget {
-            recipient: mentioned,
-            notification_type: NotificationType::Mention,
-        }];
-        let targets = merge_watcher_targets(mentions, &author, Vec::new());
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].recipient, mentioned);
-        assert_eq!(targets[0].notification_type, NotificationType::Mention);
-    }
-
-    #[test]
-    fn test_failed_watcher_lookup_still_delivers_mentions() {
-        let author = Keys::generate();
-        let mentioned = Keys::generate().public_key();
-        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
-            .tag(Tag::identifier("vid-1"))
-            .tag(Tag::public_key(mentioned))
-            .sign_with_keys(&author)
-            .unwrap();
-
-        // Redis is down. The bells are lost; the mentions must not be, because
-        // they came from the event's own tags and needed no lookup at all.
-        let lookup = Err(crate::error::ServiceError::Internal(
-            "redis down".to_string(),
-        ));
-        let watchers = watchers_or_degrade(&event, lookup);
-        assert!(watchers.is_empty());
-
-        let targets = merge_watcher_targets(
-            video_mention_targets(&event),
-            &author.public_key(),
-            watchers,
-        );
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].recipient, mentioned);
-        assert_eq!(targets[0].notification_type, NotificationType::Mention);
-    }
-
     #[tokio::test]
     async fn test_a_real_watcher_page_failure_still_delivers_mentions() {
         // This drives a genuine watcher-page failure through the real video
@@ -2631,8 +2492,8 @@ mod tests {
     #[test]
     fn test_a_mentioned_watcher_is_not_also_belled() {
         // Mention wins on overlap, which is what README and the developer guide
-        // promise. The rule used to live in `merge_watcher_targets` and moved to
-        // the page path, so it needs a test on the page path: without one,
+        // promise. The rule moved onto the page path with the fan-out rewrite
+        // and arrived there without a test: without one,
         // deleting the `mentioned` filter leaves the whole suite green while
         // every mentioned watcher gets two pushes for one video.
         let author = Keys::generate().public_key();
@@ -2752,45 +2613,22 @@ mod tests {
     }
 
     #[test]
-    fn test_watcher_and_separate_mention_both_get_their_own_type() {
+    fn test_a_watcher_page_keeps_the_watchers_who_were_not_mentioned() {
+        // Partial overlap: the mention pass already covers `mentioned`, so the
+        // page owes a bell to `watcher` and nothing to them.
         let author = Keys::generate().public_key();
         let mentioned = Keys::generate().public_key();
         let watcher = Keys::generate().public_key();
 
-        let mentions = vec![NotificationTarget {
-            recipient: mentioned,
-            notification_type: NotificationType::Mention,
-        }];
-        let targets = merge_watcher_targets(mentions, &author, vec![watcher]);
+        let targets = watcher_page_targets(
+            vec![mentioned, watcher],
+            &author,
+            &HashSet::from([mentioned]),
+        );
 
-        assert_eq!(targets.len(), 2);
-        let mention = targets.iter().find(|t| t.recipient == mentioned).unwrap();
-        let bell = targets.iter().find(|t| t.recipient == watcher).unwrap();
-        assert_eq!(mention.notification_type, NotificationType::Mention);
-        assert_eq!(bell.notification_type, NotificationType::NewPost);
-    }
-
-    #[test]
-    fn test_delivery_targets_split_new_post_from_regular_notifications() {
-        let mention_recipient = Keys::generate().public_key();
-        let watcher = Keys::generate().public_key();
-        let targets = vec![
-            NotificationTarget {
-                recipient: mention_recipient,
-                notification_type: NotificationType::Mention,
-            },
-            NotificationTarget {
-                recipient: watcher,
-                notification_type: NotificationType::NewPost,
-            },
-        ];
-
-        let (regular, new_posts) = split_delivery_targets(targets);
-
-        assert_eq!(regular.len(), 1);
-        assert_eq!(regular[0].notification_type, NotificationType::Mention);
-        assert_eq!(new_posts.len(), 1);
-        assert_eq!(new_posts[0].notification_type, NotificationType::NewPost);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, watcher);
+        assert_eq!(targets[0].notification_type, NotificationType::NewPost);
     }
 
     #[test]
@@ -2999,7 +2837,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_a_mention_suppresses_a_later_bell_on_the_same_video() {
-        // The other direction of the same rule. `merge_watcher_targets` already
+        // The other direction of the same rule. `watcher_page_targets` already
         // says mention wins over bell on overlap; that has to hold across edits
         // too. A watcher who was `p`-tagged in the original and dropped from the
         // edit resolves to a bare NewPost target on the edit, and without the

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -50,8 +50,13 @@ const REPLAY_HORIZON_DAYS: u64 = 7;
 /// Notify lists are replaceable: a list published three months ago and never
 /// touched since is still the user's current subscription set. Aging one out
 /// would silently drop every bell on it until the user happened to republish.
+///
+/// Checks the `d` tag as well as the kind, for the same reason
+/// `handle_notify_list_update` does: the relay-side `#d` filter should already
+/// guarantee it, but a buggy or hostile relay can send any kind 30000 it likes,
+/// and the exemption should cover exactly the events it exists for.
 pub fn is_notify_list(event: &Event) -> bool {
-    event.kind.as_u16() == KIND_NOTIFY_LIST
+    event.kind.as_u16() == KIND_NOTIFY_LIST && event.tags.identifier() == Some(NOTIFY_LIST_D_TAG)
 }
 
 /// Whether the handler loop should drop this event as beyond the replay horizon.

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -663,6 +663,17 @@ fn targets_of(
         .collect()
 }
 
+/// User-visible copy for a new-post push.
+///
+/// The body is required by the mobile client: an empty value makes foreground
+/// handling return early without displaying a notification.
+fn new_post_copy(sender_name: &str) -> (String, String) {
+    (
+        "New vine".to_string(),
+        format!("{} posted a new vine", sender_name),
+    )
+}
+
 /// Mention targets for a video event: p-tagged users other than the author.
 fn video_mention_targets(event: &Event) -> Vec<NotificationTarget> {
     find_mentioned_pubkeys(event)
@@ -1089,9 +1100,7 @@ async fn create_fcm_payload(
         NotificationType::NewPost => {
             // Provisional copy. divine-mobile/brand-guidelines/TONE_OF_VOICE.md
             // governs user-facing strings; confirm before release.
-            let title = "New vine".to_string();
-            let body = format!("{} posted a new vine", sender_name);
-            (title, body)
+            new_post_copy(&sender_name)
         }
     };
 
@@ -1557,6 +1566,18 @@ mod tests {
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].recipient, watcher);
         assert_eq!(targets[0].notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn test_new_post_copy_has_required_non_empty_body() {
+        let (title, body) = new_post_copy("Alice");
+
+        assert_eq!(title, "New vine");
+        assert_eq!(body, "Alice posted a new vine");
+        assert!(
+            !body.trim().is_empty(),
+            "mobile silently drops foreground pushes without a body"
+        );
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1257,13 +1257,26 @@ async fn send_notification_to_user(
     // blip is worse. Do not "fix" this into `SET NX EX`.
     if notification_type == NotificationType::NewPost && success_count > 0 {
         let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
-        redis_store::set_cached_string(
+        // Log and continue rather than `?`. Everything from here down is
+        // bookkeeping about a push that has already shipped, so propagating
+        // reports a delivered notification as failed and, worse, skips the
+        // bookkeeping below it: the coordinate claim that stops a NIP-33 edit
+        // re-notifying, and invalid-token removal.
+        if let Err(e) = redis_store::set_cached_string(
             &state.redis_pool,
             &rate_key,
             "1",
             state.settings.service.new_post_rate_limit_secs,
         )
-        .await?;
+        .await
+        {
+            error!(
+                event_id = %event_id,
+                target_pubkey = %target_pubkey,
+                error = %e,
+                "Failed to open the new-post rate-limit window after a delivered push"
+            );
+        }
     }
 
     if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
@@ -1277,13 +1290,26 @@ async fn send_notification_to_user(
                 return Ok(());
             };
             let redis_key = format!("dedup:{claim_key}");
-            redis_store::set_cached_string(
+            // Same reasoning as the rate-limit write above, and it matters more
+            // here: `satisfied_video_claims` can yield two records, and `?` on
+            // the first left the second unwritten. That is exactly the
+            // half-written state the type-scoped claim exists to prevent.
+            if let Err(e) = redis_store::set_cached_string(
                 &state.redis_pool,
                 &redis_key,
                 "1",
                 state.settings.service.video_coordinate_dedup_ttl_secs,
             )
-            .await?;
+            .await
+            {
+                error!(
+                    event_id = %event_id,
+                    target_pubkey = %target_pubkey,
+                    claim = %redis_key,
+                    error = %e,
+                    "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify"
+                );
+            }
         }
     }
 
@@ -2545,6 +2571,147 @@ mod tests {
             .query_async::<()>(&mut *conn)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_bookkeeping_failure_does_not_skip_the_video_claim() {
+        // The post-send writes are bookkeeping: the push has already shipped, so
+        // one of them failing must not take the others down with it. The
+        // coordinate record is what stops a NIP-33 edit re-notifying, so losing
+        // it because an unrelated write errored costs the user a duplicate push.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("bookkeeping-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        // `SETEX key 0 v` is a Redis error, so the rate-limit write fails while
+        // the send itself succeeds. Reachable in production via
+        // `NOSTR_PUSH__SERVICE__NEW_POST_RATE_LIMIT_SECS=0`, which nothing
+        // validates at load.
+        let mut settings = crate::config::Settings::new().unwrap();
+        settings.service.new_post_rate_limit_secs = 0;
+        let state = test_app_state(
+            settings,
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("bookkeeping-vid"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        let result = send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        let claim_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::NewPost)
+                .unwrap();
+        let record = redis_store::get_cached_string(&pool, &format!("dedup:{claim_key}"))
+            .await
+            .unwrap();
+
+        let mut conn = pool.get().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("dedup:{claim_key}"))
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the push was delivered"
+        );
+        assert!(
+            record.is_some(),
+            "a delivered video push must record its coordinate, or the next edit re-notifies"
+        );
+        assert!(result.is_ok(), "a delivered push must not report failure");
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_claim_write_is_not_reported_as_a_delivery_failure() {
+        // Same class as the test above, one write further down: the claim loop.
+        // A delivered push that returns `Err` is not just cosmetic. The caller
+        // logs it as a failed notification, and the remaining post-send work,
+        // including invalid-token removal, is skipped.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("claim-write-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let mut settings = crate::config::Settings::new().unwrap();
+        // Makes the coordinate `SETEX` error while the send still succeeds.
+        settings.service.video_coordinate_dedup_ttl_secs = 0;
+        let state = test_app_state(
+            settings,
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("claim-write-vid"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        let result = send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        // Without this the test could pass vacuously, by the claim write
+        // quietly succeeding and there being nothing to survive.
+        let claim_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::Mention)
+                .unwrap();
+        let record = redis_store::get_cached_string(&pool, &format!("dedup:{claim_key}"))
+            .await
+            .unwrap();
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the push was delivered"
+        );
+        assert!(
+            record.is_none(),
+            "the claim write must actually have failed, or this test proves nothing"
+        );
+        assert!(
+            result.is_ok(),
+            "a bookkeeping write failing is not a delivery failure"
+        );
     }
 
     #[tokio::test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -2656,6 +2656,70 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test]
+    async fn test_a_failed_send_does_not_burn_the_rate_limit_window() {
+        // Check-then-set-on-success is a deliberate choice over `SET NX EX`, and
+        // this is the behaviour it was chosen for: an FCM blip must not cost the
+        // watcher an hour of bells. The comment above the write says so and asks
+        // that it not be "fixed" later, which is precisely why it needs a test
+        // rather than a comment.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("failed-send-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        // Transient, not `TokenNotRegistered`: the token stays registered so the
+        // next attempt can still succeed, which is the case the window protects.
+        mock_sender.set_error_for_token(&fcm_token, FcmError::InternalError);
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("failed-send"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let rate_key =
+            redis_store::build_notify_rate_key(&watcher.public_key(), &owner.public_key());
+        let marker = redis_store::get_cached_string(&pool, &rate_key)
+            .await
+            .unwrap();
+
+        // Cleanup before the assertions, so a failure does not leave a
+        // registered token behind in the developer's Redis.
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "the send was supposed to fail"
+        );
+        assert!(
+            marker.is_none(),
+            "a bell nobody received must not consume the watcher's hour"
+        );
+    }
+
     #[test]
     fn test_find_comment_recipients_reply_notifies_root_and_parent_authors() {
         let actor = Keys::generate();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -2608,6 +2608,150 @@ mod tests {
     }
 
     #[test]
+    fn test_a_watcher_page_types_every_watcher_as_new_post() {
+        let author = Keys::generate().public_key();
+        let watcher = Keys::generate().public_key();
+
+        let targets = watcher_page_targets(vec![watcher], &author, &HashSet::new());
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, watcher);
+        assert_eq!(targets[0].notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn test_a_watcher_page_drops_an_author_watching_themselves() {
+        let author = Keys::generate().public_key();
+
+        let targets = watcher_page_targets(vec![author], &author, &HashSet::new());
+
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn test_a_mentioned_watcher_is_not_also_belled() {
+        // Mention wins on overlap, which is what README and the developer guide
+        // promise. The rule used to live in `merge_watcher_targets` and moved to
+        // the page path, so it needs a test on the page path: without one,
+        // deleting the `mentioned` filter leaves the whole suite green while
+        // every mentioned watcher gets two pushes for one video.
+        let author = Keys::generate().public_key();
+        let both = Keys::generate().public_key();
+        let mentioned = HashSet::from([both]);
+
+        let targets = watcher_page_targets(vec![both], &author, &mentioned);
+
+        assert!(
+            targets.is_empty(),
+            "the mention already covers this recipient, so no bell is owed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_the_fan_out_reaches_watchers_past_the_first_page() {
+        // The paging loop is the point of the fan-out bound, and nothing failed
+        // when it was broken: stopping after page one, or never advancing the
+        // cursor, left the suite green. It needs a creator whose watcher set is
+        // big enough for Redis to page at all. Below Redis's
+        // `set-max-listpack-entries` (128 by default) a set is listpack-encoded
+        // and SSCAN returns every member in one reply whatever COUNT says, so a
+        // handful of watchers cannot exercise a second page.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        const WATCHERS: usize = 150;
+        const PAGE_SIZE: usize = 10;
+
+        let author = Keys::generate();
+        let creator = author.public_key();
+        let watchers: Vec<Keys> = (0..WATCHERS).map(|_| Keys::generate()).collect();
+
+        for (idx, watcher) in watchers.iter().enumerate() {
+            redis_store::add_or_update_token(
+                &pool,
+                &watcher.public_key(),
+                &format!("fanout_token_{}", idx),
+            )
+            .await
+            .expect("register token");
+            redis_store::replace_notify_subscriptions(
+                &pool,
+                &watcher.public_key(),
+                &[creator],
+                1_000 + idx as u64,
+                &EventId::all_zeros(),
+            )
+            .await
+            .expect("bell the creator");
+        }
+
+        // Without this the assertion below could be met by one oversized page.
+        let first_page = redis_store::get_notify_watchers_page(&pool, &creator, 0, PAGE_SIZE)
+            .await
+            .expect("first watcher page");
+        assert_ne!(
+            first_page.next_cursor, 0,
+            "the seeded set must be large enough for Redis to page"
+        );
+
+        let mut settings = crate::config::Settings::new().unwrap();
+        settings.service.new_post_fanout_page_size = PAGE_SIZE;
+        settings.service.new_post_delivery_concurrency = 4;
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            settings,
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
+            .tag(Tag::identifier("paged-fanout-vid"))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        let result = handle_video_content_event(&state, &event, CancellationToken::new()).await;
+
+        for (idx, watcher) in watchers.iter().enumerate() {
+            let _ = redis_store::remove_token(
+                &pool,
+                &watcher.public_key(),
+                &format!("fanout_token_{}", idx),
+            )
+            .await;
+            // The coordinate claim carries a one-year TTL, so it has to go with
+            // the rest or every run leaves 150 keys behind for a year.
+            let claim_key =
+                video_recipient_claim_key(&event, &watcher.public_key(), NotificationType::NewPost)
+                    .expect("the test event has a d-tag");
+            let mut conn = pool.get().await.unwrap();
+            let _: () = redis::cmd("DEL")
+                .arg(format!("notify_subs:{}", watcher.public_key().to_hex()))
+                .arg(format!("notify_subs_ts:{}", watcher.public_key().to_hex()))
+                .arg(redis_store::build_notify_rate_key(
+                    &watcher.public_key(),
+                    &creator,
+                ))
+                .arg(format!("dedup:{claim_key}"))
+                .query_async(&mut *conn)
+                .await
+                .unwrap();
+        }
+        let mut conn = pool.get().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("notify_watchers:{}", creator.to_hex()))
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+
+        result.expect("the fan-out completes");
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            WATCHERS,
+            "every watcher is notified, not just the ones on the first page"
+        );
+    }
+
+    #[test]
     fn test_watcher_and_separate_mention_both_get_their_own_type() {
         let author = Keys::generate().public_key();
         let mentioned = Keys::generate().public_key();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -512,6 +512,7 @@ async fn handle_notify_list_update(state: &AppState, event: &Event) -> Result<()
         &event.pubkey,
         &creators,
         event.created_at.as_secs(),
+        &event.id,
     )
     .await?;
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -620,8 +620,9 @@ async fn handle_content_event(
         "Processing notification event"
     );
 
-    // Resolve the recipient-independent copy once, before the fan-out loop.
-    let copy = resolve_event_scoped_copy(state, event, &targets).await;
+    // The recipient-independent copy resolves at most once for the event, and
+    // only if some recipient survives the gates in `send_notification_to_user`.
+    let copy = LazyEventCopy::for_targets(&targets);
 
     // Send notifications to each target
     for target in targets {
@@ -781,6 +782,58 @@ fn renders_event_content(notification_type: NotificationType) -> bool {
     }
 }
 
+/// The event-scoped copy, resolved at most once and only if it is needed.
+///
+/// Resolving once per event rather than once per recipient is the point of the
+/// `EventScopedCopy` split. Resolving it *eagerly* is not: every gate in
+/// `send_notification_to_user` — allowlist, registered tokens, preferences,
+/// coordinate record, rate limit — can drop a recipient, and on a public relay
+/// the token gate alone drops nearly all of them, because the subscription has
+/// no `#p` narrowing and most tagged users have never registered for push.
+///
+/// An eager resolve therefore pays `get_display_name` for events that deliver
+/// nothing. That is a Redis GET plus, on a cache miss, a relay `fetch_events`
+/// bounded by `query_timeout_secs` — and misses are never written back, so an
+/// author with no kind-0 pays it on every event forever. All of it on the single
+/// sequential handler task, ahead of every other user's notifications.
+///
+/// Deferring the resolve to the first recipient that actually reaches payload
+/// construction keeps the once-per-event property and restores the property the
+/// per-recipient version had for free: an event nobody can be pushed for costs
+/// no profile work at all.
+struct LazyEventCopy {
+    cell: tokio::sync::OnceCell<EventScopedCopy>,
+    /// Whether any target renders the event body, decided over the whole target
+    /// list rather than the one recipient that happens to resolve it first.
+    needs_content: bool,
+}
+
+impl LazyEventCopy {
+    fn for_targets(targets: &[NotificationTarget]) -> Self {
+        Self {
+            cell: tokio::sync::OnceCell::new(),
+            needs_content: targets
+                .iter()
+                .any(|target| renders_event_content(target.notification_type)),
+        }
+    }
+
+    /// Pre-resolved copy, for tests that exercise delivery rather than copy.
+    #[cfg(test)]
+    fn resolved(copy: EventScopedCopy) -> Self {
+        Self {
+            cell: tokio::sync::OnceCell::new_with(Some(copy)),
+            needs_content: false,
+        }
+    }
+
+    async fn get(&self, state: &AppState, event: &Event) -> &EventScopedCopy {
+        self.cell
+            .get_or_init(|| resolve_event_scoped_copy(state, event, self.needs_content))
+            .await
+    }
+}
+
 /// Resolve the recipient-independent copy for an event, once.
 ///
 /// The content parse is skipped entirely unless some target actually renders the
@@ -788,7 +841,7 @@ fn renders_event_content(notification_type: NotificationType) -> bool {
 async fn resolve_event_scoped_copy(
     state: &AppState,
     event: &Event,
-    targets: &[NotificationTarget],
+    needs_content: bool,
 ) -> EventScopedCopy {
     let Some(mention_parser) = state.mention_parser_service.as_ref() else {
         return EventScopedCopy {
@@ -808,10 +861,6 @@ async fn resolve_event_scoped_copy(
             format_short_npub(&event.pubkey)
         }
     };
-
-    let needs_content = targets
-        .iter()
-        .any(|target| renders_event_content(target.notification_type));
 
     let formatted_content = if needs_content {
         match mention_parser.format_content_for_push(&event.content).await {
@@ -1006,7 +1055,7 @@ async fn send_notification_to_user(
     event: &Event,
     target_pubkey: &PublicKey,
     notification_type: NotificationType,
-    copy: &EventScopedCopy,
+    copy: &LazyEventCopy,
     token: CancellationToken,
 ) -> Result<()> {
     let event_id = event.id;
@@ -1124,6 +1173,17 @@ async fn send_notification_to_user(
         token_count = tokens.len(),
         "Found FCM tokens for recipient"
     );
+
+    // Every gate that could drop this recipient is behind us, so this delivery
+    // is the one that pays for the event's copy — once, for all recipients.
+    let copy = tokio::select! {
+        biased;
+        _ = token.cancelled() => {
+            info!(event_id = %event_id, target_pubkey = %target_pubkey, "Cancelled while resolving the event copy.");
+            return Err(crate::error::ServiceError::Cancelled);
+        }
+        resolved = copy.get(state, event) => resolved
+    };
 
     // Create FCM payload
     let payload = create_fcm_payload(event, target_pubkey, notification_type, copy);
@@ -1518,11 +1578,11 @@ mod tests {
     }
 
     /// Event-scoped copy for tests that exercise delivery rather than copy.
-    fn test_copy() -> EventScopedCopy {
-        EventScopedCopy {
+    fn test_copy() -> LazyEventCopy {
+        LazyEventCopy::resolved(EventScopedCopy {
             sender_name: "tester".to_string(),
             formatted_content: None,
-        }
+        })
     }
 
     #[test]
@@ -1859,6 +1919,126 @@ mod tests {
         assert!(!renders_event_content(NotificationType::Follow));
         assert!(!renders_event_content(NotificationType::Repost));
         assert!(!renders_event_content(NotificationType::NewPost));
+    }
+
+    #[test]
+    fn test_needs_content_is_decided_over_the_whole_target_list() {
+        // The copy resolves on whichever recipient clears the gates first, which
+        // need not be one that renders the body. Deciding `needs_content` from
+        // the full list keeps that ordering from silently downgrading a mention
+        // to raw, unparsed content.
+        let bell_first = LazyEventCopy::for_targets(&[
+            NotificationTarget {
+                recipient: Keys::generate().public_key(),
+                notification_type: NotificationType::NewPost,
+            },
+            NotificationTarget {
+                recipient: Keys::generate().public_key(),
+                notification_type: NotificationType::Mention,
+            },
+        ]);
+        assert!(bell_first.needs_content);
+
+        let bells_only = LazyEventCopy::for_targets(&[NotificationTarget {
+            recipient: Keys::generate().public_key(),
+            notification_type: NotificationType::NewPost,
+        }]);
+        assert!(!bells_only.needs_content);
+    }
+
+    #[tokio::test]
+    async fn test_a_recipient_without_tokens_never_resolves_the_event_copy() {
+        // The regression this guards is a throughput one, but the observable
+        // fact is binary: did the event pay for its copy at all? With no mention
+        // parser configured the resolve is free, so this asserts *whether* it
+        // happened, not what it cost. In production it costs a Redis GET and,
+        // on a cache miss, a relay round trip that is never negatively cached.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(MockFcmSender::new())),
+        );
+        let event = EventBuilder::text_note("hello")
+            .tag(Tag::public_key(recipient))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        let copy = LazyEventCopy::for_targets(&[NotificationTarget {
+            recipient,
+            notification_type: NotificationType::Mention,
+        }]);
+        send_notification_to_user(
+            &state,
+            &event,
+            &recipient,
+            NotificationType::Mention,
+            &copy,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            copy.cell.get().is_none(),
+            "an event with no deliverable recipient must not resolve its copy"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_delivered_push_resolves_the_event_copy() {
+        // The other half of the pair: deferring must not skip the resolve for a
+        // recipient that does get a push.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let recipient = Keys::generate();
+        let fcm_token = format!("lazy-copy-{}", recipient.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("hello")
+            .tag(Tag::public_key(recipient.public_key()))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        let copy = LazyEventCopy::for_targets(&[NotificationTarget {
+            recipient: recipient.public_key(),
+            notification_type: NotificationType::Mention,
+        }]);
+        send_notification_to_user(
+            &state,
+            &event,
+            &recipient.public_key(),
+            NotificationType::Mention,
+            &copy,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(mock_sender.get_sent_messages().len(), 1);
+        assert_eq!(
+            copy.cell.get().map(|c| c.sender_name.as_str()),
+            Some(format_short_npub(&author.public_key()).as_str()),
+            "a delivered push resolves the copy the payload is built from"
+        );
+
+        redis_store::remove_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -745,6 +745,15 @@ async fn handle_video_content_event(
         .map(|target| target.recipient)
         .collect();
 
+    // One copy for the whole event, spanning the mention pass and every watcher
+    // page. Building it per page would put the cost back on a per-page footing:
+    // `get_display_name` misses are never negatively cached, so a creator with
+    // no kind-0 metadata pays a five-second relay round-trip for each page, on
+    // the event-handler loop that every other user's notifications queue behind.
+    // `needs_content` is decided by the mention targets alone because `NewPost`
+    // does not render the event body, so no watcher page can widen it.
+    let copy = LazyEventCopy::for_targets(&mention_targets);
+
     let mut target_count = 0usize;
     if !mention_targets.is_empty() {
         info!(
@@ -754,7 +763,6 @@ async fn handle_video_content_event(
             notification_types = ?vec![(NotificationType::Mention.display_name(), mention_targets.len())],
             "Processing notification event"
         );
-        let copy = LazyEventCopy::for_targets(&mention_targets);
         send_notifications_sequential(state, event, mention_targets, &copy, token.clone()).await?;
         target_count += mentioned.len();
     }
@@ -802,7 +810,6 @@ async fn handle_video_content_event(
                 next_cursor,
                 "Processing new-post notification page"
             );
-            let copy = LazyEventCopy::for_targets(&new_post_targets);
             send_notifications_bounded(
                 state,
                 event,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -14,7 +14,9 @@ use crate::{
     redis_store,
     state::AppState,
 };
+use futures_util::{stream, StreamExt};
 use nostr_sdk::prelude::*;
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
@@ -580,7 +582,7 @@ async fn handle_content_event(
         // Kind 30023: Long-form content - check for mentions
         targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
     } else if kind_num == KIND_VIDEO {
-        video_notification_targets(state, event).await
+        return handle_video_content_event(state, event, token).await;
     } else {
         trace!(event_id = %event_id, kind = %event_kind, "Ignoring event kind - no notification handler");
         return Ok(());
@@ -625,10 +627,19 @@ async fn handle_content_event(
     // only if some recipient survives the gates in `send_notification_to_user`.
     let copy = LazyEventCopy::for_targets(&targets);
 
-    // Send notifications to each target
+    send_notifications_sequential(state, event, targets, &copy, token).await
+}
+
+async fn send_notifications_sequential(
+    state: &AppState,
+    event: &Event,
+    targets: Vec<NotificationTarget>,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+) -> Result<()> {
     for target in targets {
         if token.is_cancelled() {
-            info!(event_id = %event_id, "Notification sending cancelled");
+            info!(event_id = %event.id, "Notification sending cancelled");
             return Err(crate::error::ServiceError::Cancelled);
         }
 
@@ -639,7 +650,7 @@ async fn handle_content_event(
             event,
             &recipient_pubkey,
             target.notification_type,
-            &copy,
+            copy,
             token.clone(),
         )
         .await
@@ -648,7 +659,7 @@ async fn handle_content_event(
                 return Err(e);
             }
             error!(
-                event_id = %event_id,
+                event_id = %event.id,
                 recipient = %recipient_pubkey,
                 error = %e,
                 "Failed to send notification"
@@ -657,6 +668,173 @@ async fn handle_content_event(
     }
 
     Ok(())
+}
+
+async fn send_notifications_bounded(
+    state: &AppState,
+    event: &Event,
+    targets: Vec<NotificationTarget>,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+    concurrency: usize,
+) -> Result<()> {
+    let mut deliveries = stream::iter(targets)
+        .map(|target| {
+            let token = token.clone();
+            async move {
+                let recipient = target.recipient;
+                (
+                    recipient,
+                    deliver_notification_target(state, event, target, copy, token).await,
+                )
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some((recipient, result)) = deliveries.next().await {
+        if let Err(e) = result {
+            if matches!(e, crate::error::ServiceError::Cancelled) {
+                return Err(e);
+            }
+            error!(
+                event_id = %event.id,
+                recipient = %recipient,
+                error = %e,
+                "Failed to send notification"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn deliver_notification_target(
+    state: &AppState,
+    event: &Event,
+    target: NotificationTarget,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+) -> Result<()> {
+    let recipient_pubkey = target.recipient;
+
+    // Skip if recipient is the sender
+    if recipient_pubkey == event.pubkey {
+        trace!(event_id = %event.id, "Skipping notification to sender");
+        return Ok(());
+    }
+
+    send_notification_to_user(
+        state,
+        event,
+        &recipient_pubkey,
+        target.notification_type,
+        copy,
+        token,
+    )
+    .await
+}
+
+async fn handle_video_content_event(
+    state: &AppState,
+    event: &Event,
+    token: CancellationToken,
+) -> Result<()> {
+    let mention_targets = deliverable_targets(video_mention_targets(event), &event.pubkey);
+    let mentioned: HashSet<PublicKey> = mention_targets
+        .iter()
+        .map(|target| target.recipient)
+        .collect();
+
+    let mut target_count = 0usize;
+    if !mention_targets.is_empty() {
+        info!(
+            event_id = %event.id,
+            kind = %event.kind,
+            recipient_count = mention_targets.len(),
+            notification_types = ?vec![(NotificationType::Mention.display_name(), mention_targets.len())],
+            "Processing notification event"
+        );
+        let copy = LazyEventCopy::for_targets(&mention_targets);
+        send_notifications_sequential(state, event, mention_targets, &copy, token.clone()).await?;
+        target_count += mentioned.len();
+    }
+
+    let page_size = state.settings.service.new_post_fanout_page_size;
+    let concurrency = state.settings.service.new_post_delivery_concurrency;
+    let mut cursor = 0;
+    loop {
+        if token.is_cancelled() {
+            info!(event_id = %event.id, "Notification sending cancelled");
+            return Err(crate::error::ServiceError::Cancelled);
+        }
+
+        let page = match redis_store::get_notify_watchers_page(
+            &state.redis_pool,
+            &event.pubkey,
+            cursor,
+            page_size,
+        )
+        .await
+        {
+            Ok(page) => page,
+            Err(e) => {
+                error!(
+                    event_id = %event.id,
+                    creator = %event.pubkey,
+                    cursor,
+                    error = %e,
+                    "Failed to read notify watcher page - delivering mentions without remaining bells"
+                );
+                break;
+            }
+        };
+
+        let next_cursor = page.next_cursor;
+        let new_post_targets = watcher_page_targets(page.watchers, &event.pubkey, &mentioned);
+        if !new_post_targets.is_empty() {
+            let page_target_count = new_post_targets.len();
+            info!(
+                event_id = %event.id,
+                kind = %event.kind,
+                recipient_count = page_target_count,
+                notification_types = ?vec![(NotificationType::NewPost.display_name(), page_target_count)],
+                cursor,
+                next_cursor,
+                "Processing new-post notification page"
+            );
+            let copy = LazyEventCopy::for_targets(&new_post_targets);
+            send_notifications_bounded(
+                state,
+                event,
+                new_post_targets,
+                &copy,
+                token.clone(),
+                concurrency,
+            )
+            .await?;
+            target_count += page_target_count;
+        }
+
+        if next_cursor == 0 {
+            break;
+        }
+        cursor = next_cursor;
+    }
+
+    if target_count == 0 {
+        debug!(event_id = %event.id, kind = %event.kind, "No recipients found for event");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn split_delivery_targets(
+    targets: Vec<NotificationTarget>,
+) -> (Vec<NotificationTarget>, Vec<NotificationTarget>) {
+    targets
+        .into_iter()
+        .partition(|target| target.notification_type != NotificationType::NewPost)
 }
 
 /// Find recipients for a reaction event (kind 7)
@@ -929,6 +1107,7 @@ fn video_mention_targets(event: &Event) -> Vec<NotificationTarget> {
 /// skipped rather than added.
 ///
 /// Kept separate from the Redis read so the dedup rule is testable on its own.
+#[cfg(test)]
 fn merge_watcher_targets(
     mut targets: Vec<NotificationTarget>,
     author: &PublicKey,
@@ -951,6 +1130,22 @@ fn merge_watcher_targets(
     targets
 }
 
+fn watcher_page_targets(
+    watchers: Vec<PublicKey>,
+    author: &PublicKey,
+    mentioned: &HashSet<PublicKey>,
+) -> Vec<NotificationTarget> {
+    watchers
+        .into_iter()
+        .filter(|watcher| watcher != author)
+        .filter(|watcher| !mentioned.contains(watcher))
+        .map(|recipient| NotificationTarget {
+            recipient,
+            notification_type: NotificationType::NewPost,
+        })
+        .collect()
+}
+
 /// Resolve a watcher lookup into the watchers to notify, degrading to none.
 ///
 /// Bells are enrichment layered on top of mentions, and they are the only part
@@ -961,6 +1156,7 @@ fn merge_watcher_targets(
 ///
 /// Kept separate from the read so the degradation is testable without an
 /// `AppState`.
+#[cfg(test)]
 fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<PublicKey> {
     match lookup {
         Ok(watchers) => watchers,
@@ -974,16 +1170,6 @@ fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<Pub
             Vec::new()
         }
     }
-}
-
-/// Build the notification targets for a video event: mentions plus bells.
-async fn video_notification_targets(state: &AppState, event: &Event) -> Vec<NotificationTarget> {
-    let lookup = redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await;
-    merge_watcher_targets(
-        video_mention_targets(event),
-        &event.pubkey,
-        watchers_or_degrade(event, lookup),
-    )
 }
 
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
@@ -2351,19 +2537,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_a_real_watcher_lookup_failure_still_delivers_mentions() {
-        // The test above proves `watchers_or_degrade` degrades. It does not
-        // prove anything calls it: it never reaches `video_notification_targets`,
-        // where the degradation is actually wired in, so replacing that call
-        // with `lookup.expect(...)` leaves the whole suite green. This drives a
-        // genuine `get_notify_watchers` failure through the real function, by
-        // leaving a string where the watcher set belongs so `SMEMBERS` fails
-        // with WRONGTYPE.
+    async fn test_a_real_watcher_page_failure_still_delivers_mentions() {
+        // This drives a genuine watcher-page failure through the real video
+        // delivery path by leaving a string where the watcher set belongs, so
+        // SSCAN fails with WRONGTYPE. Mentions came from the event's own tags
+        // and must still be delivered.
         let Some(pool) = test_redis_pool().await else {
             return;
         };
         let author = Keys::generate();
         let mentioned = Keys::generate().public_key();
+        let fcm_token = format!("mention_token_{}", EventId::all_zeros().to_hex());
+        redis_store::add_or_update_token(&pool, &mentioned, &fcm_token)
+            .await
+            .expect("register token");
         let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
             .tag(Tag::identifier("wrongtype-vid"))
             .tag(Tag::public_key(mentioned))
@@ -2381,27 +2568,36 @@ mod tests {
 
         // Without this the test could pass vacuously, by the lookup succeeding
         // and simply finding no watchers.
-        let lookup_failed = redis_store::get_notify_watchers(&pool, &author.public_key())
-            .await
-            .is_err();
+        let lookup_failed =
+            redis_store::get_notify_watchers_page(&pool, &author.public_key(), 0, 1000)
+                .await
+                .is_err();
 
+        let mock_sender = MockFcmSender::new();
         let state = test_app_state(
             crate::config::Settings::new().unwrap(),
             pool.clone(),
-            FcmClient::new_with_impl(Box::new(MockFcmSender::new())),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
         );
-        let targets = video_notification_targets(&state, &event).await;
+        handle_video_content_event(&state, &event, CancellationToken::new())
+            .await
+            .expect("video handling degrades to mentions");
 
         let _: () = redis::cmd("DEL")
             .arg(&watchers_key)
             .query_async(&mut *conn)
             .await
             .unwrap();
+        redis_store::remove_token(&pool, &mentioned, &fcm_token)
+            .await
+            .expect("cleanup token");
 
         assert!(lookup_failed, "the seeded key must make the lookup fail");
-        assert_eq!(targets.len(), 1, "the mention survives the failed lookup");
-        assert_eq!(targets[0].recipient, mentioned);
-        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the mention survives the failed watcher page lookup"
+        );
     }
 
     #[test]
@@ -2421,6 +2617,29 @@ mod tests {
         let bell = targets.iter().find(|t| t.recipient == watcher).unwrap();
         assert_eq!(mention.notification_type, NotificationType::Mention);
         assert_eq!(bell.notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn test_delivery_targets_split_new_post_from_regular_notifications() {
+        let mention_recipient = Keys::generate().public_key();
+        let watcher = Keys::generate().public_key();
+        let targets = vec![
+            NotificationTarget {
+                recipient: mention_recipient,
+                notification_type: NotificationType::Mention,
+            },
+            NotificationTarget {
+                recipient: watcher,
+                notification_type: NotificationType::NewPost,
+            },
+        ];
+
+        let (regular, new_posts) = split_delivery_targets(targets);
+
+        assert_eq!(regular.len(), 1);
+        assert_eq!(regular[0].notification_type, NotificationType::Mention);
+        assert_eq!(new_posts.len(), 1);
+        assert_eq!(new_posts[0].notification_type, NotificationType::NewPost);
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -948,6 +948,28 @@ fn video_recipient_claim_key(
     ))
 }
 
+/// The video-coordinate records a delivered push satisfies.
+///
+/// Type-scoping the claim key made the two directions independent, but they are
+/// not: a mention push names the video, so it necessarily tells the recipient
+/// that video exists — which is the entire content of a bell. Delivering one
+/// therefore satisfies the bell's record too. The converse does not hold, since
+/// "X posted a vine" says nothing about being mentioned, and that asymmetry is
+/// why the key carries the type at all.
+///
+/// This is `merge_watcher_targets`'s "mention wins on overlap" rule extended
+/// across edits. Without it, a watcher who was `p`-tagged in the original and
+/// dropped from an edit resolves to a bare `NewPost` target on the edit and is
+/// told "posted a new vine" about a video they were already pushed about.
+///
+/// Pure, so the rule is testable without Redis.
+fn satisfied_video_claims(notification_type: NotificationType) -> Vec<NotificationType> {
+    match notification_type {
+        NotificationType::Mention => vec![NotificationType::Mention, NotificationType::NewPost],
+        other => vec![other],
+    }
+}
+
 /// Find recipients for a NIP-22 comment event (kind 1111).
 ///
 /// Per NIP-22 the uppercase `P` tag is the root-scope author (for a video
@@ -1184,23 +1206,24 @@ async fn send_notification_to_user(
     }
 
     if event.kind.as_u16() == KIND_VIDEO && success_count > 0 {
-        let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, notification_type)
-        else {
-            warn!(
-                event_id = %event_id,
-                target_pubkey = %target_pubkey,
-                "Successful video notification lacked an addressable d-tag"
-            );
-            return Ok(());
-        };
-        let redis_key = format!("dedup:{claim_key}");
-        redis_store::set_cached_string(
-            &state.redis_pool,
-            &redis_key,
-            "1",
-            state.settings.service.video_coordinate_dedup_ttl_secs,
-        )
-        .await?;
+        for satisfied in satisfied_video_claims(notification_type) {
+            let Some(claim_key) = video_recipient_claim_key(event, target_pubkey, satisfied) else {
+                warn!(
+                    event_id = %event_id,
+                    target_pubkey = %target_pubkey,
+                    "Successful video notification lacked an addressable d-tag"
+                );
+                return Ok(());
+            };
+            let redis_key = format!("dedup:{claim_key}");
+            redis_store::set_cached_string(
+                &state.redis_pool,
+                &redis_key,
+                "1",
+                state.settings.service.video_coordinate_dedup_ttl_secs,
+            )
+            .await?;
+        }
     }
 
     // Remove invalid tokens
@@ -2174,6 +2197,116 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         redis::cmd("DEL")
             .arg(redis_key)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn test_a_mention_satisfies_the_bell_record_but_not_the_reverse() {
+        // The asymmetry is the whole point: a mention names the video, so it
+        // covers the bell, but a bell says nothing about being mentioned.
+        assert_eq!(
+            satisfied_video_claims(NotificationType::Mention),
+            vec![NotificationType::Mention, NotificationType::NewPost]
+        );
+        assert_eq!(
+            satisfied_video_claims(NotificationType::NewPost),
+            vec![NotificationType::NewPost]
+        );
+        assert_eq!(
+            satisfied_video_claims(NotificationType::Comment),
+            vec![NotificationType::Comment]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_mention_suppresses_a_later_bell_on_the_same_video() {
+        // The other direction of the same rule. `merge_watcher_targets` already
+        // says mention wins over bell on overlap; that has to hold across edits
+        // too. A watcher who was `p`-tagged in the original and dropped from the
+        // edit resolves to a bare NewPost target on the edit, and without the
+        // mention's record standing in for it they are told "posted a new vine"
+        // about a video they were already pushed about.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let fcm_token = format!("mention-then-bell-{}", watcher.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+
+        // The watcher is `p`-tagged on the original, so mention wins and the
+        // bell is never delivered for this coordinate.
+        let published = EventBuilder::new(Kind::from(KIND_VIDEO), "first version")
+            .tag(Tag::identifier("mention-then-bell"))
+            .tag(Tag::public_key(watcher.public_key()))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &published,
+            &watcher.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the mention delivers"
+        );
+
+        // The creator edits the video and drops the `p` tag. The watcher is now
+        // only a bell target for the same coordinate.
+        let edit_dropping_mention = EventBuilder::new(Kind::from(KIND_VIDEO), "edited version")
+            .tag(Tag::identifier("mention-then-bell"))
+            .sign_with_keys(&owner)
+            .unwrap();
+        send_notification_to_user(
+            &state,
+            &edit_dropping_mention,
+            &watcher.public_key(),
+            NotificationType::NewPost,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "an edit must not re-announce an already-pushed video as a new post"
+        );
+
+        redis_store::remove_token(&pool, &watcher.public_key(), &fcm_token)
+            .await
+            .unwrap();
+        let bell_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::NewPost)
+                .unwrap();
+        let mention_key =
+            video_recipient_claim_key(&published, &watcher.public_key(), NotificationType::Mention)
+                .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{bell_key}"))
+            .arg(format!("dedup:{mention_key}"))
+            .arg(redis_store::build_notify_rate_key(
+                &watcher.public_key(),
+                &owner.public_key(),
+            ))
             .query_async::<()>(&mut *conn)
             .await
             .unwrap();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -582,6 +582,9 @@ async fn handle_content_event(
         "Processing notification event"
     );
 
+    // Resolve the recipient-independent copy once, before the fan-out loop.
+    let copy = resolve_event_scoped_copy(state, event, &targets).await;
+
     // Send notifications to each target
     for target in targets {
         if token.is_cancelled() {
@@ -602,6 +605,7 @@ async fn handle_content_event(
             event,
             &recipient_pubkey,
             target.notification_type,
+            &copy,
             token.clone(),
         )
         .await
@@ -689,6 +693,94 @@ fn targets_of(
             notification_type,
         })
         .collect()
+}
+
+/// The parts of a push payload that depend on the event rather than the recipient.
+///
+/// Resolved once per event and shared across the fan-out. Both fields used to be
+/// computed inside `create_fcm_payload`, which runs per recipient, so both cost
+/// scaled with the recipient count while their inputs did not.
+///
+/// That was affordable when an event reached one to three `p`-tagged recipients.
+/// A bell reaches every watcher of the creator, and `get_display_name` is not a
+/// cheap repeat: on a profile-cache miss it does a relay `fetch_events` with a
+/// five-second timeout, and misses are never cached — only profiles that were
+/// found are written back. So a creator with no kind-0 metadata paid one relay
+/// round-trip per watcher, serially, on the single event-handler loop, delaying
+/// every other user's notifications behind it.
+struct EventScopedCopy {
+    /// Display name of the event author, or a short npub when unresolvable.
+    sender_name: String,
+    /// Event content with mentions resolved, when any target renders it.
+    ///
+    /// `None` means "not resolved" — either no target needed it or the parse
+    /// failed — and callers fall back to the raw content, as they did before.
+    formatted_content: Option<String>,
+}
+
+/// Whether this notification type renders the event's content in its body.
+///
+/// Exhaustive rather than a `matches!` so a new notification type has to state
+/// its answer here instead of silently defaulting to "no" and reaching
+/// `create_fcm_payload` without the content it needs.
+fn renders_event_content(notification_type: NotificationType) -> bool {
+    match notification_type {
+        NotificationType::Comment | NotificationType::Mention => true,
+        NotificationType::Like
+        | NotificationType::Follow
+        | NotificationType::Repost
+        | NotificationType::NewPost => false,
+    }
+}
+
+/// Resolve the recipient-independent copy for an event, once.
+///
+/// The content parse is skipped entirely unless some target actually renders the
+/// body, so a pure bell fan-out does not pay for mention parsing it never uses.
+async fn resolve_event_scoped_copy(
+    state: &AppState,
+    event: &Event,
+    targets: &[NotificationTarget],
+) -> EventScopedCopy {
+    let Some(mention_parser) = state.mention_parser_service.as_ref() else {
+        return EventScopedCopy {
+            sender_name: format_short_npub(&event.pubkey),
+            formatted_content: None,
+        };
+    };
+
+    let sender_name = match mention_parser
+        .get_display_name(&event.pubkey.to_hex())
+        .await
+    {
+        Ok(Some(name)) => name,
+        Ok(None) => format_short_npub(&event.pubkey),
+        Err(e) => {
+            warn!(error = %e, "Failed to get sender display name");
+            format_short_npub(&event.pubkey)
+        }
+    };
+
+    let needs_content = targets
+        .iter()
+        .any(|target| renders_event_content(target.notification_type));
+
+    let formatted_content = if needs_content {
+        match mention_parser.format_content_for_push(&event.content).await {
+            Ok(formatted) => Some(formatted),
+            Err(e) => {
+                warn!(event_id = %event.id, error = %e, "Failed to format content for push");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    EventScopedCopy {
+        sender_name,
+        formatted_content,
+    }
 }
 
 /// User-visible copy for a new-post push.
@@ -826,6 +918,7 @@ async fn send_notification_to_user(
     event: &Event,
     target_pubkey: &PublicKey,
     notification_type: NotificationType,
+    copy: &EventScopedCopy,
     token: CancellationToken,
 ) -> Result<()> {
     let event_id = event.id;
@@ -944,7 +1037,7 @@ async fn send_notification_to_user(
     );
 
     // Create FCM payload
-    let payload = create_fcm_payload(event, target_pubkey, notification_type, state).await?;
+    let payload = create_fcm_payload(event, target_pubkey, notification_type, copy);
 
     // Send to all tokens
     info!(
@@ -1069,29 +1162,27 @@ async fn send_notification_to_user(
 }
 
 /// Create FCM payload for a notification
-async fn create_fcm_payload(
+///
+/// Takes the event-scoped copy rather than resolving it, so the relay and Redis
+/// work behind `sender_name` and `formatted_content` happens once per event
+/// instead of once per recipient. That leaves this function free of I/O, which
+/// is also what makes it directly testable.
+fn create_fcm_payload(
     event: &Event,
     target_pubkey: &PublicKey,
     notification_type: NotificationType,
-    state: &AppState,
-) -> Result<FcmPayload> {
+    copy: &EventScopedCopy,
+) -> FcmPayload {
     let mut data = std::collections::HashMap::new();
 
-    // Get sender name using mention parser service
-    let sender_name = if let Some(ref mention_parser) = state.mention_parser_service {
-        match mention_parser
-            .get_display_name(&event.pubkey.to_hex())
-            .await
-        {
-            Ok(Some(name)) => name,
-            Ok(None) => format_short_npub(&event.pubkey),
-            Err(e) => {
-                warn!(error = %e, "Failed to get sender display name");
-                format_short_npub(&event.pubkey)
-            }
-        }
-    } else {
-        format_short_npub(&event.pubkey)
+    let sender_name = copy.sender_name.clone();
+
+    // Falls back to the raw content when the parse was skipped or failed, which
+    // is what the per-recipient parse did on error.
+    let formatted_content = || {
+        copy.formatted_content
+            .clone()
+            .unwrap_or_else(|| event.content.clone())
     };
 
     // Generate title and body based on notification type
@@ -1103,19 +1194,10 @@ async fn create_fcm_payload(
         }
         NotificationType::Comment => {
             let title = "New comment".to_string();
-            // Format content with mention parser if available
-            let formatted_content = if let Some(ref mention_parser) = state.mention_parser_service {
-                match mention_parser.format_content_for_push(&event.content).await {
-                    Ok(formatted) => formatted,
-                    Err(_) => event.content.clone(),
-                }
-            } else {
-                event.content.clone()
-            };
             let body = format!(
                 "{}: {}",
                 sender_name,
-                truncate_string(&formatted_content, 150)
+                truncate_string(&formatted_content(), 150)
             );
             (title, body)
         }
@@ -1126,19 +1208,10 @@ async fn create_fcm_payload(
         }
         NotificationType::Mention => {
             let title = "You were mentioned".to_string();
-            // Format content with mention parser if available
-            let formatted_content = if let Some(ref mention_parser) = state.mention_parser_service {
-                match mention_parser.format_content_for_push(&event.content).await {
-                    Ok(formatted) => formatted,
-                    Err(_) => event.content.clone(),
-                }
-            } else {
-                event.content.clone()
-            };
             let body = format!(
                 "{}: {}",
                 sender_name,
-                truncate_string(&formatted_content, 150)
+                truncate_string(&formatted_content(), 150)
             );
             (title, body)
         }
@@ -1181,13 +1254,13 @@ async fn create_fcm_payload(
     // guess the target's owner.
     insert_trigger_reference_fields(&mut data, event);
 
-    Ok(FcmPayload {
+    FcmPayload {
         notification: None, // Data-only message for better client control
         data: Some(data),
         android: None,
         webpush: None,
         apns: None,
-    })
+    }
 }
 
 /// Authoritative addressable target extracted from an event's `A`/`a` tag.
@@ -1350,6 +1423,14 @@ mod tests {
             nostr_client: Arc::new(Client::default()),
             profile_client: Arc::new(Client::default()),
             mention_parser_service: None,
+        }
+    }
+
+    /// Event-scoped copy for tests that exercise delivery rather than copy.
+    fn test_copy() -> EventScopedCopy {
+        EventScopedCopy {
+            sender_name: "tester".to_string(),
+            formatted_content: None,
         }
     }
 
@@ -1631,6 +1712,88 @@ mod tests {
     }
 
     #[test]
+    fn test_only_body_rendering_types_need_the_event_content() {
+        // The content parse is skipped when no target renders the body, so this
+        // has to stay in step with the arms of `create_fcm_payload` that call
+        // `formatted_content()`. A type added to one and not the other silently
+        // downgrades that push to raw, unparsed content.
+        assert!(renders_event_content(NotificationType::Comment));
+        assert!(renders_event_content(NotificationType::Mention));
+
+        assert!(!renders_event_content(NotificationType::Like));
+        assert!(!renders_event_content(NotificationType::Follow));
+        assert!(!renders_event_content(NotificationType::Repost));
+        assert!(!renders_event_content(NotificationType::NewPost));
+    }
+
+    #[test]
+    fn test_payload_uses_the_event_scoped_sender_name() {
+        let author = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let event = EventBuilder::new(Kind::from(KIND_VIDEO), "a new vine")
+            .tag(Tag::identifier("hoisted-sender"))
+            .sign_with_keys(&author)
+            .unwrap();
+        let copy = EventScopedCopy {
+            sender_name: "Alice".to_string(),
+            formatted_content: None,
+        };
+
+        let payload = create_fcm_payload(&event, &recipient, NotificationType::NewPost, &copy);
+        let data = payload.data.expect("data-only payload");
+
+        // The name resolved once for the event reaches the per-recipient push.
+        assert_eq!(data.get("senderName"), Some(&"Alice".to_string()));
+        assert_eq!(data.get("title"), Some(&"New vine".to_string()));
+        assert_eq!(
+            data.get("body"),
+            Some(&"Alice posted a new vine".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mention_body_prefers_the_resolved_content() {
+        let author = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let event = EventBuilder::text_note("hey nostr:npub1raw")
+            .sign_with_keys(&author)
+            .unwrap();
+        let copy = EventScopedCopy {
+            sender_name: "Alice".to_string(),
+            formatted_content: Some("hey @bob".to_string()),
+        };
+
+        let payload = create_fcm_payload(&event, &recipient, NotificationType::Mention, &copy);
+        let data = payload.data.expect("data-only payload");
+
+        assert_eq!(data.get("body"), Some(&"Alice: hey @bob".to_string()));
+    }
+
+    #[test]
+    fn test_mention_body_falls_back_to_raw_content() {
+        let author = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let event = EventBuilder::text_note("hey nostr:npub1raw")
+            .sign_with_keys(&author)
+            .unwrap();
+        // `None` is what a skipped or failed parse leaves behind. Before the
+        // hoist the per-recipient parse fell back to the raw content on error;
+        // that behaviour has to survive the move.
+        let copy = EventScopedCopy {
+            sender_name: "Alice".to_string(),
+            formatted_content: None,
+        };
+
+        let payload = create_fcm_payload(&event, &recipient, NotificationType::Mention, &copy);
+        let data = payload.data.expect("data-only payload");
+
+        assert_eq!(
+            data.get("body"),
+            Some(&"Alice: hey nostr:npub1raw".to_string())
+        );
+    }
+
+    #[test]
     fn test_mentioned_watcher_yields_exactly_one_mention_target() {
         let author = Keys::generate().public_key();
         let both = Keys::generate().public_key();
@@ -1786,6 +1949,7 @@ mod tests {
             &first_event,
             &recipient.public_key(),
             NotificationType::Mention,
+            &test_copy(),
             CancellationToken::new(),
         )
         .await
@@ -1810,6 +1974,7 @@ mod tests {
             &successful_edit,
             &recipient.public_key(),
             NotificationType::Mention,
+            &test_copy(),
             CancellationToken::new(),
         )
         .await
@@ -1834,6 +1999,7 @@ mod tests {
             &later_edit,
             &recipient.public_key(),
             NotificationType::Mention,
+            &test_copy(),
             CancellationToken::new(),
         )
         .await

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -805,6 +805,20 @@ fn renders_event_content(notification_type: NotificationType) -> bool {
 /// construction keeps the once-per-event property and restores the property the
 /// per-recipient version had for free: an event nobody can be pushed for costs
 /// no profile work at all.
+///
+/// What it gives up: the cell caches whatever `resolve_event_scoped_copy`
+/// returns, and that includes the short-npub fallback it returns when the
+/// profile lookup fails. On `main` the lookup sat inside `create_fcm_payload`,
+/// so one recipient's timeout did not spoil the next one's — each retried.
+/// Here the first recipient to resolve fixes the sender name for the whole
+/// fan-out, so a single timed-out lookup shows every remaining watcher a short
+/// npub instead of the creator's name.
+///
+/// That is the trade rather than an oversight. Retrying per recipient is what
+/// made one unreachable profile relay cost five seconds *per recipient*, and a
+/// bell fan-out is precisely where that multiplies. A degraded name on one
+/// event is cheaper than stalling the handler for every other user's
+/// notifications.
 struct LazyEventCopy {
     cell: tokio::sync::OnceCell<EventScopedCopy>,
     /// Whether any target renders the event body, decided over the whole target
@@ -1014,6 +1028,16 @@ fn video_recipient_claim_key(
 /// across edits. Without it, a watcher who was `p`-tagged in the original and
 /// dropped from an edit resolves to a bare `NewPost` target on the edit and is
 /// told "posted a new vine" about a video they were already pushed about.
+///
+/// The guarantee is per-replica, not global. An event and its edit carry
+/// different ids, so `try_claim_event` does not serialise them, and production
+/// runs two replicas: two handlers reaching the coordinate check in the same
+/// moment both read it absent and both send. What makes it hold on one replica
+/// is that `run` awaits `route_event` inline, so the original's record is
+/// written before the edit is read. Closing the cross-replica case means
+/// `SET NX EX` on the claim, which costs the same thing the rate-limit comment
+/// in `send_notification_to_user` declines to pay: a failed send would burn the
+/// record and that recipient would never get the push at all.
 ///
 /// Pure, so the rule is testable without Redis.
 fn satisfied_video_claims(notification_type: NotificationType) -> Vec<NotificationType> {

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -10,10 +10,13 @@ use firebase_messaging_rs::{
     },
     FCMClient as FirebaseClient,
 };
+use futures_util::{stream, StreamExt};
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, time::Duration};
 use thiserror::Error;
 use tracing;
+
+const FCM_BATCH_CONCURRENCY: usize = 100;
 
 #[derive(Error, Debug, Clone)]
 pub enum FcmError {
@@ -282,18 +285,24 @@ impl FcmClient {
         tokens: &[String],
         payload: FcmPayload,
     ) -> HashMap<String, std::result::Result<(), FcmError>> {
-        let mut results = HashMap::new();
-        for token in tokens {
-            // Delegate to the trait object's method
-            let result = self.client.send_single(token, payload.clone()).await;
-            results.insert(token.clone(), result);
-        }
+        let results = stream::iter(tokens.iter().cloned())
+            .map(|token| {
+                let payload = payload.clone();
+                async move {
+                    let result = self.client.send_single(&token, payload).await;
+                    (token, result)
+                }
+            })
+            .buffer_unordered(FCM_BATCH_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
         // Note: We are not returning a Result here anymore, but a HashMap of results.
         // The original code returned Result<HashMap<...>, FcmError> which seemed incorrect
         // as individual sends could fail without the whole batch failing.
         // If a top-level error IS needed (e.g., impossible to even start sending),
         // this signature might need adjustment, but usually, per-token results are desired.
-        results // Return the map directly
+        results.into_iter().collect()
     }
 
     /// Sends a notification payload to a single FCM token.

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -23,7 +23,7 @@ const KIND_PREFERENCES_UPDATE: u16 = 3083;
 /// NIP-51 people list carrying new-post ("bell") subscriptions.
 const KIND_NOTIFY_LIST: u16 = 30000;
 
-/// Build the notify-list filter.
+/// Build the notify-list filter for the historical rebuild.
 ///
 /// This must be a *separate* filter from the main kinds filter: an identifier
 /// constraint there would wrongly apply to every kind in the list. Subscribing
@@ -32,12 +32,29 @@ const KIND_NOTIFY_LIST: u16 = 30000;
 ///
 /// Deliberately unbounded in time. A notify list is replaceable, so one
 /// published months ago and never touched since is still current; a `since`
-/// bound would silently drop those subscriptions.
-fn notify_list_filter(limit: usize) -> Filter {
+/// bound would silently drop those subscriptions. `limit` is the safety valve
+/// on result size instead.
+fn notify_list_history_filter(limit: usize) -> Filter {
     Filter::new()
         .kind(Kind::from(KIND_NOTIFY_LIST))
         .identifier(crate::event_handler::NOTIFY_LIST_D_TAG)
         .limit(limit)
+}
+
+/// Build the notify-list filter for the live subscription.
+///
+/// Unlike the historical query this is bounded in time and carries no `limit`.
+/// Per NIP-01 a filter's `limit` applies to the initial stored-event query, so
+/// reusing the history filter here makes every subscribe — including the
+/// automatic resubscribe after a relay reconnect — replay up to `limit` stored
+/// lists that the historical pass already applied. The `since` window mirrors
+/// the main live filter and covers the gap between the historical fetch and the
+/// subscription taking effect.
+fn notify_list_live_filter(since: Timestamp) -> Filter {
+    Filter::new()
+        .kind(Kind::from(KIND_NOTIFY_LIST))
+        .identifier(crate::event_handler::NOTIFY_LIST_D_TAG)
+        .since(since)
 }
 
 pub struct NostrListener {
@@ -193,7 +210,7 @@ impl NostrListener {
         token: &CancellationToken,
     ) -> Result<()> {
         let limit = self.state.settings.service.notify_list_history_limit;
-        let filter = notify_list_filter(limit);
+        let filter = notify_list_history_filter(limit);
 
         info!(limit, "Querying historical notify lists...");
 
@@ -308,8 +325,7 @@ impl NostrListener {
         // Notify lists need their own subscription: `subscribe` takes one filter
         // per call, and the `#d` narrowing cannot be merged into the kinds
         // filter above without wrongly constraining every other kind.
-        let notify_filter =
-            notify_list_filter(self.state.settings.service.notify_list_history_limit);
+        let notify_filter = notify_list_live_filter(since);
 
         info!(
             "Subscribing to notify lists (kind {KIND_NOTIFY_LIST}, d={})",

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -9,6 +9,7 @@ use crate::{
     state::AppState,
 };
 use nostr_sdk::prelude::*;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
@@ -30,15 +31,19 @@ const KIND_NOTIFY_LIST: u16 = 30000;
 /// to all of kind 30000 without the `#d` narrowing would pull every people list
 /// on the relay.
 ///
-/// Deliberately unbounded in time. A notify list is replaceable, so one
-/// published months ago and never touched since is still current; a `since`
-/// bound would silently drop those subscriptions. `limit` is the safety valve
-/// on result size instead.
-fn notify_list_history_filter(limit: usize) -> Filter {
-    Filter::new()
+/// Deliberately unbounded by `since`. A notify list is replaceable, so one
+/// published months ago and never touched since is still current. Historical
+/// rebuild pages backward with `until` instead of trusting one relay-limited
+/// fetch to contain every current list.
+fn notify_list_history_filter(limit: usize, until: Option<Timestamp>) -> Filter {
+    let filter = Filter::new()
         .kind(Kind::from(KIND_NOTIFY_LIST))
         .identifier(crate::event_handler::NOTIFY_LIST_D_TAG)
-        .limit(limit)
+        .limit(limit);
+    match until {
+        Some(until) => filter.until(until),
+        None => filter,
+    }
 }
 
 /// Build the notify-list filter for the live subscription.
@@ -210,60 +215,92 @@ impl NostrListener {
         token: &CancellationToken,
     ) -> Result<()> {
         let limit = self.state.settings.service.notify_list_history_limit;
-        let filter = notify_list_history_filter(limit);
+        let mut until = None;
+        let mut seen = HashSet::new();
+        let mut total = 0usize;
 
         info!(limit, "Querying historical notify lists...");
 
-        tokio::select! {
-            biased;
-            _ = token.cancelled() => {
-                info!("Cancelled before historical notify-list query");
-                return Ok(());
-            }
-            fetch_result = self.state.nostr_client.fetch_events(filter, Duration::from_secs(60)) => {
-                match fetch_result {
-                    Ok(lists) => {
-                        let count = lists.len();
-                        if count >= limit {
-                            warn!(
-                                count,
-                                limit,
-                                "Historical notify-list query hit its limit; some subscriptions may be missing"
-                            );
+        loop {
+            let filter = notify_list_history_filter(limit, until);
+
+            let lists = tokio::select! {
+                biased;
+                _ = token.cancelled() => {
+                    info!("Cancelled before historical notify-list query");
+                    return Ok(());
+                }
+                fetch_result = self.state.nostr_client.fetch_events(filter, Duration::from_secs(60)) => {
+                    match fetch_result {
+                        Ok(lists) => lists,
+                        Err(e) => {
+                            error!("Failed to query historical notify lists: {}", e);
+                            warn!("Proceeding with partial historical notify-list replay - existing bells may not deliver until republished");
+                            break;
                         }
-                        info!(count, "Processing historical notify lists...");
-
-                        for event in lists {
-                            if event.pubkey == *service_pubkey {
-                                continue;
-                            }
-
-                            tokio::select! {
-                                biased;
-                                _ = token.cancelled() => {
-                                    info!("Cancelled during historical notify-list processing");
-                                    return Ok(());
-                                }
-                                send_res = event_tx.send((Box::new(event), EventContext::Historical)) => {
-                                    if let Err(e) = send_res {
-                                        error!("Failed to send historical notify list: {}", e);
-                                        return Err(ServiceError::Internal(
-                                            "Event handler channel closed".to_string()
-                                        ));
-                                    }
-                                }
-                            }
-                        }
-
-                        info!("Finished processing historical notify lists");
                     }
-                    Err(e) => {
-                        error!("Failed to query historical notify lists: {}", e);
-                        warn!("Proceeding without historical notify lists - existing bells will not deliver until republished");
+                }
+            };
+
+            let count = lists.len();
+            if count == 0 {
+                break;
+            }
+            info!(count, total, until = ?until, "Processing historical notify-list page...");
+
+            let mut oldest = None;
+            let mut new_count = 0usize;
+            for event in lists {
+                oldest = match oldest {
+                    Some(current) if current <= event.created_at => Some(current),
+                    _ => Some(event.created_at),
+                };
+
+                if !seen.insert(event.id) {
+                    continue;
+                }
+                new_count += 1;
+                total += 1;
+
+                if event.pubkey == *service_pubkey {
+                    continue;
+                }
+
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => {
+                        info!("Cancelled during historical notify-list processing");
+                        return Ok(());
+                    }
+                    send_res = event_tx.send((Box::new(event), EventContext::Historical)) => {
+                        if let Err(e) = send_res {
+                            error!("Failed to send historical notify list: {}", e);
+                            return Err(ServiceError::Internal(
+                                "Event handler channel closed".to_string()
+                            ));
+                        }
                     }
                 }
             }
+
+            if count < limit {
+                break;
+            }
+
+            if new_count == 0 {
+                warn!(
+                    count,
+                    limit,
+                    until = ?until,
+                    "Historical notify-list pagination made no progress; some subscriptions may be missing"
+                );
+                break;
+            }
+
+            until = oldest;
         }
+
+        info!(count = total, "Finished processing historical notify lists");
 
         Ok(())
     }

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -20,6 +20,26 @@ const KIND_REGISTRATION: u16 = 3079;
 const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
 
+/// NIP-51 people list carrying new-post ("bell") subscriptions.
+const KIND_NOTIFY_LIST: u16 = 30000;
+
+/// Build the notify-list filter.
+///
+/// This must be a *separate* filter from the main kinds filter: an identifier
+/// constraint there would wrongly apply to every kind in the list. Subscribing
+/// to all of kind 30000 without the `#d` narrowing would pull every people list
+/// on the relay.
+///
+/// Deliberately unbounded in time. A notify list is replaceable, so one
+/// published months ago and never touched since is still current; a `since`
+/// bound would silently drop those subscriptions.
+fn notify_list_filter(limit: usize) -> Filter {
+    Filter::new()
+        .kind(Kind::from(KIND_NOTIFY_LIST))
+        .identifier(crate::event_handler::NOTIFY_LIST_D_TAG)
+        .limit(limit)
+}
+
 pub struct NostrListener {
     state: Arc<AppState>,
 }
@@ -157,6 +177,77 @@ impl NostrListener {
             }
         }
 
+        self.process_historical_notify_lists(event_tx, service_pubkey, token)
+            .await
+    }
+
+    /// Replay notify lists from history.
+    ///
+    /// Mandatory, not an optimization: the reverse index lives only in Redis, so
+    /// without this a restart against a fresh Redis silently drops every bell
+    /// until each user happens to republish their list.
+    async fn process_historical_notify_lists(
+        &self,
+        event_tx: &Sender<(Box<Event>, EventContext)>,
+        service_pubkey: &PublicKey,
+        token: &CancellationToken,
+    ) -> Result<()> {
+        let limit = self.state.settings.service.notify_list_history_limit;
+        let filter = notify_list_filter(limit);
+
+        info!(limit, "Querying historical notify lists...");
+
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => {
+                info!("Cancelled before historical notify-list query");
+                return Ok(());
+            }
+            fetch_result = self.state.nostr_client.fetch_events(filter, Duration::from_secs(60)) => {
+                match fetch_result {
+                    Ok(lists) => {
+                        let count = lists.len();
+                        if count >= limit {
+                            warn!(
+                                count,
+                                limit,
+                                "Historical notify-list query hit its limit; some subscriptions may be missing"
+                            );
+                        }
+                        info!(count, "Processing historical notify lists...");
+
+                        for event in lists {
+                            if event.pubkey == *service_pubkey {
+                                continue;
+                            }
+
+                            tokio::select! {
+                                biased;
+                                _ = token.cancelled() => {
+                                    info!("Cancelled during historical notify-list processing");
+                                    return Ok(());
+                                }
+                                send_res = event_tx.send((Box::new(event), EventContext::Historical)) => {
+                                    if let Err(e) = send_res {
+                                        error!("Failed to send historical notify list: {}", e);
+                                        return Err(ServiceError::Internal(
+                                            "Event handler channel closed".to_string()
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+
+                        info!("Finished processing historical notify lists");
+                    }
+                    Err(e) => {
+                        error!("Failed to query historical notify lists: {}", e);
+                        warn!("Proceeding without historical notify lists - existing bells will not deliver until republished");
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -208,6 +299,36 @@ impl NostrListener {
                     }
                     Err(e) => {
                         error!("Failed to subscribe to notification kinds: {}", e);
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+
+        // Notify lists need their own subscription: `subscribe` takes one filter
+        // per call, and the `#d` narrowing cannot be merged into the kinds
+        // filter above without wrongly constraining every other kind.
+        let notify_filter =
+            notify_list_filter(self.state.settings.service.notify_list_history_limit);
+
+        info!(
+            "Subscribing to notify lists (kind {KIND_NOTIFY_LIST}, d={})",
+            crate::event_handler::NOTIFY_LIST_D_TAG
+        );
+
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => {
+                info!("Cancelled before notify-list subscription");
+                return Ok(());
+            }
+            sub_result = self.state.nostr_client.subscribe(notify_filter, None) => {
+                match sub_result {
+                    Ok(_output) => {
+                        info!("Successfully subscribed to notify lists");
+                    }
+                    Err(e) => {
+                        error!("Failed to subscribe to notify lists: {}", e);
                         return Err(e.into());
                     }
                 }

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -25,6 +25,7 @@ impl Default for UserPreferences {
                 7,     // Reactions/likes
                 16,    // Reposts
                 30023, // Long-form content
+                34236, // Videos from subscribed creators (new-post "bells")
             ],
         }
     }
@@ -53,6 +54,12 @@ pub enum NotificationType {
     Follow,
     Mention,
     Repost,
+    /// A creator the recipient subscribed to published a new video.
+    ///
+    /// Unlike every other variant this is not triggered by someone acting on the
+    /// recipient's content, so its recipients come from the notify-list reverse
+    /// index rather than the trigger event's `p` tags.
+    NewPost,
 }
 
 impl NotificationType {
@@ -64,6 +71,9 @@ impl NotificationType {
             NotificationType::Follow => 3,
             NotificationType::Mention => 1, // Same as Comment - both are kind 1
             NotificationType::Repost => 16,
+            // Distinct from Mention's kind 1 even though video mentions also
+            // arrive on kind 34236 events, so the two toggle independently.
+            NotificationType::NewPost => 34236,
         }
     }
 
@@ -80,6 +90,7 @@ impl NotificationType {
             NotificationType::Follow => "follow",
             NotificationType::Mention => "mention",
             NotificationType::Repost => "repost",
+            NotificationType::NewPost => "newPost",
         }
     }
 }
@@ -219,6 +230,44 @@ mod tests {
         let prefs_without_1 = UserPreferences { kinds: vec![7, 16] };
         assert!(!NotificationType::Comment.is_enabled(&prefs_without_1));
         assert!(!NotificationType::Mention.is_enabled(&prefs_without_1));
+    }
+
+    #[test]
+    fn test_new_post_kind_is_video_kind() {
+        assert_eq!(NotificationType::NewPost.kind(), 34236);
+    }
+
+    #[test]
+    fn test_new_post_display_name_is_wire_contract() {
+        // divine-mobile matches this exact string in notificationKindFromPushType.
+        assert_eq!(NotificationType::NewPost.display_name(), "newPost");
+    }
+
+    #[test]
+    fn test_new_post_disabled_when_prefs_omit_video_kind() {
+        let prefs = UserPreferences {
+            kinds: vec![1, 3, 7, 16, 30023],
+        };
+        assert!(!NotificationType::NewPost.is_enabled(&prefs));
+    }
+
+    #[test]
+    fn test_new_post_enabled_under_shipped_defaults() {
+        let prefs = UserPreferences::default();
+        assert!(NotificationType::NewPost.is_enabled(&prefs));
+    }
+
+    #[test]
+    fn test_new_post_and_mention_toggle_independently() {
+        // Mention is kind 1, NewPost is 34236, so a user can mute new-post
+        // pushes without muting video mentions.
+        let only_mentions = UserPreferences { kinds: vec![1] };
+        assert!(NotificationType::Mention.is_enabled(&only_mentions));
+        assert!(!NotificationType::NewPost.is_enabled(&only_mentions));
+
+        let only_new_posts = UserPreferences { kinds: vec![34236] };
+        assert!(!NotificationType::Mention.is_enabled(&only_new_posts));
+        assert!(NotificationType::NewPost.is_enabled(&only_new_posts));
     }
 
     #[test]

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -316,6 +316,16 @@ pub fn build_notify_rate_key(subscriber: &PublicKey, creator: &PublicKey) -> Str
 /// would still race. Returns `false` when the incoming event was rejected as
 /// stale or duplicate, `true` when it was applied.
 ///
+/// The atomicity is load-bearing because production runs more than one replica.
+/// `try_claim_event` only prevents two replicas handling the *same* event; two
+/// different list events from one subscriber can still land concurrently, and a
+/// read-then-write would let the older one win. A single replica needs none of
+/// this — its handler loop is sequential.
+///
+/// `creators` must already be bounded by the caller
+/// (`notify_list_max_creators`): the script runs as one blocking unit and Redis
+/// is single-threaded, so an unbounded list stalls the instance for every user.
+///
 /// Not Redis Cluster safe: the script writes `notify_watchers:*` keys that are
 /// not declared in `KEYS`, because the set of creators is only known from the
 /// event body. This deployment uses single-instance Redis (see

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -338,6 +338,25 @@ pub fn build_notify_rate_key(subscriber: &PublicKey, creator: &PublicKey) -> Str
 /// read-then-write would let the older one win. A single replica needs none of
 /// this — its handler loop is sequential.
 ///
+/// Atomic is not transactional, though: Redis runs the script without
+/// interleaving anything else, but a script that dies partway through keeps the
+/// writes it already made. So the write order holds one invariant at every
+/// intermediate step — every `notify_watchers:{creator}` naming this subscriber
+/// has `creator` in `notify_subs:{subscriber}`. Removals clear the reverse
+/// index before the forward one and additions write the forward index first,
+/// which leaves a half-applied script with `notify_subs` a *superset* of the
+/// true relation. The next list reconciles that, because removals are computed
+/// from it.
+///
+/// The opposite skew does not recover, which is why the forward set is diffed
+/// rather than `DEL`d and rebuilt. `notify_subs` is the only record of which
+/// `notify_watchers:*` keys hold this subscriber, so once it is short, the
+/// missing creators are unreachable: `previous` comes back without them, their
+/// `SREM` is never issued, and the subscriber keeps getting pushes for a
+/// creator they unbelled. Republishing the list they actually hold does not
+/// help — only re-belling that exact creator and unbelling again would, which
+/// is not something a user would think to do.
+///
 /// `creators` must already be bounded by the caller
 /// (`notify_list_max_creators`): the script runs as one blocking unit and Redis
 /// is single-threaded, so an unbounded list stalls the instance for every user.
@@ -394,17 +413,21 @@ pub async fn replace_notify_subscriptions(
           incoming[ARGV[i]] = true
         end
 
-        -- Drop the subscriber from creators no longer on the list.
+        -- Drop the subscriber from creators no longer on the list, reverse
+        -- index first. Applying the difference rather than replacing the
+        -- forward set wholesale is what keeps a half-applied script
+        -- recoverable; see the ordering note in the function doc. An empty
+        -- incoming list is legitimate (the user unbelled everyone) and Redis
+        -- drops the key once its last member is removed.
         local previous = redis.call('SMEMBERS', KEYS[1])
         for _, creator in ipairs(previous) do
           if not incoming[creator] then
             redis.call('SREM', prefix .. creator, subscriber)
+            redis.call('SREM', KEYS[1], creator)
           end
         end
 
-        -- Replace the forward set wholesale. An empty incoming list is
-        -- legitimate (the user unbelled everyone) and clears the key.
-        redis.call('DEL', KEYS[1])
+        -- Add the new ones, forward index first, for the same reason.
         for i = 5, #ARGV do
           redis.call('SADD', KEYS[1], ARGV[i])
           redis.call('SADD', prefix .. ARGV[i], subscriber)

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -278,6 +278,147 @@ pub async fn try_claim_event(
 }
 
 // =============================================================================
+// Notify Subscriptions ("bells")
+// =============================================================================
+
+/// Forward index: creators this subscriber has belled.
+fn build_notify_subs_key(subscriber: &PublicKey) -> String {
+    format!("notify_subs:{}", subscriber.to_hex())
+}
+
+/// `created_at` of the last applied notify-list event for this subscriber.
+fn build_notify_subs_ts_key(subscriber: &PublicKey) -> String {
+    format!("notify_subs_ts:{}", subscriber.to_hex())
+}
+
+/// Prefix of the reverse index. Kept as a prefix (not a built key) because the
+/// Lua script below composes watcher keys from it.
+const NOTIFY_WATCHERS_PREFIX: &str = "notify_watchers:";
+
+/// Reverse index: subscribers watching this creator. The hot read path.
+fn build_notify_watchers_key(creator: &PublicKey) -> String {
+    format!("{}{}", NOTIFY_WATCHERS_PREFIX, creator.to_hex())
+}
+
+/// Rate-limit window marker for one (subscriber, creator) pair.
+pub fn build_notify_rate_key(subscriber: &PublicKey, creator: &PublicKey) -> String {
+    format!("notify_rate:{}:{}", subscriber.to_hex(), creator.to_hex())
+}
+
+/// Diff-and-apply a replacement notify list atomically.
+///
+/// `notify_subs` and `notify_watchers` are two views of the same relation and
+/// must move together, so the whole diff runs in one Lua script rather than a
+/// read-then-write from the caller.
+///
+/// The script re-checks the stored `created_at` internally: a relay can deliver
+/// an older replacement after a newer one, and an advisory check in the caller
+/// would still race. Returns `false` when the incoming event was rejected as
+/// stale or duplicate, `true` when it was applied.
+///
+/// Not Redis Cluster safe: the script writes `notify_watchers:*` keys that are
+/// not declared in `KEYS`, because the set of creators is only known from the
+/// event body. This deployment uses single-instance Redis (see
+/// `docker-compose.yml`); moving to Cluster requires resharding this into one
+/// call per creator slot or a hash-tagged key layout.
+pub async fn replace_notify_subscriptions(
+    pool: &RedisPool,
+    subscriber: &PublicKey,
+    creators: &[PublicKey],
+    created_at: u64,
+) -> Result<bool> {
+    const REPLACE_SCRIPT: &str = r#"
+        local stored = redis.call('GET', KEYS[2])
+        if stored and tonumber(stored) >= tonumber(ARGV[1]) then
+          return 0
+        end
+
+        local prefix = ARGV[2]
+        local subscriber = ARGV[3]
+
+        local incoming = {}
+        for i = 4, #ARGV do
+          incoming[ARGV[i]] = true
+        end
+
+        -- Drop the subscriber from creators no longer on the list.
+        local previous = redis.call('SMEMBERS', KEYS[1])
+        for _, creator in ipairs(previous) do
+          if not incoming[creator] then
+            redis.call('SREM', prefix .. creator, subscriber)
+          end
+        end
+
+        -- Replace the forward set wholesale. An empty incoming list is
+        -- legitimate (the user unbelled everyone) and clears the key.
+        redis.call('DEL', KEYS[1])
+        for i = 4, #ARGV do
+          redis.call('SADD', KEYS[1], ARGV[i])
+          redis.call('SADD', prefix .. ARGV[i], subscriber)
+        end
+
+        redis.call('SET', KEYS[2], ARGV[1])
+        return 1
+    "#;
+
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    let script = redis::Script::new(REPLACE_SCRIPT);
+    let mut invocation = script.prepare_invoke();
+    invocation
+        .key(build_notify_subs_key(subscriber))
+        .key(build_notify_subs_ts_key(subscriber))
+        .arg(created_at)
+        .arg(NOTIFY_WATCHERS_PREFIX)
+        .arg(subscriber.to_hex());
+    for creator in creators {
+        invocation.arg(creator.to_hex());
+    }
+
+    let applied: i64 = invocation
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    Ok(applied == 1)
+}
+
+/// Read the subscribers watching `creator`.
+///
+/// Unparseable members are skipped with a warning rather than failing the whole
+/// lookup, so one corrupt entry cannot block delivery to everyone else.
+pub async fn get_notify_watchers(pool: &RedisPool, creator: &PublicKey) -> Result<Vec<PublicKey>> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    let members: Vec<String> = redis::cmd("SMEMBERS")
+        .arg(build_notify_watchers_key(creator))
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    let mut watchers = Vec::with_capacity(members.len());
+    for member in members {
+        match PublicKey::from_hex(&member) {
+            Ok(pubkey) => watchers.push(pubkey),
+            Err(e) => tracing::warn!(
+                creator = %creator.to_hex(),
+                member = %member,
+                error = %e,
+                "Skipping unparseable notify watcher"
+            ),
+        }
+    }
+
+    Ok(watchers)
+}
+
+// =============================================================================
 // Caching
 // =============================================================================
 

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -286,7 +286,9 @@ fn build_notify_subs_key(subscriber: &PublicKey) -> String {
     format!("notify_subs:{}", subscriber.to_hex())
 }
 
-/// `created_at` of the last applied notify-list event for this subscriber.
+/// `created_at:event_id` of the last applied notify-list event for this
+/// subscriber. The id is carried so a `created_at` tie can resolve the way
+/// NIP-01 resolves it, by lowest event id.
 fn build_notify_subs_ts_key(subscriber: &PublicKey) -> String {
     format!("notify_subs_ts:{}", subscriber.to_hex())
 }
@@ -316,6 +318,20 @@ pub fn build_notify_rate_key(subscriber: &PublicKey, creator: &PublicKey) -> Str
 /// would still race. Returns `false` when the incoming event was rejected as
 /// stale or duplicate, `true` when it was applied.
 ///
+/// Ties on `created_at` resolve the way NIP-01 resolves them: "in case of
+/// replaceable events with the same timestamp, the event with the lowest id
+/// (first in lexical order) should be retained". Resolving by arrival order
+/// instead would let this service and the relay hold permanently different
+/// lists — a rebuild from relay history would then disagree with what we served
+/// live. Note the direction: an incoming event with an *equal* timestamp wins
+/// only when its id sorts *below* the stored one, which reads backwards from
+/// "newer wins". An exact replay (same timestamp, same id) is still rejected.
+///
+/// `notify_subs_ts` therefore stores `created_at:event_id`. A bare integer left
+/// by an earlier build is read as a timestamp with no known id, which can only
+/// make the guard more conservative: ties against it are rejected, exactly as
+/// they were before.
+///
 /// The atomicity is load-bearing because production runs more than one replica.
 /// `try_claim_event` only prevents two replicas handling the *same* event; two
 /// different list events from one subscriber can still land concurrently, and a
@@ -336,18 +352,45 @@ pub async fn replace_notify_subscriptions(
     subscriber: &PublicKey,
     creators: &[PublicKey],
     created_at: u64,
+    event_id: &EventId,
 ) -> Result<bool> {
     const REPLACE_SCRIPT: &str = r#"
+        local incoming_at = tonumber(ARGV[1])
+        local incoming_id = ARGV[4]
+
         local stored = redis.call('GET', KEYS[2])
-        if stored and tonumber(stored) >= tonumber(ARGV[1]) then
-          return 0
+        if stored then
+          -- `created_at:event_id`, or a bare integer written by an earlier
+          -- build. An unparseable value is treated as absent rather than
+          -- wedging the subscriber's list forever.
+          local stored_at, stored_id = string.match(stored, '^(%d+):(%x+)$')
+          if stored_at then
+            stored_at = tonumber(stored_at)
+          else
+            stored_at = tonumber(stored)
+            stored_id = nil
+          end
+
+          if stored_at then
+            if stored_at > incoming_at then
+              return 0
+            end
+            if stored_at == incoming_at then
+              -- NIP-01 retains the lowest id on a tie, so the incoming event
+              -- has to sort strictly below the stored one. With no stored id
+              -- there is nothing to compare, so the tie stays rejected.
+              if not stored_id or incoming_id >= stored_id then
+                return 0
+              end
+            end
+          end
         end
 
         local prefix = ARGV[2]
         local subscriber = ARGV[3]
 
         local incoming = {}
-        for i = 4, #ARGV do
+        for i = 5, #ARGV do
           incoming[ARGV[i]] = true
         end
 
@@ -362,12 +405,14 @@ pub async fn replace_notify_subscriptions(
         -- Replace the forward set wholesale. An empty incoming list is
         -- legitimate (the user unbelled everyone) and clears the key.
         redis.call('DEL', KEYS[1])
-        for i = 4, #ARGV do
+        for i = 5, #ARGV do
           redis.call('SADD', KEYS[1], ARGV[i])
           redis.call('SADD', prefix .. ARGV[i], subscriber)
         end
 
-        redis.call('SET', KEYS[2], ARGV[1])
+        -- ARGV[1] verbatim rather than `incoming_at`, so the stored timestamp
+        -- is the caller's decimal string and never Lua's float formatting.
+        redis.call('SET', KEYS[2], ARGV[1] .. ':' .. incoming_id)
         return 1
     "#;
 
@@ -383,7 +428,8 @@ pub async fn replace_notify_subscriptions(
         .key(build_notify_subs_ts_key(subscriber))
         .arg(created_at)
         .arg(NOTIFY_WATCHERS_PREFIX)
-        .arg(subscriber.to_hex());
+        .arg(subscriber.to_hex())
+        .arg(event_id.to_hex());
     for creator in creators {
         invocation.arg(creator.to_hex());
     }

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -325,7 +325,8 @@ pub fn build_notify_rate_key(subscriber: &PublicKey, creator: &PublicKey) -> Str
 /// lists — a rebuild from relay history would then disagree with what we served
 /// live. Note the direction: an incoming event with an *equal* timestamp wins
 /// only when its id sorts *below* the stored one, which reads backwards from
-/// "newer wins". An exact replay (same timestamp, same id) is still rejected.
+/// "newer wins". An exact replay (same timestamp, same id) is allowed through
+/// as an idempotent repair path for startup rebuilds.
 ///
 /// `notify_subs_ts` therefore stores `created_at:event_id`. A bare integer left
 /// by an earlier build is read as a timestamp with no known id, which can only
@@ -396,9 +397,10 @@ pub async fn replace_notify_subscriptions(
             end
             if stored_at == incoming_at then
               -- NIP-01 retains the lowest id on a tie, so the incoming event
-              -- has to sort strictly below the stored one. With no stored id
-              -- there is nothing to compare, so the tie stays rejected.
-              if not stored_id or incoming_id >= stored_id then
+              -- has to sort below the stored one, or be the exact same event
+              -- replayed during a rebuild. With no stored id there is nothing
+              -- to compare, so the tie stays rejected.
+              if not stored_id or incoming_id > stored_id then
                 return 0
               end
             end
@@ -419,8 +421,10 @@ pub async fn replace_notify_subscriptions(
         -- recoverable; see the ordering note in the function doc. An empty
         -- incoming list is legitimate (the user unbelled everyone) and Redis
         -- drops the key once its last member is removed.
+        local had_previous = {}
         local previous = redis.call('SMEMBERS', KEYS[1])
         for _, creator in ipairs(previous) do
+          had_previous[creator] = true
           if not incoming[creator] then
             redis.call('SREM', prefix .. creator, subscriber)
             redis.call('SREM', KEYS[1], creator)
@@ -429,8 +433,16 @@ pub async fn replace_notify_subscriptions(
 
         -- Add the new ones, forward index first, for the same reason.
         for i = 5, #ARGV do
-          redis.call('SADD', KEYS[1], ARGV[i])
-          redis.call('SADD', prefix .. ARGV[i], subscriber)
+          local creator = ARGV[i]
+          if not had_previous[creator] then
+            redis.call('SADD', KEYS[1], creator)
+            redis.call('SADD', prefix .. creator, subscriber)
+          else
+            -- Exact replays are allowed as repair. Re-assert the reverse entry
+            -- in case Redis lost `notify_watchers:*` while `notify_subs:*`
+            -- survived.
+            redis.call('SADD', prefix .. creator, subscriber)
+          end
         end
 
         -- ARGV[1] verbatim rather than `incoming_at`, so the stored timestamp

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -474,7 +474,13 @@ pub async fn replace_notify_subscriptions(
     Ok(applied == 1)
 }
 
-/// Read the subscribers watching `creator`.
+/// Read every subscriber watching `creator` in one `SMEMBERS`.
+///
+/// **Not the fan-out read.** Delivery pages with `get_notify_watchers_page`,
+/// and the bell fallback asks `is_notify_watcher`; this is the unbounded read
+/// both of those exist to keep off the hot path, and it has no caller in `src/`.
+/// It survives as the whole-set assertion helper the notify-list tests are
+/// written against. Do not reintroduce it into delivery.
 ///
 /// Unparseable members are skipped with a warning rather than failing the whole
 /// lookup, so one corrupt entry cannot block delivery to everyone else.

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -12,6 +12,7 @@ use bb8_redis::bb8::Pool;
 use bb8_redis::RedisConnectionManager;
 use nostr_sdk::{EventId, PublicKey, Timestamp};
 use redis::{RedisResult, Value};
+use std::collections::HashSet;
 use std::time::Duration;
 
 // Type alias for the connection pool
@@ -505,14 +506,69 @@ pub async fn get_notify_watchers(pool: &RedisPool, creator: &PublicKey) -> Resul
     Ok(watchers)
 }
 
+/// One page of subscribers watching a creator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotifyWatcherPage {
+    pub watchers: Vec<PublicKey>,
+    pub next_cursor: u64,
+}
+
+/// Read one SSCAN page of subscribers watching `creator`.
+///
+/// The video fan-out path loops over pages so each Redis read and delivery
+/// batch stays bounded without dropping subscribers beyond a permanent cap.
+/// Unparseable members are skipped with a warning rather than failing the page.
+pub async fn get_notify_watchers_page(
+    pool: &RedisPool,
+    creator: &PublicKey,
+    cursor: u64,
+    count: usize,
+) -> Result<NotifyWatcherPage> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    let (next_cursor, members): (u64, Vec<String>) = redis::cmd("SSCAN")
+        .arg(build_notify_watchers_key(creator))
+        .arg(cursor)
+        .arg("COUNT")
+        .arg(count)
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    let mut seen = HashSet::with_capacity(members.len());
+    let mut watchers = Vec::with_capacity(members.len());
+    for member in members {
+        match PublicKey::from_hex(&member) {
+            Ok(pubkey) => {
+                if seen.insert(pubkey) {
+                    watchers.push(pubkey);
+                }
+            }
+            Err(e) => tracing::warn!(
+                creator = %creator.to_hex(),
+                member = %member,
+                error = %e,
+                "Skipping unparseable notify watcher"
+            ),
+        }
+    }
+
+    Ok(NotifyWatcherPage {
+        watchers,
+        next_cursor,
+    })
+}
+
 /// Test whether `subscriber` watches `creator`.
 ///
 /// The membership question on its own. The bell fallback in
 /// `send_notification_to_user` asks it per muted-mention recipient, and it is
 /// the whole answer it needs, so it must not pay `get_notify_watchers`'s
-/// transfer-and-parse of a creator's entire watcher set. `SISMEMBER` answers in
-/// the server. `get_notify_watchers` stays the read for the fan-out, which does
-/// need every member.
+/// transfer-and-parse of a creator's entire watcher set. `SISMEMBER` answers
+/// in the server. Fan-out reads use `get_notify_watchers_page`.
 pub async fn is_notify_watcher(
     pool: &RedisPool,
     creator: &PublicKey,

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -509,6 +509,32 @@ pub async fn get_notify_watchers(pool: &RedisPool, creator: &PublicKey) -> Resul
     Ok(watchers)
 }
 
+/// Test whether `subscriber` watches `creator`.
+///
+/// The membership question on its own. The bell fallback in
+/// `send_notification_to_user` asks it per muted-mention recipient, and it is
+/// the whole answer it needs, so it must not pay `get_notify_watchers`'s
+/// transfer-and-parse of a creator's entire watcher set. `SISMEMBER` answers in
+/// the server. `get_notify_watchers` stays the read for the fan-out, which does
+/// need every member.
+pub async fn is_notify_watcher(
+    pool: &RedisPool,
+    creator: &PublicKey,
+    subscriber: &PublicKey,
+) -> Result<bool> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    redis::cmd("SISMEMBER")
+        .arg(build_notify_watchers_key(creator))
+        .arg(subscriber.to_hex())
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)
+}
+
 // =============================================================================
 // Caching
 // =============================================================================

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -421,28 +421,24 @@ pub async fn replace_notify_subscriptions(
         -- recoverable; see the ordering note in the function doc. An empty
         -- incoming list is legitimate (the user unbelled everyone) and Redis
         -- drops the key once its last member is removed.
-        local had_previous = {}
         local previous = redis.call('SMEMBERS', KEYS[1])
         for _, creator in ipairs(previous) do
-          had_previous[creator] = true
           if not incoming[creator] then
             redis.call('SREM', prefix .. creator, subscriber)
             redis.call('SREM', KEYS[1], creator)
           end
         end
 
-        -- Add the new ones, forward index first, for the same reason.
+        -- Add the new ones, forward index first, for the same reason. Both
+        -- writes are unconditional, and the second one is why: re-asserting the
+        -- reverse entry for a creator already on the forward set is exactly
+        -- what lets an exact replay repair a `notify_watchers:*` that Redis
+        -- lost while `notify_subs:*` survived. Skipping either write when the
+        -- creator "is already applied" would take that repair away, and the
+        -- forward `SADD` it would save is a no-op on a member anyway.
         for i = 5, #ARGV do
-          local creator = ARGV[i]
-          if not had_previous[creator] then
-            redis.call('SADD', KEYS[1], creator)
-            redis.call('SADD', prefix .. creator, subscriber)
-          else
-            -- Exact replays are allowed as repair. Re-assert the reverse entry
-            -- in case Redis lost `notify_watchers:*` while `notify_subs:*`
-            -- survived.
-            redis.call('SADD', prefix .. creator, subscriber)
-          end
+          redis.call('SADD', KEYS[1], ARGV[i])
+          redis.call('SADD', prefix .. ARGV[i], subscriber)
         end
 
         -- ARGV[1] verbatim rather than `incoming_at`, so the stored timestamp

--- a/tests/event_claim_test.rs
+++ b/tests/event_claim_test.rs
@@ -122,8 +122,8 @@ async fn test_a_standing_claim_would_have_skipped_the_replayed_list() {
 #[tokio::test]
 async fn test_a_replayed_list_still_applies_without_a_claim() {
     // The other half: with the claim out of the way, re-applying the same list
-    // is safe. `replace_notify_subscriptions` rejects the duplicate on
-    // `created_at` and leaves the index intact, which is why the claim was
+    // is safe. `replace_notify_subscriptions` treats the duplicate as an
+    // idempotent repair and leaves the index intact, which is why the claim was
     // never load-bearing here.
     let Some(pool) = create_test_pool().await else {
         return;
@@ -170,7 +170,7 @@ async fn test_a_replayed_list_still_applies_without_a_claim() {
     }
 
     assert!(applied, "the list applies the first time");
-    assert!(!reapplied, "the duplicate is rejected on created_at");
+    assert!(reapplied, "the duplicate is safe to replay for repair");
     assert_eq!(
         watchers,
         vec![subscriber],

--- a/tests/event_claim_test.rs
+++ b/tests/event_claim_test.rs
@@ -132,12 +132,16 @@ async fn test_a_replayed_list_still_applies_without_a_claim() {
     let subscriber = Keys::generate().public_key();
     let creator = Keys::generate().public_key();
     let created_at = Timestamp::now().as_secs();
+    // A replay is the same event arriving twice, so both calls carry the same
+    // id — which is also what makes the guard's tie-break reject the second.
+    let event_id = list_event("notify").id;
 
     let applied = redis_store::replace_notify_subscriptions(
         &pool,
         &subscriber,
         std::slice::from_ref(&creator),
         created_at,
+        &event_id,
     )
     .await
     .expect("first apply");
@@ -147,6 +151,7 @@ async fn test_a_replayed_list_still_applies_without_a_claim() {
         &subscriber,
         std::slice::from_ref(&creator),
         created_at,
+        &event_id,
     )
     .await
     .expect("replayed apply");

--- a/tests/event_claim_test.rs
+++ b/tests/event_claim_test.rs
@@ -1,0 +1,190 @@
+// ABOUTME: Covers the notify-list exemption from the handler loop's event claim.
+// ABOUTME: Redis-backed cases skip cleanly when Redis is unavailable, per the dedup_test convention.
+
+use divine_push_service::{event_handler, redis_store};
+use nostr_sdk::prelude::*;
+use std::time::Duration;
+
+async fn create_test_pool() -> Option<redis_store::RedisPool> {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    match redis_store::create_pool(&redis_url, 5).await {
+        Ok(pool) => {
+            let mut conn = match pool.get().await {
+                Ok(conn) => conn,
+                Err(_) => {
+                    println!("Skipping test: Redis not available");
+                    return None;
+                }
+            };
+
+            let ping_result: redis::RedisResult<String> =
+                redis::cmd("PING").query_async(&mut *conn).await;
+
+            if ping_result.is_err() {
+                println!("Skipping test: Redis not available");
+                return None;
+            }
+
+            drop(conn);
+            Some(pool)
+        }
+        Err(_) => {
+            println!("Skipping test: Redis not available");
+            None
+        }
+    }
+}
+
+/// Build a kind-30000 list event with the given `d` tag.
+fn list_event(d_tag: &str) -> Event {
+    EventBuilder::new(Kind::from(30000u16), "")
+        .tag(Tag::identifier(d_tag))
+        .tag(Tag::public_key(Keys::generate().public_key()))
+        .sign_with_keys(&Keys::generate())
+        .unwrap()
+}
+
+#[test]
+fn test_notify_lists_are_exempt_from_the_event_claim() {
+    // The claim is taken before routing and never released. A notify list whose
+    // handler hits a transient Redis error therefore leaves a claim standing for
+    // an event that was never applied, and the historical replay on the next
+    // restart skips it — the subscriber's bells stay dark for the full dedup
+    // TTL. The claim buys nothing in exchange: the Lua script behind
+    // `replace_notify_subscriptions` is atomic and rejects anything not strictly
+    // newer, so duplicate delivery is already a no-op.
+    assert!(!event_handler::requires_event_claim(&list_event("notify")));
+}
+
+#[test]
+fn test_the_exemption_does_not_cover_other_kind_30000_lists() {
+    // Same scoping as the replay-horizon exemption. The idempotency argument
+    // rests on the notify-list Lua script, which only runs for `d=notify`, so an
+    // unrelated people list keeps the claim.
+    assert!(event_handler::requires_event_claim(&list_event("mute")));
+}
+
+#[test]
+fn test_push_sending_events_still_claim() {
+    // Everything that actually sends a push depends on the claim to stop two
+    // replicas notifying the same user twice.
+    let video = EventBuilder::new(Kind::from(34236u16), "video")
+        .tag(Tag::identifier("vid-1"))
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+    let reaction = EventBuilder::new(Kind::from(7u16), "+")
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+    let note = EventBuilder::new(Kind::TextNote, "hello")
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+
+    assert!(event_handler::requires_event_claim(&video));
+    assert!(event_handler::requires_event_claim(&reaction));
+    assert!(event_handler::requires_event_claim(&note));
+}
+
+#[tokio::test]
+async fn test_a_standing_claim_would_have_skipped_the_replayed_list() {
+    // Pins the mechanism the exemption bypasses, so the two tests above are not
+    // just asserting a negation of themselves. A claim taken on the first
+    // attempt survives the handler's failure, and the replay's attempt to claim
+    // the same event id comes back false — which, without the exemption, is the
+    // `continue` that drops the list.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let list = list_event("notify");
+
+    let first = redis_store::try_claim_event(&pool, &list.id, 60)
+        .await
+        .expect("first claim");
+    let replay = redis_store::try_claim_event(&pool, &list.id, 60)
+        .await
+        .expect("replayed claim");
+
+    let mut conn = pool.get().await.expect("redis connection");
+    let _: redis::RedisResult<i64> = redis::cmd("DEL")
+        .arg(format!("dedup:{}", list.id.to_hex()))
+        .query_async(&mut *conn)
+        .await;
+
+    assert!(first, "the failed first attempt still took the claim");
+    assert!(
+        !replay,
+        "so the replay is refused, and only the exemption lets the list through"
+    );
+}
+
+#[tokio::test]
+async fn test_a_replayed_list_still_applies_without_a_claim() {
+    // The other half: with the claim out of the way, re-applying the same list
+    // is safe. `replace_notify_subscriptions` rejects the duplicate on
+    // `created_at` and leaves the index intact, which is why the claim was
+    // never load-bearing here.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let created_at = Timestamp::now().as_secs();
+
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        std::slice::from_ref(&creator),
+        created_at,
+    )
+    .await
+    .expect("first apply");
+
+    let reapplied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        std::slice::from_ref(&creator),
+        created_at,
+    )
+    .await
+    .expect("replayed apply");
+
+    let watchers = redis_store::get_notify_watchers(&pool, &creator)
+        .await
+        .expect("watchers");
+
+    let mut conn = pool.get().await.expect("redis connection");
+    for key in [
+        format!("notify_subs:{}", subscriber.to_hex()),
+        format!("notify_subs_ts:{}", subscriber.to_hex()),
+        format!("notify_watchers:{}", creator.to_hex()),
+    ] {
+        let _: redis::RedisResult<i64> = redis::cmd("DEL").arg(key).query_async(&mut *conn).await;
+    }
+
+    assert!(applied, "the list applies the first time");
+    assert!(!reapplied, "the duplicate is rejected on created_at");
+    assert_eq!(
+        watchers,
+        vec![subscriber],
+        "and the index is unchanged by the replay"
+    );
+}
+
+#[test]
+fn test_the_exemption_composes_with_the_replay_horizon() {
+    // Both gates sit in the same loop and both have to let an old list through.
+    // Exempting one without the other still loses every bell set more than the
+    // horizon ago.
+    let old_list = EventBuilder::new(Kind::from(30000u16), "")
+        .tag(Tag::identifier("notify"))
+        .tag(Tag::public_key(Keys::generate().public_key()))
+        .custom_created_at(Timestamp::now() - Duration::from_secs(90 * 24 * 60 * 60))
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+
+    assert!(!event_handler::is_beyond_replay_horizon(&old_list));
+    assert!(!event_handler::requires_event_claim(&old_list));
+}

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -242,7 +242,7 @@ async fn test_older_replacement_is_ignored() {
 }
 
 #[tokio::test]
-async fn test_replaying_the_same_created_at_is_ignored() {
+async fn test_replaying_the_same_event_repairs_the_reverse_index() {
     let Some(pool) = create_test_pool().await else {
         return;
     };
@@ -262,18 +262,33 @@ async fn test_replaying_the_same_created_at_is_ignored() {
     .await
     .expect("initial replace");
 
+    let watchers_key = format!("notify_watchers:{}", creator.to_hex());
+    let mut conn = pool.get().await.expect("redis connection");
+    let _: () = redis::cmd("DEL")
+        .arg(&watchers_key)
+        .query_async(&mut *conn)
+        .await
+        .expect("simulate lost reverse index");
+
     let applied = redis_store::replace_notify_subscriptions(
         &pool,
         &subscriber,
-        &[],
+        &[creator],
         2000,
         &test_event_id(2000),
     )
     .await
-    .expect("equal-timestamp replace");
+    .expect("exact replay");
     assert!(
-        !applied,
-        "the same event delivered twice is a replay, not an update"
+        applied,
+        "the same event delivered twice is an idempotent repair path"
+    );
+    assert_eq!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup"),
+        vec![subscriber],
+        "an exact replay re-asserts the reverse index"
     );
 
     cleanup(&pool, &keys_for(&subscriber, &all)).await;

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -1,0 +1,318 @@
+// ABOUTME: Redis round-trip tests for the notify-list reverse index.
+// ABOUTME: Skips cleanly when Redis is unavailable, per the dedup_test convention.
+
+use divine_push_service::redis_store;
+use nostr_sdk::prelude::*;
+
+async fn create_test_pool() -> Option<redis_store::RedisPool> {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    match redis_store::create_pool(&redis_url, 5).await {
+        Ok(pool) => {
+            let mut conn = match pool.get().await {
+                Ok(conn) => conn,
+                Err(_) => {
+                    println!("Skipping test: Redis not available");
+                    return None;
+                }
+            };
+
+            let ping_result: redis::RedisResult<String> =
+                redis::cmd("PING").query_async(&mut *conn).await;
+
+            if ping_result.is_err() {
+                println!("Skipping test: Redis not available");
+                return None;
+            }
+
+            drop(conn);
+            Some(pool)
+        }
+        Err(_) => {
+            println!("Skipping test: Redis not available");
+            None
+        }
+    }
+}
+
+/// Remove every key this test family touches for the given pubkeys.
+async fn cleanup(pool: &redis_store::RedisPool, keys: &[String]) {
+    let mut conn = pool.get().await.expect("redis connection");
+    for key in keys {
+        let _: redis::RedisResult<i64> = redis::cmd("DEL").arg(key).query_async(&mut *conn).await;
+    }
+}
+
+fn keys_for(subscriber: &PublicKey, creators: &[PublicKey]) -> Vec<String> {
+    let mut keys = vec![
+        format!("notify_subs:{}", subscriber.to_hex()),
+        format!("notify_subs_ts:{}", subscriber.to_hex()),
+    ];
+    for creator in creators {
+        keys.push(format!("notify_watchers:{}", creator.to_hex()));
+    }
+    keys
+}
+
+#[tokio::test]
+async fn test_publishing_a_list_populates_the_reverse_index() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator_a = Keys::generate().public_key();
+    let creator_b = Keys::generate().public_key();
+    let all = [creator_a, creator_b];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator_a, creator_b],
+        1000,
+    )
+    .await
+    .expect("replace should succeed");
+    assert!(applied, "a first list must be applied");
+
+    let watchers_a = redis_store::get_notify_watchers(&pool, &creator_a)
+        .await
+        .expect("watchers lookup");
+    let watchers_b = redis_store::get_notify_watchers(&pool, &creator_b)
+        .await
+        .expect("watchers lookup");
+
+    assert_eq!(watchers_a, vec![subscriber]);
+    assert_eq!(watchers_b, vec![subscriber]);
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_shrinking_a_list_removes_only_the_dropped_creator() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let kept = Keys::generate().public_key();
+    let dropped = Keys::generate().public_key();
+    let all = [kept, dropped];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[kept, dropped], 1000)
+        .await
+        .expect("initial replace");
+
+    // Republished list without `dropped` — an unbell.
+    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[kept], 2000)
+        .await
+        .expect("second replace");
+    assert!(applied);
+
+    assert_eq!(
+        redis_store::get_notify_watchers(&pool, &kept)
+            .await
+            .expect("watchers lookup"),
+        vec![subscriber],
+        "a creator still on the list keeps the watcher"
+    );
+    assert!(
+        redis_store::get_notify_watchers(&pool, &dropped)
+            .await
+            .expect("watchers lookup")
+            .is_empty(),
+        "an unbelled creator loses the watcher"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_empty_list_clears_every_subscription() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 1000)
+        .await
+        .expect("initial replace");
+
+    // A user who unbelled everyone publishes a list with no p tags. This is
+    // legitimate, not malformed, and must clear the index.
+    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000)
+        .await
+        .expect("empty replace");
+    assert!(applied);
+
+    assert!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup")
+            .is_empty(),
+        "an empty list clears the reverse index"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_older_replacement_is_ignored() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 2000)
+        .await
+        .expect("initial replace");
+
+    // A relay delivering a stale replacement after a newer one must not
+    // resurrect an unbell.
+    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 1000)
+        .await
+        .expect("stale replace");
+    assert!(!applied, "an older created_at must be rejected");
+
+    assert_eq!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup"),
+        vec![subscriber],
+        "the newer list survives a stale replacement"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_replaying_the_same_created_at_is_ignored() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 2000)
+        .await
+        .expect("initial replace");
+
+    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000)
+        .await
+        .expect("equal-timestamp replace");
+    assert!(
+        !applied,
+        "an equal created_at is a duplicate delivery, not an update"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[test]
+fn test_rate_limit_key_carries_full_pubkeys() {
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+
+    let key = redis_store::build_notify_rate_key(&subscriber, &creator);
+
+    // Nostr identifiers are never truncated, in keys or anywhere else.
+    assert!(key.contains(&subscriber.to_hex()));
+    assert!(key.contains(&creator.to_hex()));
+    assert_eq!(
+        key,
+        format!("notify_rate:{}:{}", subscriber.to_hex(), creator.to_hex())
+    );
+}
+
+#[tokio::test]
+async fn test_rate_limit_window_is_scoped_per_creator() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let throttled = Keys::generate().public_key();
+    let other = Keys::generate().public_key();
+
+    let throttled_key = redis_store::build_notify_rate_key(&subscriber, &throttled);
+    let other_key = redis_store::build_notify_rate_key(&subscriber, &other);
+    cleanup(&pool, &[throttled_key.clone(), other_key.clone()]).await;
+
+    // Simulate a delivered push opening the window for one creator.
+    redis_store::set_cached_string(&pool, &throttled_key, "1", 3600)
+        .await
+        .expect("open window");
+
+    assert!(
+        redis_store::get_cached_string(&pool, &throttled_key)
+            .await
+            .expect("lookup")
+            .is_some(),
+        "a second video from the same creator is inside the window"
+    );
+    assert!(
+        redis_store::get_cached_string(&pool, &other_key)
+            .await
+            .expect("lookup")
+            .is_none(),
+        "a video from a different creator is unaffected"
+    );
+
+    cleanup(&pool, &[throttled_key, other_key]).await;
+}
+
+#[tokio::test]
+async fn test_two_subscribers_watching_one_creator() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber_a = Keys::generate().public_key();
+    let subscriber_b = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    cleanup(&pool, &keys_for(&subscriber_a, &[creator])).await;
+    cleanup(&pool, &keys_for(&subscriber_b, &[creator])).await;
+
+    redis_store::replace_notify_subscriptions(&pool, &subscriber_a, &[creator], 1000)
+        .await
+        .expect("replace a");
+    redis_store::replace_notify_subscriptions(&pool, &subscriber_b, &[creator], 1000)
+        .await
+        .expect("replace b");
+
+    let mut watchers = redis_store::get_notify_watchers(&pool, &creator)
+        .await
+        .expect("watchers lookup");
+    watchers.sort_by_key(|pk| pk.to_hex());
+    let mut expected = vec![subscriber_a, subscriber_b];
+    expected.sort_by_key(|pk| pk.to_hex());
+    assert_eq!(watchers, expected);
+
+    // One unbelling must not disturb the other.
+    redis_store::replace_notify_subscriptions(&pool, &subscriber_a, &[], 2000)
+        .await
+        .expect("unbell a");
+    assert_eq!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup"),
+        vec![subscriber_b]
+    );
+
+    cleanup(&pool, &keys_for(&subscriber_a, &[creator])).await;
+    cleanup(&pool, &keys_for(&subscriber_b, &[creator])).await;
+}

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -551,3 +551,97 @@ async fn test_two_subscribers_watching_one_creator() {
     cleanup(&pool, &keys_for(&subscriber_a, &[creator])).await;
     cleanup(&pool, &keys_for(&subscriber_b, &[creator])).await;
 }
+
+/// A Lua script is atomic but not transactional: Redis will not interleave
+/// anything else, but a script that dies partway keeps the writes it already
+/// made. A write rejected under `maxmemory` is the reachable way in; here the
+/// abort is injected by parking a string on one `notify_watchers:*` key, so
+/// `SADD` raises `WRONGTYPE` at a chosen point in the add loop.
+///
+/// What has to survive it is the forward index. It is the only record of which
+/// watcher sets name this subscriber, so if it comes back *short*, the creators
+/// it lost can never be unbelled: `previous` omits them, their `SREM` is never
+/// issued, and the pushes continue. A superset is recoverable; a subset is not.
+#[tokio::test]
+async fn test_a_half_applied_list_still_converges_on_the_next_one() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let kept = Keys::generate().public_key();
+    let dropped = Keys::generate().public_key();
+    let poisoned = Keys::generate().public_key();
+    let all = [kept, dropped, poisoned];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[kept, dropped],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("initial list");
+
+    // Park a string where a watcher set belongs.
+    let poisoned_key = format!("notify_watchers:{}", poisoned.to_hex());
+    {
+        let mut conn = pool.get().await.expect("redis connection");
+        let _: () = redis::cmd("SET")
+            .arg(&poisoned_key)
+            .arg("not a set")
+            .query_async(&mut *conn)
+            .await
+            .expect("poison the watcher key");
+    }
+
+    // `poisoned` is listed first, so the script dies before it re-adds `kept`.
+    let interrupted = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[poisoned, kept],
+        2000,
+        &test_event_id(2000),
+    )
+    .await;
+    assert!(
+        interrupted.is_err(),
+        "the injection must actually abort the script, or this test proves nothing"
+    );
+
+    // The invariant, stated where it is broken: the forward index still names
+    // every creator whose watcher set names this subscriber.
+    let forward: Vec<String> = {
+        let mut conn = pool.get().await.expect("redis connection");
+        redis::cmd("SMEMBERS")
+            .arg(format!("notify_subs:{}", subscriber.to_hex()))
+            .query_async(&mut *conn)
+            .await
+            .expect("read the forward index")
+    };
+    assert!(
+        forward.contains(&kept.to_hex()),
+        "a half-applied list must leave the forward index a superset, not a subset"
+    );
+
+    // Clear the injection so the next list runs to completion.
+    cleanup(&pool, &[poisoned_key]).await;
+
+    // The subscriber unbells everyone. Republishing is the only corrective
+    // action a user has, so it has to be enough.
+    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 3000, &test_event_id(3000))
+        .await
+        .expect("unbell everyone");
+
+    assert!(
+        redis_store::get_notify_watchers(&pool, &kept)
+            .await
+            .expect("watchers lookup")
+            .is_empty(),
+        "a creator stranded by the interrupted list must still be removable"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -44,6 +44,14 @@ async fn cleanup(pool: &redis_store::RedisPool, keys: &[String]) {
     }
 }
 
+/// Deterministic stand-in event id. Only its ordering matters to the guard, so
+/// tests that care about a tie build ids explicitly instead of using this.
+fn test_event_id(seed: u64) -> EventId {
+    let mut bytes = [0u8; 32];
+    bytes[24..].copy_from_slice(&seed.to_be_bytes());
+    EventId::from_slice(&bytes).expect("32 bytes is a valid event id")
+}
+
 fn keys_for(subscriber: &PublicKey, creators: &[PublicKey]) -> Vec<String> {
     let mut keys = vec![
         format!("notify_subs:{}", subscriber.to_hex()),
@@ -72,6 +80,7 @@ async fn test_publishing_a_list_populates_the_reverse_index() {
         &subscriber,
         &[creator_a, creator_b],
         1000,
+        &test_event_id(1),
     )
     .await
     .expect("replace should succeed");
@@ -102,14 +111,26 @@ async fn test_shrinking_a_list_removes_only_the_dropped_creator() {
     let all = [kept, dropped];
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
 
-    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[kept, dropped], 1000)
-        .await
-        .expect("initial replace");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[kept, dropped],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("initial replace");
 
     // Republished list without `dropped` — an unbell.
-    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[kept], 2000)
-        .await
-        .expect("second replace");
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[kept],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("second replace");
     assert!(applied);
 
     assert_eq!(
@@ -141,15 +162,27 @@ async fn test_empty_list_clears_every_subscription() {
     let all = [creator];
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
 
-    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 1000)
-        .await
-        .expect("initial replace");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("initial replace");
 
     // A user who unbelled everyone publishes a list with no p tags. This is
     // legitimate, not malformed, and must clear the index.
-    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000)
-        .await
-        .expect("empty replace");
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("empty replace");
     assert!(applied);
 
     assert!(
@@ -174,15 +207,27 @@ async fn test_older_replacement_is_ignored() {
     let all = [creator];
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
 
-    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 2000)
-        .await
-        .expect("initial replace");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("initial replace");
 
     // A relay delivering a stale replacement after a newer one must not
     // resurrect an unbell.
-    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 1000)
-        .await
-        .expect("stale replace");
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("stale replace");
     assert!(!applied, "an older created_at must be rejected");
 
     assert_eq!(
@@ -207,17 +252,189 @@ async fn test_replaying_the_same_created_at_is_ignored() {
     let all = [creator];
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
 
-    redis_store::replace_notify_subscriptions(&pool, &subscriber, &[creator], 2000)
-        .await
-        .expect("initial replace");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("initial replace");
 
-    let applied = redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000)
-        .await
-        .expect("equal-timestamp replace");
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("equal-timestamp replace");
     assert!(
         !applied,
-        "an equal created_at is a duplicate delivery, not an update"
+        "the same event delivered twice is a replay, not an update"
     );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_a_created_at_tie_is_resolved_by_the_lower_event_id() {
+    // NIP-01: "in case of replaceable events with the same timestamp, the event
+    // with the lowest id (first in lexical order) should be retained". Resolving
+    // by arrival order instead lets this service and the relay hold permanently
+    // different lists, so a rebuild from relay history disagrees with what was
+    // served live.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    // The higher id arrives first, so it is what we are holding.
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2000,
+        &test_event_id(9),
+    )
+    .await
+    .expect("initial replace");
+
+    // Same second, lower id: the relay retains this one, so we must too, even
+    // though it arrived second.
+    let applied =
+        redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000, &test_event_id(4))
+            .await
+            .expect("lower-id replace");
+    assert!(
+        applied,
+        "a same-second event with a lower id is the one NIP-01 retains"
+    );
+    assert!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup")
+            .is_empty(),
+        "the retained list is the one that was applied"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_a_created_at_tie_rejects_a_higher_event_id() {
+    // The other side of the tie-break, and the one that reads backwards from
+    // "newer wins": arriving second is not enough, the id has to sort lower.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2000,
+        &test_event_id(4),
+    )
+    .await
+    .expect("initial replace");
+
+    let applied =
+        redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2000, &test_event_id(9))
+            .await
+            .expect("higher-id replace");
+    assert!(
+        !applied,
+        "a same-second event with a higher id is the one NIP-01 discards"
+    );
+    assert_eq!(
+        redis_store::get_notify_watchers(&pool, &creator)
+            .await
+            .expect("watchers lookup"),
+        vec![subscriber],
+        "the lower-id list survives"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_a_legacy_bare_timestamp_still_guards_and_is_upgraded() {
+    // `notify_subs_ts` used to hold a bare integer. Deployed instances have
+    // those, so the read path has to keep working: a tie against a value with no
+    // id stays rejected (nothing to compare), a newer list still applies, and
+    // applying it writes the new format so the tie-break works from then on.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let all = [creator];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    let ts_key = format!("notify_subs_ts:{}", subscriber.to_hex());
+    let mut conn = pool.get().await.expect("redis connection");
+    let _: () = redis::cmd("SET")
+        .arg(&ts_key)
+        .arg(2000)
+        .query_async(&mut *conn)
+        .await
+        .expect("seed the legacy format");
+
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2000,
+        &test_event_id(1),
+    )
+    .await
+    .expect("tie against legacy");
+    assert!(
+        !applied,
+        "a tie against a stored value with no id has nothing to break on"
+    );
+
+    let applied = redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        2001,
+        &test_event_id(9),
+    )
+    .await
+    .expect("newer than legacy");
+    assert!(applied, "a strictly newer list still applies");
+
+    let stored: String = redis::cmd("GET")
+        .arg(&ts_key)
+        .query_async(&mut *conn)
+        .await
+        .expect("read back");
+    assert_eq!(
+        stored,
+        format!("2001:{}", test_event_id(9).to_hex()),
+        "applying upgrades the key to the tie-breakable format"
+    );
+
+    // And the tie-break now works against the upgraded value.
+    let applied =
+        redis_store::replace_notify_subscriptions(&pool, &subscriber, &[], 2001, &test_event_id(2))
+            .await
+            .expect("tie against upgraded");
+    assert!(applied, "a lower id wins once the stored id is known");
 
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
 }
@@ -287,12 +504,24 @@ async fn test_two_subscribers_watching_one_creator() {
     cleanup(&pool, &keys_for(&subscriber_a, &[creator])).await;
     cleanup(&pool, &keys_for(&subscriber_b, &[creator])).await;
 
-    redis_store::replace_notify_subscriptions(&pool, &subscriber_a, &[creator], 1000)
-        .await
-        .expect("replace a");
-    redis_store::replace_notify_subscriptions(&pool, &subscriber_b, &[creator], 1000)
-        .await
-        .expect("replace b");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber_a,
+        &[creator],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("replace a");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber_b,
+        &[creator],
+        1000,
+        &test_event_id(1000),
+    )
+    .await
+    .expect("replace b");
 
     let mut watchers = redis_store::get_notify_watchers(&pool, &creator)
         .await
@@ -303,9 +532,15 @@ async fn test_two_subscribers_watching_one_creator() {
     assert_eq!(watchers, expected);
 
     // One unbelling must not disturb the other.
-    redis_store::replace_notify_subscriptions(&pool, &subscriber_a, &[], 2000)
-        .await
-        .expect("unbell a");
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber_a,
+        &[],
+        2000,
+        &test_event_id(2000),
+    )
+    .await
+    .expect("unbell a");
     assert_eq!(
         redis_store::get_notify_watchers(&pool, &creator)
             .await

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -3,6 +3,7 @@
 
 use divine_push_service::redis_store;
 use nostr_sdk::prelude::*;
+use std::collections::HashSet;
 
 async fn create_test_pool() -> Option<redis_store::RedisPool> {
     let redis_url =
@@ -719,4 +720,49 @@ async fn test_a_half_applied_list_still_converges_on_the_next_one() {
     );
 
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_watcher_pages_walk_to_full_coverage() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscribers: Vec<PublicKey> = (0..3).map(|_| Keys::generate().public_key()).collect();
+    let creator = Keys::generate().public_key();
+    for subscriber in &subscribers {
+        cleanup(&pool, &keys_for(subscriber, &[creator])).await;
+    }
+
+    for (idx, subscriber) in subscribers.iter().enumerate() {
+        redis_store::replace_notify_subscriptions(
+            &pool,
+            subscriber,
+            &[creator],
+            1000 + idx as u64,
+            &test_event_id(1000 + idx as u64),
+        )
+        .await
+        .expect("replace");
+    }
+
+    let mut cursor = 0;
+    let mut watchers = HashSet::new();
+    loop {
+        let page = redis_store::get_notify_watchers_page(&pool, &creator, cursor, 2)
+            .await
+            .expect("watcher page lookup");
+        watchers.extend(page.watchers);
+        if page.next_cursor == 0 {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    let expected: HashSet<PublicKey> = subscribers.iter().copied().collect();
+    assert_eq!(watchers, expected);
+
+    for subscriber in &subscribers {
+        cleanup(&pool, &keys_for(subscriber, &[creator])).await;
+    }
 }

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -728,7 +728,12 @@ async fn test_watcher_pages_walk_to_full_coverage() {
         return;
     };
 
-    let subscribers: Vec<PublicKey> = (0..3).map(|_| Keys::generate().public_key()).collect();
+    // 150, not a handful. Below Redis's `set-max-listpack-entries` (128 by
+    // default) a set is listpack-encoded and SSCAN returns every member in one
+    // reply whatever COUNT asks for, so a three-member set walks exactly one
+    // page and the test passes against a `get_notify_watchers_page` that
+    // ignores its cursor entirely.
+    let subscribers: Vec<PublicKey> = (0..150).map(|_| Keys::generate().public_key()).collect();
     let creator = Keys::generate().public_key();
     for subscriber in &subscribers {
         cleanup(&pool, &keys_for(subscriber, &[creator])).await;
@@ -747,11 +752,13 @@ async fn test_watcher_pages_walk_to_full_coverage() {
     }
 
     let mut cursor = 0;
+    let mut pages = 0;
     let mut watchers = HashSet::new();
     loop {
-        let page = redis_store::get_notify_watchers_page(&pool, &creator, cursor, 2)
+        let page = redis_store::get_notify_watchers_page(&pool, &creator, cursor, 10)
             .await
             .expect("watcher page lookup");
+        pages += 1;
         watchers.extend(page.watchers);
         if page.next_cursor == 0 {
             break;
@@ -759,6 +766,10 @@ async fn test_watcher_pages_walk_to_full_coverage() {
         cursor = page.next_cursor;
     }
 
+    assert!(
+        pages > 1,
+        "the walk must cross a page boundary to test anything, got {pages}"
+    );
     let expected: HashSet<PublicKey> = subscribers.iter().copied().collect();
     assert_eq!(watchers, expected);
 

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -100,6 +100,66 @@ async fn test_publishing_a_list_populates_the_reverse_index() {
 }
 
 #[tokio::test]
+async fn test_membership_agrees_with_the_full_watcher_read() {
+    // `is_notify_watcher` is the bell fallback's read, and it has to answer
+    // exactly what `get_notify_watchers(..).contains(..)` answered before it,
+    // including for a creator whose watcher key does not exist at all.
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscriber = Keys::generate().public_key();
+    let stranger = Keys::generate().public_key();
+    let creator = Keys::generate().public_key();
+    let unwatched = Keys::generate().public_key();
+    let all = [creator, unwatched];
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+
+    redis_store::replace_notify_subscriptions(
+        &pool,
+        &subscriber,
+        &[creator],
+        1000,
+        &test_event_id(1),
+    )
+    .await
+    .expect("replace should succeed");
+
+    for (creator_under_test, candidate) in [
+        (creator, subscriber),
+        (creator, stranger),
+        (unwatched, subscriber),
+    ] {
+        let full = redis_store::get_notify_watchers(&pool, &creator_under_test)
+            .await
+            .expect("watchers lookup")
+            .contains(&candidate);
+        let member = redis_store::is_notify_watcher(&pool, &creator_under_test, &candidate)
+            .await
+            .expect("membership lookup");
+        assert_eq!(
+            member, full,
+            "SISMEMBER must agree with SMEMBERS for creator {creator_under_test} and candidate {candidate}"
+        );
+    }
+
+    assert!(
+        redis_store::is_notify_watcher(&pool, &creator, &subscriber)
+            .await
+            .expect("membership lookup"),
+        "the subscriber watches the creator they belled"
+    );
+    assert!(
+        !redis_store::is_notify_watcher(&pool, &unwatched, &subscriber)
+            .await
+            .expect("membership lookup"),
+        "a missing watcher key is not a membership"
+    );
+
+    cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
 async fn test_shrinking_a_list_removes_only_the_dropped_creator() {
     let Some(pool) = create_test_pool().await else {
         return;

--- a/tests/preferences_test.rs
+++ b/tests/preferences_test.rs
@@ -12,7 +12,26 @@ async fn get_test_pool() -> Option<redis_store::RedisPool> {
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
 
     match redis_store::create_pool(&redis_url, 5).await {
-        Ok(pool) => Some(pool),
+        Ok(pool) => {
+            let mut conn = match pool.get().await {
+                Ok(conn) => conn,
+                Err(_) => {
+                    println!("Skipping test: Redis not available");
+                    return None;
+                }
+            };
+
+            let ping_result: redis::RedisResult<String> =
+                redis::cmd("PING").query_async(&mut *conn).await;
+
+            if ping_result.is_err() {
+                println!("Skipping test: Redis not available");
+                return None;
+            }
+
+            drop(conn);
+            Some(pool)
+        }
         Err(_) => {
             println!("Skipping test: Redis not available");
             None

--- a/tests/replay_horizon_test.rs
+++ b/tests/replay_horizon_test.rs
@@ -104,3 +104,13 @@ fn test_old_content_events_are_still_dropped() {
 
     assert!(event_handler::is_beyond_replay_horizon(&old_video));
 }
+
+#[test]
+fn test_exemption_does_not_cover_other_kind_30000_lists() {
+    // The relay filter narrows to `#d=notify`, but a buggy or hostile relay can
+    // send any kind 30000. An unrelated people list is not subscription state
+    // this service owns, so it gets no exemption from the horizon.
+    let other = aged_list_event("mute", Duration::from_secs(90 * 24 * 60 * 60));
+
+    assert!(event_handler::is_beyond_replay_horizon(&other));
+}

--- a/tests/replay_horizon_test.rs
+++ b/tests/replay_horizon_test.rs
@@ -32,16 +32,29 @@ fn test_replay_horizon_accepts_recent_events() {
 
 #[test]
 fn test_replay_horizon_edge_case() {
-    // Create an event that's exactly 7 days old (at the horizon boundary)
-    let boundary_timestamp = Timestamp::now() - Duration::from_secs(7 * 24 * 60 * 60);
+    // Straddle the boundary rather than sitting on it. This test and
+    // `is_event_too_old` each call `Timestamp::now()`, and the horizon only
+    // moves forward between the two, so an event built at *exactly* 7 days
+    // flips to "too old" whenever a second ticks over in between. A minute of
+    // slack on each side pins the same cutoff without the coin flip.
+    const HORIZON_SECS: u64 = 7 * 24 * 60 * 60;
+    const SLACK_SECS: u64 = 60;
 
-    let event = EventBuilder::new(Kind::TextNote, "Boundary message")
-        .custom_created_at(boundary_timestamp)
-        .sign_with_keys(&Keys::generate())
-        .unwrap();
+    let build = |age_secs: u64| {
+        EventBuilder::new(Kind::TextNote, "Boundary message")
+            .custom_created_at(Timestamp::now() - Duration::from_secs(age_secs))
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    };
 
-    // The event should still be accepted (7 days is the cutoff, not 6)
-    assert!(!event_handler::is_event_too_old(&event));
+    // 7 days is the cutoff, not 6.
+    assert!(!event_handler::is_event_too_old(&build(
+        HORIZON_SECS - SLACK_SECS
+    )));
+    // And it is a cutoff, not a floor.
+    assert!(event_handler::is_event_too_old(&build(
+        HORIZON_SECS + SLACK_SECS
+    )));
 }
 
 #[test]

--- a/tests/replay_horizon_test.rs
+++ b/tests/replay_horizon_test.rs
@@ -57,3 +57,50 @@ fn test_replay_horizon_future_events() {
     // Future events should be accepted (they're not old)
     assert!(!event_handler::is_event_too_old(&event));
 }
+
+/// Build a kind-30000 list event with the given `d` tag, aged by `age`.
+fn aged_list_event(d_tag: &str, age: Duration) -> Event {
+    EventBuilder::new(Kind::from(30000u16), "")
+        .tag(Tag::identifier(d_tag))
+        .tag(Tag::public_key(Keys::generate().public_key()))
+        .custom_created_at(Timestamp::now() - age)
+        .sign_with_keys(&Keys::generate())
+        .unwrap()
+}
+
+#[test]
+fn test_notify_list_survives_the_replay_horizon() {
+    // The whole feature rests on this. A bell list is replaceable state, not a
+    // timely trigger: one published 90 days ago and never touched since is
+    // still the user's current subscription set. If the horizon aged it out,
+    // every user who set their bells more than a week ago would silently get
+    // nothing, with no error anywhere.
+    let list = aged_list_event("notify", Duration::from_secs(90 * 24 * 60 * 60));
+
+    assert!(
+        event_handler::is_event_too_old(&list),
+        "the event really is beyond the horizon"
+    );
+    assert!(
+        !event_handler::is_beyond_replay_horizon(&list),
+        "but the handler loop must not drop it"
+    );
+}
+
+#[test]
+fn test_recent_notify_list_is_kept() {
+    let list = aged_list_event("notify", Duration::from_secs(60 * 60));
+
+    assert!(!event_handler::is_beyond_replay_horizon(&list));
+}
+
+#[test]
+fn test_old_content_events_are_still_dropped() {
+    let old_video = EventBuilder::new(Kind::from(34236u16), "video")
+        .tag(Tag::identifier("vid-1"))
+        .custom_created_at(Timestamp::now() - Duration::from_secs(8 * 24 * 60 * 60))
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+
+    assert!(event_handler::is_beyond_replay_horizon(&old_video));
+}

--- a/tests/test_token_reregistration.rs
+++ b/tests/test_token_reregistration.rs
@@ -14,6 +14,19 @@ async fn test_token_reregistration_by_different_pubkey() {
             return;
         }
     };
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => {
+            println!("Skipping test: Redis not available");
+            return;
+        }
+    };
+    let ping_result: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut *conn).await;
+    if ping_result.is_err() {
+        println!("Skipping test: Redis not available");
+        return;
+    }
+    drop(conn);
 
     // Create test data
     let token = "test_fcm_token_12345";


### PR DESCRIPTION
## Summary

Implements new-post ("bell") push notifications: a user gets a push when a creator they subscribed to publishes a kind 34236 video.

Subscriptions come from a public NIP-51 kind 30000 `d=notify` list. The service keeps a `creator -> subscribers` reverse index in Redis, rebuilds it from historical notify lists on startup, and on each incoming kind 34236 notifies the author's watchers, rate-limited to one push per `(subscriber, creator)` per hour.

No new FCM payload fields. `insert_video_reference_fields` already emits the routing target the client needs.

## Motivation

Existing notifications are "someone acted on your content", resolved from tags on the trigger event. New-post pushes invert that: the recipient subscribed to a creator's output, and the trigger event does not name the recipients. That requires a reverse index instead of tag-walking.

## Linked Issue

Closes #33. Design plan is #34 (docs-only, separate review). This PR targets `main` and does not stack on it.

## Cross-Repo Dependency

The mobile half is not merged yet. `divine-mobile` PR #6517 adds the bell UI, publishes the `d=notify` list, includes kind 34236 in push preferences, republishes preferences after the schema change, and routes the `newPost` push type.

This service can deploy before mobile as a dark backend change, but the feature should not be called user-visible until #6517 lands and ships behind its feature flag.

## Decisions Worth Review

- Notify lists are exempt from the 7-day replay horizon because replaceable subscription state can remain current for months.
- Notify lists are exempt from the per-event claim because they send no push and `replace_notify_subscriptions` is idempotent by `created_at:event_id`.
- Historical notify-list replay pages backward with `until`, using `notify_list_history_limit` as the page size.
- The Redis reverse-index update is one Lua diff-and-apply script. It preserves a recoverable write order and exact event replays reassert the reverse index.
- Video coordinate dedup keys are type-scoped, but legacy untyped keys are read for rollout compatibility.
- A delivered mention satisfies the bell record for the same video; a delivered bell does not satisfy a later mention.
- A rate-limited bell still records the video coordinate so later edits do not announce the suppressed video as new.
- If a watcher is also mentioned but muted mentions while allowing bells, the send path falls back to the enabled `NewPost` delivery.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib` (93 passed)
- `cargo test --test notify_subscriptions_test -- --nocapture`
- `cargo test --test event_claim_test -- --nocapture`

Local note: this machine has no Redis listener on 6379, so suites with skip guards print their "Redis not available" probe lines and the non-skipping `preferences_test` Redis cases fail locally with bb8 connection timeouts. CI provisions Redis and should be the source of truth for the full `cargo test` run.

## Rollout Notes

New config is defaulted:

| Setting | Default |
|---|---|
| `new_post_rate_limit_secs` | `3600` |
| `notify_list_max_creators` | `1000` |
| `notify_list_history_limit` | `5000` |

`34236` is added to `default_preferences.kinds`, so new users get bells enabled by default once mobile can publish notify lists and updated preferences.
