### PR TITLE
fix(fcm): deliver Android social notifications promptly

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -64,7 +64,7 @@ The service watches for these event kinds and notifies the tagged recipient:
 
 The FCM message carries **no top-level `notification` field** — the `data` map below is always present and is identical in shape for every notification type (only the `title`/`body` strings differ); every `data` value is a string. Per-platform delivery then diverges so that **one incoming push produces exactly one visible banner**:
 
-- **Android** — data-only (`notification` and `android` unset). Android does not auto-display data messages, so the app renders the single banner itself from the `data` fields.
+- **Android** — data-only (top-level `notification` unset) with `android.priority` set to `high`. Android does not auto-display data messages, so the app renders the single banner itself from the `data` fields; high priority lets FCM wake an idle device promptly for this user-visible notification.
 - **iOS** — the service attaches an APNS override: `aps.alert` (title/body) + `mutable-content: 1`, push-type `alert`, priority 10. The OS presents the single banner; a Notification Service Extension (if shipped) uses `mutable-content` to *enrich* that same banner, never to create a second one. `content-available` is deliberately omitted — see [Avoiding duplicate banners](#avoiding-duplicate-banners).
 
 ```json

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -338,6 +338,23 @@ fn build_apns_config(payload: &FcmPayload) -> Option<serde_json::Value> {
     }))
 }
 
+/// Builds the `android` block for user-visible FCM messages.
+///
+/// High priority may wake a device from Doze, so reserve it for payloads that
+/// contain notification copy and will produce a visible notification.
+fn build_android_config(payload: &FcmPayload) -> Option<serde_json::Value> {
+    let notification_has_alert = payload
+        .notification
+        .as_ref()
+        .is_some_and(|notification| notification.title.is_some() || notification.body.is_some());
+    let data_has_alert = payload
+        .data
+        .as_ref()
+        .is_some_and(|data| data.contains_key("title") || data.contains_key("body"));
+
+    (notification_has_alert || data_has_alert).then(|| serde_json::json!({ "priority": "high" }))
+}
+
 fn json_object_from_data(
     data: impl Iterator<Item = (String, String)>,
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -380,6 +397,7 @@ impl RealFcmClient {
     ) -> std::result::Result<(), FcmError> {
         let prefix = token_prefix(token);
         let apns = build_apns_config(&payload);
+        let android = build_android_config(&payload);
 
         let mut message = serde_json::Map::new();
         message.insert(
@@ -407,10 +425,9 @@ impl RealFcmClient {
         if let Some(apns) = apns {
             message.insert("apns".to_string(), apns);
         }
-        message.insert(
-            "android".to_string(),
-            serde_json::json!({ "priority": "high" }),
-        );
+        if let Some(android) = android {
+            message.insert("android".to_string(), android);
+        }
 
         let access_token =
             self.token_provider.token(&[FCM_SCOPE]).await.map_err(|e| {
@@ -1118,6 +1135,65 @@ mod tests {
         assert!(body["message"]["apns"]["payload"]["aps"]
             .get("content-available")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn send_single_does_not_use_high_priority_for_silent_data() {
+        let (client, captured) =
+            stub_fcm(200, &[], r#"{"name":"projects/test-project/messages/1"}"#).await;
+        let payload = FcmPayload {
+            notification: None,
+            data: Some(std::collections::HashMap::from([(
+                "eventId".to_string(),
+                "abc123".to_string(),
+            )])),
+            android: None,
+            webpush: None,
+            apns: None,
+        };
+
+        client
+            .send_single("device-token-1", payload)
+            .await
+            .expect("send should succeed");
+
+        let requests = captured.lock().unwrap().clone();
+        assert_eq!(requests.len(), 1);
+        let (body, _) = &requests[0];
+
+        assert!(body["message"].get("android").is_none());
+        assert_eq!(
+            body["message"]["apns"]["headers"]["apns-push-type"],
+            "background"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_single_preserves_notification_payload() {
+        let (client, captured) =
+            stub_fcm(200, &[], r#"{"name":"projects/test-project/messages/1"}"#).await;
+        let payload = FcmPayload {
+            notification: Some(FcmNotification {
+                title: Some("New like".to_string()),
+                body: Some("Alice liked your post".to_string()),
+            }),
+            data: None,
+            android: None,
+            webpush: None,
+            apns: None,
+        };
+
+        client
+            .send_single("device-token-1", payload)
+            .await
+            .expect("send should succeed");
+
+        let requests = captured.lock().unwrap().clone();
+        assert_eq!(requests.len(), 1);
+        let (body, _) = &requests[0];
+
+        assert_eq!(body["message"]["notification"]["title"], "New like");
+        assert_eq!(body["message"]["android"]["priority"], "high");
     }
 
     /// The exact production failure: FCM returns 503 with a `Retry-After`

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -407,6 +407,10 @@ impl RealFcmClient {
         if let Some(apns) = apns {
             message.insert("apns".to_string(), apns);
         }
+        message.insert(
+            "android".to_string(),
+            serde_json::json!({ "priority": "high" }),
+        );
 
         let access_token =
             self.token_provider.token(&[FCM_SCOPE]).await.map_err(|e| {
@@ -1072,14 +1076,13 @@ mod tests {
         (client, captured)
     }
 
-    fn alert_payload() -> FcmPayload {
+    fn social_payload() -> FcmPayload {
         let mut data = std::collections::HashMap::new();
         data.insert("eventId".to_string(), "abc123".to_string());
+        data.insert("title".to_string(), "New like".to_string());
+        data.insert("body".to_string(), "Alice liked your post".to_string());
         FcmPayload {
-            notification: Some(FcmNotification {
-                title: Some("New like".to_string()),
-                body: Some("Alice liked your post".to_string()),
-            }),
+            notification: None,
             data: Some(data),
             android: None,
             webpush: None,
@@ -1088,12 +1091,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_single_posts_a_well_formed_authenticated_message() {
+    async fn send_single_posts_a_high_priority_data_only_social_message() {
         let (client, captured) =
             stub_fcm(200, &[], r#"{"name":"projects/test-project/messages/1"}"#).await;
 
         client
-            .send_single("device-token-1", alert_payload())
+            .send_single("device-token-1", social_payload())
             .await
             .expect("send should succeed");
 
@@ -1103,8 +1106,10 @@ mod tests {
 
         assert_eq!(auth.as_deref(), Some("Bearer stub-access-token"));
         assert_eq!(body["message"]["token"], "device-token-1");
-        assert_eq!(body["message"]["notification"]["title"], "New like");
+        assert!(body["message"].get("notification").is_none());
+        assert_eq!(body["message"]["android"]["priority"], "high");
         assert_eq!(body["message"]["data"]["eventId"], "abc123");
+        assert_eq!(body["message"]["data"]["title"], "New like");
         assert_eq!(
             body["message"]["apns"]["headers"]["apns-push-type"],
             "alert"
@@ -1126,7 +1131,7 @@ mod tests {
         )
         .await;
 
-        let result = client.send_single("device-token-1", alert_payload()).await;
+        let result = client.send_single("device-token-1", social_payload()).await;
 
         match result {
             Err(FcmError::RetryableInternal(delay)) => {
@@ -1162,7 +1167,7 @@ mod tests {
 
         let outcome = tokio::time::timeout(
             Duration::from_secs(10),
-            client.send_single("device-token-1", alert_payload()),
+            client.send_single("device-token-1", social_payload()),
         )
         .await;
 
@@ -1205,7 +1210,7 @@ mod tests {
         );
 
         // Paused clock: this advances virtual time, it does not really wait.
-        let result = client.send_single("device-token-1", alert_payload()).await;
+        let result = client.send_single("device-token-1", social_payload()).await;
 
         match result {
             Err(FcmError::InternalRequest(message)) => {
@@ -1240,7 +1245,7 @@ mod tests {
         )
         .await;
 
-        let result = client.send_single("dead-token", alert_payload()).await;
+        let result = client.send_single("dead-token", social_payload()).await;
         assert!(matches!(result, Err(FcmError::TokenNotRegistered)));
     }
 }


### PR DESCRIPTION
## Summary

Android social notifications can be delayed while a device is idle because Firebase Cloud Messaging defaults them to normal priority.
This change requests high-priority Android delivery while preserving the data-only payload that lets the app render one notification.

## What Changed

- Added the supported high-priority Android configuration to Firebase HTTP v1 messages.
- Kept the Android payload data-only with no top-level notification field.
- Added wire-level coverage for the serialized request and documented the intentional platform contract.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Not tested on a physical Android device.

The reusable Semantic PR workflow has no local command and will run after the pull request is opened.

Closes #44
