### PR TITLE
feat(observability): expose push delivery metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +591,8 @@ dependencies = [
  "futures-util",
  "gcp_auth",
  "hex",
+ "metrics",
+ "metrics-exporter-prometheus",
  "nostr-relay-builder",
  "nostr-sdk",
  "once_cell",
@@ -1299,6 +1316,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "indexmap",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1744,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1885,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2239,6 +2338,12 @@ checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -2910,6 +3015,28 @@ checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
 
 # --- Serialization & Deserialization ---
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The service implements a draft push-notification protocol; see [docs/nip-xx-push
 - **Deduplication** — atomic Redis `SET NX EX` per-event locks ensure each event is delivered once, even across replicas.
 - **Replay protection** — a configurable processing window (7 days by default) ignores stale events.
 - **Token cleanup** — a background task prunes stale tokens (older than 90 days by default) once a day.
+- **Prometheus metrics** — relay ingestion, event processing, FCM delivery outcomes, and token pruning are exposed for monitoring.
 - **Optional allow-list** — `allowed_pubkeys` can restrict delivery to a specific set of recipients.
 
 ## Protocol
@@ -68,7 +69,7 @@ Each FCM message carries a stable `data` payload with routing and presentation f
 4. For each match it checks dedup and the recipient's preferences, then sends a data message to Firebase FCM.
 5. Firebase delivers the notification to the device.
 
-The service is a single async binary running four cooperating tasks: a Nostr listener, an event handler, the token-cleanup service, and an HTTP server for health checks. Those tasks are supervised: if one ends unexpectedly, the others are cancelled and the process exits non-zero, so a pod whose delivery pipeline has died is restarted instead of staying in service. It is single-app — one Firebase project, one relay — built with `axum`, `tokio`, `nostr-sdk`, and `redis`.
+The service is a single async binary running four cooperating tasks: a Nostr listener, an event handler, the token-cleanup service, and an HTTP server for health checks and metrics. Those tasks are supervised: if one ends unexpectedly, the others are cancelled and the process exits non-zero, so a pod whose delivery pipeline has died is restarted instead of staying in service. It is single-app — one Firebase project, one relay — built with `axum`, `tokio`, `nostr-sdk`, and `redis`.
 
 ## Getting started
 
@@ -159,6 +160,7 @@ The container is a multi-stage build on `debian:bookworm-slim` that bundles the 
 | Endpoint | Description |
 |----------|-------------|
 | `GET /health` | Health check and service-key discovery. Clients read `pubkey` to discover the service key for registration and encryption. |
+| `GET /metrics` | Prometheus metrics for relay ingestion and push delivery. Responses include `Cache-Control: no-store`. |
 
 `/health` answers `200` while the delivery pipeline is alive:
 
@@ -174,6 +176,24 @@ If the Nostr listener or the event handler has died it answers `503` with
 `"status": "degraded"` and that task set to `false`. Both the liveness and the
 readiness probe point here, so a dead pipeline fails its probes rather than
 serving `200` behind a healthy-looking pod.
+
+The metrics endpoint exposes:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `push_events_received_total` | Counter | Events received from the Nostr relay. |
+| `push_events_processed_total` | Counter | Events whose handler completed. |
+| `push_fcm_sends_attempted_total` | Counter | FCM sends attempted per device token. |
+| `push_fcm_sends_succeeded_total` | Counter | Successful FCM sends per device token. |
+| `push_fcm_sends_failed_total{reason}` | Counter | Failed FCM sends by bounded failure reason. |
+| `push_tokens_pruned_total{reason}` | Counter | Tokens removed as `invalid` or `stale`. |
+| `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event handler call. Initialized at startup to give a new instance one alert window. |
+
+The delivery deadman is based on the last-processed gauge:
+
+```promql
+time() - max(push_last_event_processed_timestamp_seconds) > 900
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -182,18 +182,26 @@ The metrics endpoint exposes:
 | Metric | Type | Description |
 |--------|------|-------------|
 | `push_events_received_total` | Counter | Events received from the Nostr relay. |
-| `push_events_processed_total` | Counter | Events whose handler completed. |
+| `push_events_processed_total` | Counter | Events whose routing attempt completed, including attempts that ended in an error. |
 | `push_fcm_sends_attempted_total` | Counter | FCM sends attempted per device token. |
 | `push_fcm_sends_succeeded_total` | Counter | Successful FCM sends per device token. |
 | `push_fcm_sends_failed_total{reason}` | Counter | Failed FCM sends by bounded failure reason. |
 | `push_tokens_pruned_total{reason}` | Counter | Tokens removed as `invalid` or `stale`. |
-| `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event handler call. Initialized at startup to give a new instance one alert window. |
+| `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event routing attempt. Initialized at startup to give a new instance one alert window. |
 
 The delivery deadman is based on the last-processed gauge:
 
 ```promql
 time() - max(push_last_event_processed_timestamp_seconds) > 900
 ```
+
+This deadman detects a pipeline that stops completing event-routing attempts. It
+does not claim that an attempt delivered a push: use
+`push_fcm_sends_succeeded_total` and `push_fcm_sends_failed_total{reason}` to
+alert on FCM rejecting every delivery. Use the deadman alongside task-health and
+restart alerting; the startup timestamp avoids a premature deadman alert while a
+new instance waits for its first event, while task-health alerting covers a
+crash-looping instance that repeatedly resets that startup grace.
 
 ## License
 

--- a/src/cleanup_service.rs
+++ b/src/cleanup_service.rs
@@ -52,6 +52,9 @@ pub async fn run_cleanup_service(state: Arc<AppState>, token: CancellationToken)
                            match cleanup_result {
                                 Ok(cleaned_count) => {
                                     if cleaned_count > 0 {
+                                        crate::metrics::tokens_pruned("stale", cleaned_count as u64);
+                                    }
+                                    if cleaned_count > 0 {
                                         info!(count = cleaned_count, "Cleaned up stale tokens.");
                                     } else {
                                         info!("No stale tokens found to cleanup.");

--- a/src/cleanup_service.rs
+++ b/src/cleanup_service.rs
@@ -52,9 +52,7 @@ pub async fn run_cleanup_service(state: Arc<AppState>, token: CancellationToken)
                            match cleanup_result {
                                 Ok(cleaned_count) => {
                                     if cleaned_count > 0 {
-                                        crate::metrics::tokens_pruned("stale", cleaned_count as u64);
-                                    }
-                                    if cleaned_count > 0 {
+                                        record_stale_tokens_pruned(cleaned_count);
                                         info!(count = cleaned_count, "Cleaned up stale tokens.");
                                     } else {
                                         info!("No stale tokens found to cleanup.");
@@ -71,4 +69,29 @@ pub async fn run_cleanup_service(state: Arc<AppState>, token: CancellationToken)
     }
     info!("Cleanup service shut down.");
     Ok(())
+}
+
+fn record_stale_tokens_pruned(count: usize) {
+    crate::metrics::tokens_pruned("stale", count as u64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
+    #[test]
+    fn stale_cleanup_records_the_confirmed_redis_count() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || record_stale_tokens_pruned(3));
+
+        handle.run_upkeep();
+        let rendered = handle.render();
+        assert!(
+            rendered.contains(r#"push_tokens_pruned_total{reason="stale"} 3"#),
+            "{rendered}"
+        );
+    }
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -197,6 +197,8 @@ pub async fn run(
                     }
                 }
 
+                crate::metrics::event_processed();
+
                 if token.is_cancelled() {
                     info!(event_id = %event_id, "Event handler cancellation detected after processing event.");
                     break;
@@ -1658,16 +1660,22 @@ async fn send_notification_to_user(
                 return Err(crate::error::ServiceError::Cancelled);
             }
             let truncated_token = fcm_sender::token_prefix(&fcm_token_to_remove);
-            if let Err(e) =
-                redis_store::remove_token(&state.redis_pool, target_pubkey, &fcm_token_to_remove)
-                    .await
+            match redis_store::remove_token(&state.redis_pool, target_pubkey, &fcm_token_to_remove)
+                .await
             {
-                error!(
-                    target_pubkey = %target_pubkey, token_prefix = %truncated_token, error = %e,
-                    "Failed to remove invalid token"
-                );
-            } else {
-                info!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Removed invalid token");
+                Ok(true) => {
+                    crate::metrics::tokens_pruned("invalid", 1);
+                    info!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Removed invalid token");
+                }
+                Ok(false) => {
+                    debug!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Invalid token was already removed");
+                }
+                Err(e) => {
+                    error!(
+                        target_pubkey = %target_pubkey, token_prefix = %truncated_token, error = %e,
+                        "Failed to remove invalid token"
+                    );
+                }
             }
         }
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1663,12 +1663,13 @@ async fn send_notification_to_user(
             match redis_store::remove_token(&state.redis_pool, target_pubkey, &fcm_token_to_remove)
                 .await
             {
-                Ok(true) => {
-                    crate::metrics::tokens_pruned("invalid", 1);
-                    info!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Removed invalid token");
-                }
-                Ok(false) => {
-                    debug!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Invalid token was already removed");
+                Ok(removed) => {
+                    record_invalid_token_pruned(removed);
+                    if removed {
+                        info!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Removed invalid token");
+                    } else {
+                        debug!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Invalid token was already removed");
+                    }
                 }
                 Err(e) => {
                     error!(
@@ -1681,6 +1682,12 @@ async fn send_notification_to_user(
     }
 
     Ok(())
+}
+
+fn record_invalid_token_pruned(removed: bool) {
+    if removed {
+        crate::metrics::tokens_pruned("invalid", 1);
+    }
 }
 
 /// Create FCM payload for a notification
@@ -1920,6 +1927,24 @@ mod tests {
     use super::*;
     use crate::fcm_sender::{FcmClient, FcmError, MockFcmSender};
     use nostr_sdk::prelude::{Keys, SecretKey};
+
+    #[test]
+    fn invalid_pruning_records_confirmed_removal() {
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            record_invalid_token_pruned(true);
+            record_invalid_token_pruned(false);
+        });
+
+        handle.run_upkeep();
+        let rendered = handle.render();
+        assert!(
+            rendered.contains(r#"push_tokens_pruned_total{reason="invalid"} 1"#),
+            "{rendered}"
+        );
+    }
 
     async fn test_redis_pool() -> Option<redis_store::RedisPool> {
         let redis_url =

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -90,6 +90,23 @@ pub enum FcmError {
     Unknown { code: u16, hint: Option<String> },
 }
 
+impl FcmError {
+    /// Stable, bounded reason used by the FCM failure metric.
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::Initialization(_) => "initialization",
+            Self::InternalRequest(_) => "internal_request",
+            Self::InternalResponse(_) => "internal_response",
+            Self::Unauthorized(_) => "unauthorized",
+            Self::InvalidRequest(_) => "invalid_request",
+            Self::TokenNotRegistered => "token_not_registered",
+            Self::RetryableInternal(_) => "retryable_internal",
+            Self::InternalError => "internal_error",
+            Self::Unknown { .. } => "unknown",
+        }
+    }
+}
+
 /// The `errorCode` FCM returns in `error.details[]` for a token the device has
 /// discarded. This is the signal that a stored token should be pruned.
 const FCM_ERROR_CODE_UNREGISTERED: &str = "UNREGISTERED";
@@ -483,6 +500,7 @@ impl FcmClient {
             .map(|token| {
                 let payload = payload.clone();
                 async move {
+                    crate::metrics::fcm_send_attempted();
                     // Defence in depth, retained from #42. The specific panic it
                     // was written for is gone — `firebase-messaging-rs` read the
                     // `Retry-After` header via `HeaderName::from_static`, which
@@ -503,6 +521,10 @@ impl FcmClient {
                                 "FCM send panicked while handling the response".to_string(),
                             ))
                         });
+                    match &result {
+                        Ok(()) => crate::metrics::fcm_send_succeeded(),
+                        Err(error) => crate::metrics::fcm_send_failed(error.metric_reason()),
+                    }
                     (token, result)
                 }
             })
@@ -637,6 +659,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_fcm_sender_batch_send() {
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let _guard = metrics::set_default_local_recorder(&recorder);
         // Ensure FcmPayload derives PartialEq and Clone
         let mock_sender = MockFcmSender::new(); // Create instance directly
                                                 // Pass a boxed clone to the client
@@ -673,6 +698,21 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].0, "token1");
         assert_eq!(sent[0].1, payload);
+
+        handle.run_upkeep();
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("push_fcm_sends_attempted_total 2"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("push_fcm_sends_succeeded_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"push_fcm_sends_failed_total{reason="token_not_registered"} 1"#),
+            "{rendered}"
+        );
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod event_handler;
 pub mod fcm_sender;
 pub mod health;
+pub mod metrics;
 pub mod models;
 pub mod nostr_listener;
 pub mod preferences;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use divine_push_service::config;
 use divine_push_service::error::Result;
 use divine_push_service::event_handler;
 use divine_push_service::health::{CriticalTask, OnReturn, TaskHealth, TaskTracker};
+use divine_push_service::metrics;
 use divine_push_service::nostr_listener;
 use divine_push_service::server::run_server;
 use divine_push_service::state;
@@ -60,6 +61,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     tracing::info!("Starting diVine Push Service...");
+
+    let metrics_handle = metrics::init();
 
     let settings = config::Settings::new()?;
     tracing::info!("Configuration loaded successfully");
@@ -119,12 +122,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     tracing::info!("Cleanup service started");
 
-    // Start HTTP server (health check only)
+    // Start HTTP server
     let token_server = token.clone();
     let state_server = Arc::clone(&app_state);
     let health_server = Arc::clone(&health);
     tracker.spawn("http_server", None, OnReturn::Fatal, async move {
-        run_server(state_server, health_server, token_server).await;
+        run_server(state_server, health_server, metrics_handle, token_server).await;
         tracing::info!("HTTP server task finished.");
     });
     tracing::info!("HTTP server started");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,133 @@
+//! Prometheus metrics for relay ingestion and push delivery.
+
+use chrono::Utc;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+pub const EVENTS_RECEIVED_TOTAL: &str = "push_events_received_total";
+pub const EVENTS_PROCESSED_TOTAL: &str = "push_events_processed_total";
+pub const FCM_SENDS_ATTEMPTED_TOTAL: &str = "push_fcm_sends_attempted_total";
+pub const FCM_SENDS_SUCCEEDED_TOTAL: &str = "push_fcm_sends_succeeded_total";
+pub const FCM_SENDS_FAILED_TOTAL: &str = "push_fcm_sends_failed_total";
+pub const TOKENS_PRUNED_TOTAL: &str = "push_tokens_pruned_total";
+pub const LAST_EVENT_PROCESSED_TIMESTAMP_SECONDS: &str =
+    "push_last_event_processed_timestamp_seconds";
+
+/// Installs the process-wide Prometheus recorder and initializes its metrics.
+pub fn init() -> PrometheusHandle {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus recorder");
+
+    metrics::describe_counter!(
+        EVENTS_RECEIVED_TOTAL,
+        "Nostr events received from the relay"
+    );
+    metrics::describe_counter!(
+        EVENTS_PROCESSED_TOTAL,
+        "Nostr events processed by the handler"
+    );
+    metrics::describe_counter!(
+        FCM_SENDS_ATTEMPTED_TOTAL,
+        "FCM delivery attempts, counted per device token"
+    );
+    metrics::describe_counter!(
+        FCM_SENDS_SUCCEEDED_TOTAL,
+        "Successful FCM deliveries, counted per device token"
+    );
+    metrics::describe_counter!(
+        FCM_SENDS_FAILED_TOTAL,
+        "Failed FCM deliveries, counted per device token and reason"
+    );
+    metrics::describe_counter!(
+        TOKENS_PRUNED_TOTAL,
+        "FCM tokens removed by the service, counted by reason"
+    );
+    metrics::describe_gauge!(
+        LAST_EVENT_PROCESSED_TIMESTAMP_SECONDS,
+        "Unix timestamp of the last event whose handler completed"
+    );
+
+    // Give a newly started instance one deadman window to receive an event.
+    set_last_event_processed_timestamp(Utc::now().timestamp() as f64);
+    handle
+}
+
+pub fn event_received() {
+    metrics::counter!(EVENTS_RECEIVED_TOTAL).increment(1);
+}
+
+pub fn event_processed() {
+    metrics::counter!(EVENTS_PROCESSED_TOTAL).increment(1);
+    set_last_event_processed_timestamp(Utc::now().timestamp() as f64);
+}
+
+pub fn fcm_send_attempted() {
+    metrics::counter!(FCM_SENDS_ATTEMPTED_TOTAL).increment(1);
+}
+
+pub fn fcm_send_succeeded() {
+    metrics::counter!(FCM_SENDS_SUCCEEDED_TOTAL).increment(1);
+}
+
+pub fn fcm_send_failed(reason: &'static str) {
+    metrics::counter!(FCM_SENDS_FAILED_TOTAL, "reason" => reason).increment(1);
+}
+
+pub fn tokens_pruned(reason: &'static str, count: u64) {
+    metrics::counter!(TOKENS_PRUNED_TOTAL, "reason" => reason).increment(count);
+}
+
+fn set_last_event_processed_timestamp(timestamp: f64) {
+    metrics::gauge!(LAST_EVENT_PROCESSED_TIMESTAMP_SECONDS).set(timestamp);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delivery_metrics_render_with_bounded_labels() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            event_received();
+            event_processed();
+            fcm_send_attempted();
+            fcm_send_succeeded();
+            fcm_send_failed("unauthorized");
+            tokens_pruned("invalid", 1);
+        });
+
+        handle.run_upkeep();
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("push_events_received_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("push_events_processed_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("push_fcm_sends_attempted_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("push_fcm_sends_succeeded_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"push_fcm_sends_failed_total{reason="unauthorized"} 1"#),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"push_tokens_pruned_total{reason="invalid"} 1"#),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("push_last_event_processed_timestamp_seconds"),
+            "{rendered}"
+        );
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -24,7 +24,7 @@ pub fn init() -> PrometheusHandle {
     );
     metrics::describe_counter!(
         EVENTS_PROCESSED_TOTAL,
-        "Nostr events processed by the handler"
+        "Nostr events whose handler routing attempt completed"
     );
     metrics::describe_counter!(
         FCM_SENDS_ATTEMPTED_TOTAL,
@@ -44,7 +44,7 @@ pub fn init() -> PrometheusHandle {
     );
     metrics::describe_gauge!(
         LAST_EVENT_PROCESSED_TIMESTAMP_SECONDS,
-        "Unix timestamp of the last event whose handler completed"
+        "Unix timestamp of the last completed event routing attempt"
     );
 
     // Give a newly started instance one deadman window to receive an event.

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -190,6 +190,8 @@ impl NostrListener {
                         info!(count = historical_events.len(), "Processing historical control events...");
 
                         for event in historical_events {
+                            crate::metrics::event_received();
+
                             if event.pubkey == *service_pubkey {
                                 continue;
                             }
@@ -273,6 +275,8 @@ impl NostrListener {
             let mut oldest = None;
             let mut new_count = 0usize;
             for event in lists {
+                crate::metrics::event_received();
+
                 oldest = match oldest {
                     Some(current) if current <= event.created_at => Some(current),
                     _ => Some(event.created_at),
@@ -455,6 +459,8 @@ async fn run_live_loop(
                     Ok(notification) => {
                         match notification {
                             RelayPoolNotification::Event { event, .. } => {
+                                crate::metrics::event_received();
+
                                 if event.pubkey == service_pubkey {
                                     debug!("Skipping event from service account");
                                     continue;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,12 @@
-//! HTTP server exposing the Kubernetes health probe.
+//! HTTP server exposing health and Prometheus metrics.
 
-use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    routing::get,
+    Json, Router,
+};
+use metrics_exporter_prometheus::PrometheusHandle;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -14,13 +20,19 @@ use crate::state::AppState;
 pub struct ServerState {
     service_pubkey: Option<String>,
     health: Arc<TaskHealth>,
+    metrics: PrometheusHandle,
 }
 
 impl ServerState {
-    pub fn new(service_pubkey: Option<String>, health: Arc<TaskHealth>) -> Self {
+    pub fn new(
+        service_pubkey: Option<String>,
+        health: Arc<TaskHealth>,
+        metrics: PrometheusHandle,
+    ) -> Self {
         Self {
             service_pubkey,
             health,
+            metrics,
         }
     }
 }
@@ -57,18 +69,33 @@ async fn health_check(State(state): State<ServerState>) -> (StatusCode, Json<ser
     )
 }
 
+async fn metrics(
+    State(state): State<ServerState>,
+) -> ([(header::HeaderName, &'static str); 1], String) {
+    (
+        [(header::CACHE_CONTROL, "no-store")],
+        state.metrics.render(),
+    )
+}
+
 pub fn router(state: ServerState) -> Router {
     Router::new()
         .route("/health", get(health_check))
+        .route("/metrics", get(metrics))
         .with_state(state)
 }
 
 pub async fn run_server(
     app_state: Arc<AppState>,
     health: Arc<TaskHealth>,
+    metrics: PrometheusHandle,
     token: CancellationToken,
 ) {
-    let app = router(ServerState::new(app_state.service_pubkey_hex(), health));
+    let app = router(ServerState::new(
+        app_state.service_pubkey_hex(),
+        health,
+        metrics,
+    ));
 
     // Failure paths below deliberately just return. Cancelling the token here
     // would make this look like an ordinary shutdown to the supervising
@@ -115,10 +142,16 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+    use metrics_exporter_prometheus::PrometheusBuilder;
     use tower::ServiceExt;
 
+    fn server_state(health: Arc<TaskHealth>) -> ServerState {
+        let metrics = PrometheusBuilder::new().build_recorder().handle();
+        ServerState::new(Some("pubkey-hex".to_string()), health, metrics)
+    }
+
     async fn get_health(health: Arc<TaskHealth>) -> (StatusCode, serde_json::Value) {
-        let response = router(ServerState::new(Some("pubkey-hex".to_string()), health))
+        let response = router(server_state(health))
             .oneshot(
                 Request::builder()
                     .uri("/health")
@@ -192,5 +225,34 @@ mod tests {
         let (status, _body) = get_health(health).await;
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn metrics_are_rendered_without_caching() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        ::metrics::with_local_recorder(&recorder, crate::metrics::event_received);
+        let response = router(ServerState::new(
+            Some("pubkey-hex".to_string()),
+            Arc::new(TaskHealth::new()),
+            handle,
+        ))
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8(body.to_vec())
+            .unwrap()
+            .contains("push_events_received_total 1"));
     }
 }


### PR DESCRIPTION
## Summary

Add application metrics that show whether the push pipeline is receiving events, completing routing attempts, and delivering through FCM. The existing health endpoint still reports task liveness; the new metrics make a live but inactive or failing delivery path observable.

Refs #48.

## What Changed

- Added `GET /metrics` on the existing HTTP port with `Cache-Control: no-store`.
- Added relay-event, event-processing, FCM attempt/success/failure, and token-pruning counters with bounded reason labels.
- Added the last-processed-event timestamp used by the event-processing deadman.
- Added endpoint and metric tests, including mixed FCM outcomes and confirmed token-pruning counts.
- Documented metric semantics and how the deadman complements FCM failure and task-health alerting.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

The reusable Semantic PR workflow has no local command and was not run locally. I did not test a live VictoriaMetrics scrape or alert delivery; those require the companion infrastructure change.

## Follow-up

The infrastructure repository still needs the service scrape and alert rules described in issue #48.
