### PR TITLE
fix(push): bound new-post fanout delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The service subscribes to trigger events on its relay and notifies the tagged re
 | Repost | 16 | Repost of a user's note (NIP-18) |
 | New post | 34236 | A creator the user subscribed to ("belled") published a video |
 
-New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour; the in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
+New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour, and fan-out is paged and delivered with bounded concurrency so one popular creator cannot force one unbounded Redis read or sequential delivery loop. The in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
 
 Divine video comments are NIP-22 `kind:1111` and notify both the root video author and the direct parent author (deduplicated when they coincide). Follows (kind 3) are defined in the protocol and subscribed to, but new-follow notifications are **not currently emitted** — that requires diffing contact-list state, which is not yet implemented.
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -15,8 +15,10 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
-  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list cannot stall Redis
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
+  new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
+  new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
 
 redis:
   url: "redis://127.0.0.1:6379"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -15,8 +15,10 @@ service:
   processed_event_ttl_secs: 604800  # 7 days
   video_coordinate_dedup_ttl_secs: 31536000  # 1 year
   new_post_rate_limit_secs: 3600  # One new-post push per (subscriber, creator) per hour
-  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list can't stall Redis
+  notify_list_max_creators: 1000  # Bounds the Lua diff so one huge list cannot stall Redis
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
+  new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
+  new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
   # allowed_pubkeys: [] — empty means no restriction (production default)
 
 redis:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -315,8 +315,9 @@ key layout.
 
 ### Delivery
 
-On each incoming kind 34236, `video_notification_targets` unions the video's
-mention targets with `SMEMBERS notify_watchers:{author}`.
+On each incoming kind 34236, the handler sends the video's mention targets first,
+then walks `notify_watchers:{author}` with paged `SSCAN` reads and bounded
+delivery for each page.
 
 **Mention wins on overlap.** A user who both watches the creator and is mentioned
 in the video gets one push, typed `mention`, because that is the more specific
@@ -343,6 +344,14 @@ When the rate limit suppresses a new-post push, the video-coordinate record is
 still written. That video has been intentionally dropped for that watcher, and a
 later NIP-33 edit should not re-announce it as a fresh post.
 
+New-post fan-out is paged by `new_post_fanout_page_size` and each page is
+delivered with at most `new_post_delivery_concurrency` concurrent recipient
+sends. This is separate from the notify-list write cap: one user's list cannot
+stall Redis on write, and one popular creator's audience cannot turn a single
+video into one unbounded Redis read or unbounded sequential delivery loop. The
+page size is not a recipient cap; the handler continues until Redis returns
+cursor 0.
+
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and
 sees all six. That is intended.
@@ -359,5 +368,5 @@ sees all six. That is intended.
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
 | `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. Exact-id replays apply idempotently for repair. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |
-| `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path — one `SMEMBERS` per incoming video. |
+| `notify_watchers:{creator}` | Set | Subscribers watching this creator. The hot read path walks this set with paged `SSCAN` reads. |
 | `notify_rate:{subscriber}:{creator}` | String | New-post rate-limit window marker, TTL `new_post_rate_limit_secs` (one hour by default). |

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,12 +78,22 @@ pub struct ServiceSettings {
     /// stall the instance for everyone.
     #[serde(default = "default_notify_list_max_creators")]
     pub notify_list_max_creators: usize,
-    /// Cap on notify lists pulled during historical replay.
+    /// Page size for notify lists pulled during historical replay.
     ///
     /// The historical notify-list query is deliberately unbounded in time, so
     /// this is the safety valve on result size instead.
     #[serde(default = "default_notify_list_history_limit")]
     pub notify_list_history_limit: usize,
+    /// Watcher page size for one video event.
+    ///
+    /// New-post recipients are follower-count-shaped, not p-tag-shaped. Paging
+    /// keeps Redis reads and delivery batches bounded without dropping bell
+    /// subscribers past an arbitrary cap.
+    #[serde(default = "default_new_post_fanout_page_size")]
+    pub new_post_fanout_page_size: usize,
+    /// Maximum concurrent new-post deliveries for one watcher page.
+    #[serde(default = "default_new_post_delivery_concurrency")]
+    pub new_post_delivery_concurrency: usize,
     /// When set, only send notifications to these pubkeys (hex). Empty means no restriction.
     /// Accepts a comma-separated string (from env vars) or a YAML list.
     #[serde(default, deserialize_with = "deserialize_comma_separated")]
@@ -106,6 +116,14 @@ fn default_notify_list_max_creators() -> usize {
 
 fn default_notify_list_history_limit() -> usize {
     5000
+}
+
+fn default_new_post_fanout_page_size() -> usize {
+    1000
+}
+
+fn default_new_post_delivery_concurrency() -> usize {
+    50
 }
 
 fn default_new_post_rate_limit() -> u64 {
@@ -272,20 +290,21 @@ impl Settings {
 
     /// Reject values that deserialize cleanly but cannot work at runtime.
     ///
-    /// Every field here is a bound the service writes to Redis or counts
-    /// against, and every one of them fails *quietly* at zero. Redis rejects an
-    /// expiry of 0, but nothing downstream treats that rejection as fatal, so
-    /// the throttle simply never engages, the cache never caches, the claim
-    /// never lands. The two caps are worse still: they are read as "nothing
-    /// allowed" and take a subscriber's bells with them. A startup error is the
-    /// only place an operator would find out.
+    /// Every field here is a bound the service writes to Redis, counts against,
+    /// or uses to size bounded fan-out work, and every one of them fails
+    /// *quietly* at zero. Redis rejects an expiry of 0, but nothing downstream
+    /// treats that rejection as fatal, so the throttle simply never engages,
+    /// the cache never caches, the claim never lands. The caps and page sizes
+    /// are worse still: they are read as "nothing allowed" and take a
+    /// subscriber's bells with them. A startup error is the only place an
+    /// operator would find out.
     ///
     /// This is reachable without editing `settings.yaml`. The config crate
     /// layers `NOSTR_PUSH__*` over the file, and production already sets
     /// `NOSTR_PUSH__SERVICE__ALLOWED_PUBKEYS` that way, so the same mechanism
     /// reaches every field below.
     fn validate(&self) -> Result<(), ConfigError> {
-        let must_be_positive: [(&str, u64, &str); 6] = [
+        let must_be_positive: [(&str, u64, &str); 8] = [
             (
                 "nostr.profile_cache_ttl_secs",
                 self.nostr.profile_cache_ttl_secs,
@@ -315,6 +334,16 @@ impl Settings {
                 "service.notify_list_history_limit",
                 self.service.notify_list_history_limit as u64,
                 "the startup replay fetches nothing",
+            ),
+            (
+                "service.new_post_fanout_page_size",
+                self.service.new_post_fanout_page_size as u64,
+                "new-post fan-out never reads bell subscribers",
+            ),
+            (
+                "service.new_post_delivery_concurrency",
+                self.service.new_post_delivery_concurrency as u64,
+                "new-post fan-out cannot start delivery work",
             ),
         ];
 
@@ -407,7 +436,7 @@ mod tests {
 
         // One case per field, because a loop over the same setter would pass
         // just as well against a `validate` that only checks the first.
-        let cases: [ZeroCase; 6] = [
+        let cases: [ZeroCase; 8] = [
             ("nostr.profile_cache_ttl_secs", |s| {
                 s.nostr.profile_cache_ttl_secs = 0
             }),
@@ -425,6 +454,12 @@ mod tests {
             }),
             ("service.notify_list_history_limit", |s| {
                 s.service.notify_list_history_limit = 0
+            }),
+            ("service.new_post_fanout_page_size", |s| {
+                s.service.new_post_fanout_page_size = 0
+            }),
+            ("service.new_post_delivery_concurrency", |s| {
+                s.service.new_post_delivery_concurrency = 0
             }),
         ];
 
@@ -453,6 +488,19 @@ mod tests {
                 settings.service.video_coordinate_dedup_ttl_secs
                     > settings.service.processed_event_ttl_secs,
                 "video-coordinate delivery records must outlive event-id claims"
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_post_fanout_limits_are_bounded() {
+        for filename in ["settings.yaml", "settings.development.yaml"] {
+            let settings = load_runtime_settings(filename);
+            assert!(settings.service.new_post_fanout_page_size > 0);
+            assert!(settings.service.new_post_delivery_concurrency > 0);
+            assert!(
+                settings.service.new_post_delivery_concurrency
+                    <= settings.service.new_post_fanout_page_size
             );
         }
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -14,7 +14,9 @@ use crate::{
     redis_store,
     state::AppState,
 };
+use futures_util::{stream, StreamExt};
 use nostr_sdk::prelude::*;
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
@@ -580,7 +582,7 @@ async fn handle_content_event(
         // Kind 30023: Long-form content - check for mentions
         targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
     } else if kind_num == KIND_VIDEO {
-        video_notification_targets(state, event).await
+        return handle_video_content_event(state, event, token).await;
     } else {
         trace!(event_id = %event_id, kind = %event_kind, "Ignoring event kind - no notification handler");
         return Ok(());
@@ -625,10 +627,19 @@ async fn handle_content_event(
     // only if some recipient survives the gates in `send_notification_to_user`.
     let copy = LazyEventCopy::for_targets(&targets);
 
-    // Send notifications to each target
+    send_notifications_sequential(state, event, targets, &copy, token).await
+}
+
+async fn send_notifications_sequential(
+    state: &AppState,
+    event: &Event,
+    targets: Vec<NotificationTarget>,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+) -> Result<()> {
     for target in targets {
         if token.is_cancelled() {
-            info!(event_id = %event_id, "Notification sending cancelled");
+            info!(event_id = %event.id, "Notification sending cancelled");
             return Err(crate::error::ServiceError::Cancelled);
         }
 
@@ -639,7 +650,7 @@ async fn handle_content_event(
             event,
             &recipient_pubkey,
             target.notification_type,
-            &copy,
+            copy,
             token.clone(),
         )
         .await
@@ -648,7 +659,7 @@ async fn handle_content_event(
                 return Err(e);
             }
             error!(
-                event_id = %event_id,
+                event_id = %event.id,
                 recipient = %recipient_pubkey,
                 error = %e,
                 "Failed to send notification"
@@ -657,6 +668,173 @@ async fn handle_content_event(
     }
 
     Ok(())
+}
+
+async fn send_notifications_bounded(
+    state: &AppState,
+    event: &Event,
+    targets: Vec<NotificationTarget>,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+    concurrency: usize,
+) -> Result<()> {
+    let mut deliveries = stream::iter(targets)
+        .map(|target| {
+            let token = token.clone();
+            async move {
+                let recipient = target.recipient;
+                (
+                    recipient,
+                    deliver_notification_target(state, event, target, copy, token).await,
+                )
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some((recipient, result)) = deliveries.next().await {
+        if let Err(e) = result {
+            if matches!(e, crate::error::ServiceError::Cancelled) {
+                return Err(e);
+            }
+            error!(
+                event_id = %event.id,
+                recipient = %recipient,
+                error = %e,
+                "Failed to send notification"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn deliver_notification_target(
+    state: &AppState,
+    event: &Event,
+    target: NotificationTarget,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+) -> Result<()> {
+    let recipient_pubkey = target.recipient;
+
+    // Skip if recipient is the sender
+    if recipient_pubkey == event.pubkey {
+        trace!(event_id = %event.id, "Skipping notification to sender");
+        return Ok(());
+    }
+
+    send_notification_to_user(
+        state,
+        event,
+        &recipient_pubkey,
+        target.notification_type,
+        copy,
+        token,
+    )
+    .await
+}
+
+async fn handle_video_content_event(
+    state: &AppState,
+    event: &Event,
+    token: CancellationToken,
+) -> Result<()> {
+    let mention_targets = deliverable_targets(video_mention_targets(event), &event.pubkey);
+    let mentioned: HashSet<PublicKey> = mention_targets
+        .iter()
+        .map(|target| target.recipient)
+        .collect();
+
+    let mut target_count = 0usize;
+    if !mention_targets.is_empty() {
+        info!(
+            event_id = %event.id,
+            kind = %event.kind,
+            recipient_count = mention_targets.len(),
+            notification_types = ?vec![(NotificationType::Mention.display_name(), mention_targets.len())],
+            "Processing notification event"
+        );
+        let copy = LazyEventCopy::for_targets(&mention_targets);
+        send_notifications_sequential(state, event, mention_targets, &copy, token.clone()).await?;
+        target_count += mentioned.len();
+    }
+
+    let page_size = state.settings.service.new_post_fanout_page_size;
+    let concurrency = state.settings.service.new_post_delivery_concurrency;
+    let mut cursor = 0;
+    loop {
+        if token.is_cancelled() {
+            info!(event_id = %event.id, "Notification sending cancelled");
+            return Err(crate::error::ServiceError::Cancelled);
+        }
+
+        let page = match redis_store::get_notify_watchers_page(
+            &state.redis_pool,
+            &event.pubkey,
+            cursor,
+            page_size,
+        )
+        .await
+        {
+            Ok(page) => page,
+            Err(e) => {
+                error!(
+                    event_id = %event.id,
+                    creator = %event.pubkey,
+                    cursor,
+                    error = %e,
+                    "Failed to read notify watcher page - delivering mentions without remaining bells"
+                );
+                break;
+            }
+        };
+
+        let next_cursor = page.next_cursor;
+        let new_post_targets = watcher_page_targets(page.watchers, &event.pubkey, &mentioned);
+        if !new_post_targets.is_empty() {
+            let page_target_count = new_post_targets.len();
+            info!(
+                event_id = %event.id,
+                kind = %event.kind,
+                recipient_count = page_target_count,
+                notification_types = ?vec![(NotificationType::NewPost.display_name(), page_target_count)],
+                cursor,
+                next_cursor,
+                "Processing new-post notification page"
+            );
+            let copy = LazyEventCopy::for_targets(&new_post_targets);
+            send_notifications_bounded(
+                state,
+                event,
+                new_post_targets,
+                &copy,
+                token.clone(),
+                concurrency,
+            )
+            .await?;
+            target_count += page_target_count;
+        }
+
+        if next_cursor == 0 {
+            break;
+        }
+        cursor = next_cursor;
+    }
+
+    if target_count == 0 {
+        debug!(event_id = %event.id, kind = %event.kind, "No recipients found for event");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn split_delivery_targets(
+    targets: Vec<NotificationTarget>,
+) -> (Vec<NotificationTarget>, Vec<NotificationTarget>) {
+    targets
+        .into_iter()
+        .partition(|target| target.notification_type != NotificationType::NewPost)
 }
 
 /// Find recipients for a reaction event (kind 7)
@@ -929,6 +1107,7 @@ fn video_mention_targets(event: &Event) -> Vec<NotificationTarget> {
 /// skipped rather than added.
 ///
 /// Kept separate from the Redis read so the dedup rule is testable on its own.
+#[cfg(test)]
 fn merge_watcher_targets(
     mut targets: Vec<NotificationTarget>,
     author: &PublicKey,
@@ -951,6 +1130,22 @@ fn merge_watcher_targets(
     targets
 }
 
+fn watcher_page_targets(
+    watchers: Vec<PublicKey>,
+    author: &PublicKey,
+    mentioned: &HashSet<PublicKey>,
+) -> Vec<NotificationTarget> {
+    watchers
+        .into_iter()
+        .filter(|watcher| watcher != author)
+        .filter(|watcher| !mentioned.contains(watcher))
+        .map(|recipient| NotificationTarget {
+            recipient,
+            notification_type: NotificationType::NewPost,
+        })
+        .collect()
+}
+
 /// Resolve a watcher lookup into the watchers to notify, degrading to none.
 ///
 /// Bells are enrichment layered on top of mentions, and they are the only part
@@ -961,6 +1156,7 @@ fn merge_watcher_targets(
 ///
 /// Kept separate from the read so the degradation is testable without an
 /// `AppState`.
+#[cfg(test)]
 fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<PublicKey> {
     match lookup {
         Ok(watchers) => watchers,
@@ -974,16 +1170,6 @@ fn watchers_or_degrade(event: &Event, lookup: Result<Vec<PublicKey>>) -> Vec<Pub
             Vec::new()
         }
     }
-}
-
-/// Build the notification targets for a video event: mentions plus bells.
-async fn video_notification_targets(state: &AppState, event: &Event) -> Vec<NotificationTarget> {
-    let lookup = redis_store::get_notify_watchers(&state.redis_pool, &event.pubkey).await;
-    merge_watcher_targets(
-        video_mention_targets(event),
-        &event.pubkey,
-        watchers_or_degrade(event, lookup),
-    )
 }
 
 /// Build the coordinate-and-recipient key used to deduplicate video edits.
@@ -2351,19 +2537,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_a_real_watcher_lookup_failure_still_delivers_mentions() {
-        // The test above proves `watchers_or_degrade` degrades. It does not
-        // prove anything calls it: it never reaches `video_notification_targets`,
-        // where the degradation is actually wired in, so replacing that call
-        // with `lookup.expect(...)` leaves the whole suite green. This drives a
-        // genuine `get_notify_watchers` failure through the real function, by
-        // leaving a string where the watcher set belongs so `SMEMBERS` fails
-        // with WRONGTYPE.
+    async fn test_a_real_watcher_page_failure_still_delivers_mentions() {
+        // This drives a genuine watcher-page failure through the real video
+        // delivery path by leaving a string where the watcher set belongs, so
+        // SSCAN fails with WRONGTYPE. Mentions came from the event's own tags
+        // and must still be delivered.
         let Some(pool) = test_redis_pool().await else {
             return;
         };
         let author = Keys::generate();
         let mentioned = Keys::generate().public_key();
+        let fcm_token = format!("mention_token_{}", EventId::all_zeros().to_hex());
+        redis_store::add_or_update_token(&pool, &mentioned, &fcm_token)
+            .await
+            .expect("register token");
         let event = EventBuilder::new(Kind::from(KIND_VIDEO), "video")
             .tag(Tag::identifier("wrongtype-vid"))
             .tag(Tag::public_key(mentioned))
@@ -2381,27 +2568,36 @@ mod tests {
 
         // Without this the test could pass vacuously, by the lookup succeeding
         // and simply finding no watchers.
-        let lookup_failed = redis_store::get_notify_watchers(&pool, &author.public_key())
-            .await
-            .is_err();
+        let lookup_failed =
+            redis_store::get_notify_watchers_page(&pool, &author.public_key(), 0, 1000)
+                .await
+                .is_err();
 
+        let mock_sender = MockFcmSender::new();
         let state = test_app_state(
             crate::config::Settings::new().unwrap(),
             pool.clone(),
-            FcmClient::new_with_impl(Box::new(MockFcmSender::new())),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
         );
-        let targets = video_notification_targets(&state, &event).await;
+        handle_video_content_event(&state, &event, CancellationToken::new())
+            .await
+            .expect("video handling degrades to mentions");
 
         let _: () = redis::cmd("DEL")
             .arg(&watchers_key)
             .query_async(&mut *conn)
             .await
             .unwrap();
+        redis_store::remove_token(&pool, &mentioned, &fcm_token)
+            .await
+            .expect("cleanup token");
 
         assert!(lookup_failed, "the seeded key must make the lookup fail");
-        assert_eq!(targets.len(), 1, "the mention survives the failed lookup");
-        assert_eq!(targets[0].recipient, mentioned);
-        assert_eq!(targets[0].notification_type, NotificationType::Mention);
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "the mention survives the failed watcher page lookup"
+        );
     }
 
     #[test]
@@ -2421,6 +2617,29 @@ mod tests {
         let bell = targets.iter().find(|t| t.recipient == watcher).unwrap();
         assert_eq!(mention.notification_type, NotificationType::Mention);
         assert_eq!(bell.notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn test_delivery_targets_split_new_post_from_regular_notifications() {
+        let mention_recipient = Keys::generate().public_key();
+        let watcher = Keys::generate().public_key();
+        let targets = vec![
+            NotificationTarget {
+                recipient: mention_recipient,
+                notification_type: NotificationType::Mention,
+            },
+            NotificationTarget {
+                recipient: watcher,
+                notification_type: NotificationType::NewPost,
+            },
+        ];
+
+        let (regular, new_posts) = split_delivery_targets(targets);
+
+        assert_eq!(regular.len(), 1);
+        assert_eq!(regular[0].notification_type, NotificationType::Mention);
+        assert_eq!(new_posts.len(), 1);
+        assert_eq!(new_posts[0].notification_type, NotificationType::NewPost);
     }
 
     #[test]

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -10,10 +10,13 @@ use firebase_messaging_rs::{
     },
     FCMClient as FirebaseClient,
 };
+use futures_util::{stream, StreamExt};
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, time::Duration};
 use thiserror::Error;
 use tracing;
+
+const FCM_BATCH_CONCURRENCY: usize = 100;
 
 #[derive(Error, Debug, Clone)]
 pub enum FcmError {
@@ -282,18 +285,24 @@ impl FcmClient {
         tokens: &[String],
         payload: FcmPayload,
     ) -> HashMap<String, std::result::Result<(), FcmError>> {
-        let mut results = HashMap::new();
-        for token in tokens {
-            // Delegate to the trait object's method
-            let result = self.client.send_single(token, payload.clone()).await;
-            results.insert(token.clone(), result);
-        }
+        let results = stream::iter(tokens.iter().cloned())
+            .map(|token| {
+                let payload = payload.clone();
+                async move {
+                    let result = self.client.send_single(&token, payload).await;
+                    (token, result)
+                }
+            })
+            .buffer_unordered(FCM_BATCH_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
         // Note: We are not returning a Result here anymore, but a HashMap of results.
         // The original code returned Result<HashMap<...>, FcmError> which seemed incorrect
         // as individual sends could fail without the whole batch failing.
         // If a top-level error IS needed (e.g., impossible to even start sending),
         // this signature might need adjustment, but usually, per-token results are desired.
-        results // Return the map directly
+        results.into_iter().collect()
     }
 
     /// Sends a notification payload to a single FCM token.

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -12,6 +12,7 @@ use bb8_redis::bb8::Pool;
 use bb8_redis::RedisConnectionManager;
 use nostr_sdk::{EventId, PublicKey, Timestamp};
 use redis::{RedisResult, Value};
+use std::collections::HashSet;
 use std::time::Duration;
 
 // Type alias for the connection pool
@@ -505,14 +506,69 @@ pub async fn get_notify_watchers(pool: &RedisPool, creator: &PublicKey) -> Resul
     Ok(watchers)
 }
 
+/// One page of subscribers watching a creator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotifyWatcherPage {
+    pub watchers: Vec<PublicKey>,
+    pub next_cursor: u64,
+}
+
+/// Read one SSCAN page of subscribers watching `creator`.
+///
+/// The video fan-out path loops over pages so each Redis read and delivery
+/// batch stays bounded without dropping subscribers beyond a permanent cap.
+/// Unparseable members are skipped with a warning rather than failing the page.
+pub async fn get_notify_watchers_page(
+    pool: &RedisPool,
+    creator: &PublicKey,
+    cursor: u64,
+    count: usize,
+) -> Result<NotifyWatcherPage> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    let (next_cursor, members): (u64, Vec<String>) = redis::cmd("SSCAN")
+        .arg(build_notify_watchers_key(creator))
+        .arg(cursor)
+        .arg("COUNT")
+        .arg(count)
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    let mut seen = HashSet::with_capacity(members.len());
+    let mut watchers = Vec::with_capacity(members.len());
+    for member in members {
+        match PublicKey::from_hex(&member) {
+            Ok(pubkey) => {
+                if seen.insert(pubkey) {
+                    watchers.push(pubkey);
+                }
+            }
+            Err(e) => tracing::warn!(
+                creator = %creator.to_hex(),
+                member = %member,
+                error = %e,
+                "Skipping unparseable notify watcher"
+            ),
+        }
+    }
+
+    Ok(NotifyWatcherPage {
+        watchers,
+        next_cursor,
+    })
+}
+
 /// Test whether `subscriber` watches `creator`.
 ///
 /// The membership question on its own. The bell fallback in
 /// `send_notification_to_user` asks it per muted-mention recipient, and it is
 /// the whole answer it needs, so it must not pay `get_notify_watchers`'s
-/// transfer-and-parse of a creator's entire watcher set. `SISMEMBER` answers in
-/// the server. `get_notify_watchers` stays the read for the fan-out, which does
-/// need every member.
+/// transfer-and-parse of a creator's entire watcher set. `SISMEMBER` answers
+/// in the server. Fan-out reads use `get_notify_watchers_page`.
 pub async fn is_notify_watcher(
     pool: &RedisPool,
     creator: &PublicKey,

--- a/tests/notify_subscriptions_test.rs
+++ b/tests/notify_subscriptions_test.rs
@@ -3,6 +3,7 @@
 
 use divine_push_service::redis_store;
 use nostr_sdk::prelude::*;
+use std::collections::HashSet;
 
 async fn create_test_pool() -> Option<redis_store::RedisPool> {
     let redis_url =
@@ -719,4 +720,49 @@ async fn test_a_half_applied_list_still_converges_on_the_next_one() {
     );
 
     cleanup(&pool, &keys_for(&subscriber, &all)).await;
+}
+
+#[tokio::test]
+async fn test_watcher_pages_walk_to_full_coverage() {
+    let Some(pool) = create_test_pool().await else {
+        return;
+    };
+
+    let subscribers: Vec<PublicKey> = (0..3).map(|_| Keys::generate().public_key()).collect();
+    let creator = Keys::generate().public_key();
+    for subscriber in &subscribers {
+        cleanup(&pool, &keys_for(subscriber, &[creator])).await;
+    }
+
+    for (idx, subscriber) in subscribers.iter().enumerate() {
+        redis_store::replace_notify_subscriptions(
+            &pool,
+            subscriber,
+            &[creator],
+            1000 + idx as u64,
+            &test_event_id(1000 + idx as u64),
+        )
+        .await
+        .expect("replace");
+    }
+
+    let mut cursor = 0;
+    let mut watchers = HashSet::new();
+    loop {
+        let page = redis_store::get_notify_watchers_page(&pool, &creator, cursor, 2)
+            .await
+            .expect("watcher page lookup");
+        watchers.extend(page.watchers);
+        if page.next_cursor == 0 {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    let expected: HashSet<PublicKey> = subscribers.iter().copied().collect();
+    assert_eq!(watchers, expected);
+
+    for subscriber in &subscribers {
+        cleanup(&pool, &keys_for(subscriber, &[creator])).await;
+    }
 }

--- a/tests/preferences_test.rs
+++ b/tests/preferences_test.rs
@@ -12,7 +12,26 @@ async fn get_test_pool() -> Option<redis_store::RedisPool> {
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
 
     match redis_store::create_pool(&redis_url, 5).await {
-        Ok(pool) => Some(pool),
+        Ok(pool) => {
+            let mut conn = match pool.get().await {
+                Ok(conn) => conn,
+                Err(_) => {
+                    println!("Skipping test: Redis not available");
+                    return None;
+                }
+            };
+
+            let ping_result: redis::RedisResult<String> =
+                redis::cmd("PING").query_async(&mut *conn).await;
+
+            if ping_result.is_err() {
+                println!("Skipping test: Redis not available");
+                return None;
+            }
+
+            drop(conn);
+            Some(pool)
+        }
         Err(_) => {
             println!("Skipping test: Redis not available");
             None

--- a/tests/test_token_reregistration.rs
+++ b/tests/test_token_reregistration.rs
@@ -14,6 +14,19 @@ async fn test_token_reregistration_by_different_pubkey() {
             return;
         }
     };
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => {
+            println!("Skipping test: Redis not available");
+            return;
+        }
+    };
+    let ping_result: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut *conn).await;
+    if ping_result.is_err() {
+        println!("Skipping test: Redis not available");
+        return;
+    }
+    drop(conn);
 
     // Create test data
     let token = "test_fcm_token_12345";


### PR DESCRIPTION
## Summary
- rebase onto current `feat/new-post-notifications` and keep the base branch's graceful watcher-lookup degradation
- replace the permanent NewPost watcher cap with paged Redis `SSCAN` fan-out, so every bell subscriber can be reached without one unbounded watcher read
- deliver each NewPost watcher page with bounded recipient concurrency, and make per-recipient FCM token sends concurrent inside `send_batch`
- add validation for the new paging/concurrency knobs and regression coverage for full watcher-page coverage and mention delivery when watcher paging fails
- keep Redis-backed tests aligned with the existing skip-when-unavailable convention so local full-suite verification is reliable

## Motivation
PR #35 adds bell notifications where recipient count is audience-shaped rather than p-tag-shaped. The handler needs bounded Redis reads and bounded delivery work, but dropping all subscribers past a fixed cap would silently penalize popular creators and the people who explicitly enabled bells.

This version treats `new_post_fanout_page_size` as a work-size bound, not a product recipient limit: the handler continues paging until Redis returns cursor 0. Mention targets still deliver even if the watcher lookup path fails.

## Linked issue
Refs #33.
Refs #35.
Refs #37.

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features`
