### PR TITLE
fix(push): make recipient delivery retry-safe and fan-out durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,11 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - `token_to_pubkey` - Hash mapping a token back to its owner
 - `stale_tokens` - Sorted set of token timestamps, for cleanup
 - `user_preferences:{pubkey}` - User's notification preferences (JSON)
-- `dedup:{event_id}` - Per-event processing claim with TTL. Notify lists are exempt: they are idempotent by `created_at`, so the claim prevents nothing and a failed handler would otherwise strand the list for the TTL
+- `dedup:{event_id}` - Per-event processing claim for control events
+- `dedup:{event_id}:{recipient}` - Per-recipient content-delivery claim. Retryable failures release it; successful or ambiguous sends retain it
 - `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video. The scoping is one-directional: a delivered mention also writes the `newPost` record, because naming the video already tells the recipient it exists
+- `fanout:enqueued:{event_id}` - Initial durable new-post fan-out enqueue marker
+- `new_post_fanout_jobs` - Sorted set of durable cursor-page jobs, scored by availability or lease expiry
 - `notify_subs:{subscriber}` - Creators this user has belled
 - `notify_subs_ts:{subscriber}` - `created_at:event_id` of the last applied notify list (out-of-order guard). The id resolves a `created_at` tie by NIP-01's lowest-id rule; a bare integer from an earlier build still reads as a timestamp with no known id
 - `notify_watchers:{creator}` - Subscribers watching this creator (hot read path)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The metrics endpoint exposes:
 | `push_fcm_sends_attempted_total` | Counter | FCM sends attempted per device token. |
 | `push_fcm_sends_succeeded_total` | Counter | Successful FCM sends per device token. |
 | `push_fcm_sends_failed_total{reason}` | Counter | Failed FCM sends by bounded failure reason. |
-| `push_new_post_fanout_retries_total{reason,outcome}` | Counter | Durable new-post page retries by bounded failure reason and scheduled/exhausted outcome. |
+| `push_new_post_fanout_retries_total{reason,outcome}` | Counter | Durable new-post page retries by bounded failure reason and scheduled, preserved, or exhausted outcome. |
 | `push_tokens_pruned_total{reason}` | Counter | Tokens removed as `invalid` or `stale`. |
 | `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event routing attempt. Initialized at startup to give a new instance one alert window. |
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The metrics endpoint exposes:
 | `push_fcm_sends_attempted_total` | Counter | FCM sends attempted per device token. |
 | `push_fcm_sends_succeeded_total` | Counter | Successful FCM sends per device token. |
 | `push_fcm_sends_failed_total{reason}` | Counter | Failed FCM sends by bounded failure reason. |
+| `push_new_post_fanout_retries_total{reason,outcome}` | Counter | Durable new-post page retries by bounded failure reason and scheduled/exhausted outcome. |
 | `push_tokens_pruned_total{reason}` | Counter | Tokens removed as `invalid` or `stale`. |
 | `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event routing attempt. Initialized at startup to give a new instance one alert window. |
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The metrics endpoint exposes:
 | `push_fcm_sends_attempted_total` | Counter | FCM sends attempted per device token. |
 | `push_fcm_sends_succeeded_total` | Counter | Successful FCM sends per device token. |
 | `push_fcm_sends_failed_total{reason}` | Counter | Failed FCM sends by bounded failure reason. |
-| `push_new_post_fanout_retries_total{reason,outcome}` | Counter | Durable new-post page retries by bounded failure reason and scheduled, preserved, or exhausted outcome. |
+| `push_new_post_fanout_retries_total{reason,outcome}` | Counter | Durable new-post page retries by bounded failure reason and scheduled, preserved, exhausted, or expired outcome. |
 | `push_tokens_pruned_total{reason}` | Counter | Tokens removed as `invalid` or `stale`. |
 | `push_last_event_processed_timestamp_seconds` | Gauge | Unix timestamp of the last completed event routing attempt. Initialized at startup to give a new instance one alert window. |
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -19,6 +19,9 @@ service:
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
   new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
   new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
+  new_post_fanout_lease_secs: 3600  # Reclaim a page if its worker dies
+  new_post_fanout_retry_secs: 5  # Delay before retrying a recoverable page failure
+  new_post_fanout_poll_millis: 250  # Idle durable-worker poll interval
 
 redis:
   url: "redis://127.0.0.1:6379"

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -19,7 +19,7 @@ service:
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
   new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
   new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
-  new_post_fanout_lease_secs: 3600  # Reclaim a page if its worker dies
+  new_post_fanout_lease_secs: 1200  # 20 waves x 45s FCM ceiling, plus 5m overhead
   new_post_fanout_retry_secs: 5  # Delay before retrying a recoverable page failure
   new_post_fanout_poll_millis: 250  # Idle durable-worker poll interval
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -19,7 +19,7 @@ service:
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
   new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
   new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
-  new_post_fanout_lease_secs: 3600  # Reclaim a page if its worker dies
+  new_post_fanout_lease_secs: 1200  # 20 waves x 45s FCM ceiling, plus 5m overhead
   new_post_fanout_retry_secs: 5  # Delay before retrying a recoverable page failure
   new_post_fanout_poll_millis: 250  # Idle durable-worker poll interval
   # allowed_pubkeys: [] — empty means no restriction (production default)

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -19,6 +19,9 @@ service:
   notify_list_history_limit: 5000  # Page size for historical notify-list replay
   new_post_fanout_page_size: 1000  # Watcher SSCAN page size for one video
   new_post_delivery_concurrency: 50  # Concurrent NewPost deliveries per page
+  new_post_fanout_lease_secs: 3600  # Reclaim a page if its worker dies
+  new_post_fanout_retry_secs: 5  # Delay before retrying a recoverable page failure
+  new_post_fanout_poll_millis: 250  # Idle durable-worker poll interval
   # allowed_pubkeys: [] — empty means no restriction (production default)
 
 redis:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -360,9 +360,12 @@ page sized by `new_post_fanout_page_size`, and delivers with at most
 `new_post_delivery_concurrency` concurrent recipient sends. Completing the page
 atomically removes it and queues the next cursor. A crashed worker's page is
 eligible again after `new_post_fanout_lease_secs`; recoverable failures use
-`new_post_fanout_retry_secs`. Successful per-recipient claims make these
-at-least-once page retries safe. The page size is not a recipient cap; jobs
-continue until Redis returns cursor 0.
+exponential backoff from `new_post_fanout_retry_secs` up to five minutes. Jobs
+expire after the processed-event TTL instead of retrying and occupying Redis
+forever. Graceful shutdown releases the active page immediately; a crash relies
+on lease expiry. Successful per-recipient claims make these at-least-once page
+retries safe. The page size is not a recipient cap; jobs continue until Redis
+returns cursor 0.
 
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -24,8 +24,8 @@ sequenceDiagram
     Note over App,Device: Notification Delivery
     Relay->>Push: New event (like, comment, follow, etc.)
     Push->>Redis: Check recipient has registered token
-    Push->>Redis: Check dedup (SET NX EX)
     Push->>Redis: Check user preferences
+    Push->>Redis: Claim (event, recipient) (SET NX EX)
     Push->>FCM: Send data-only message
     FCM->>Device: Push notification
 ```
@@ -173,7 +173,7 @@ GET /health
 {
   "status": "ok",
   "pubkey": "abc123...",
-  "tasks": { "nostr_listener": true, "event_handler": true }
+  "tasks": { "nostr_listener": true, "event_handler": true, "new_post_fanout": true }
 }
 ```
 
@@ -182,15 +182,23 @@ Clients use this pubkey to:
 - Encrypt the NIP-44 content to the service's key
 
 The same endpoint is both Kubernetes probes. It returns `503` with
-`"status": "degraded"` when the Nostr listener or the event handler has died,
+`"status": "degraded"` when the Nostr listener, event handler, or durable
+new-post fan-out worker has died,
 so a pod that can no longer deliver is restarted instead of staying in service.
 The `pubkey` field is present either way.
 
 ## Deduplication
 
-The service uses atomic Redis `SET NX EX` per-event keys to prevent duplicate notifications across multiple replicas. Each event that sends a push is claimed exactly once with a 7-day TTL.
+The service uses atomic Redis `SET NX EX` keys per `(event_id, recipient)` to
+prevent duplicate notifications across replicas. The claim is taken only after
+token, preference, coordinate, and rate-limit gates pass. A confirmed retryable
+FCM failure releases that recipient's claim; any successful token retains it for
+the configured processed-event TTL. This lets a replay resume recipients after
+a partial failure without resending recipients that already succeeded.
 
-Notify lists (kind 30000, `d=notify`) are the exception: they send no push, and claiming them would strand a subscriber's bells for the TTL if the handler failed. See [Ingestion](#ingestion) for why the claim buys nothing there.
+Control events keep a coarse per-event claim because each mutates one
+event-scoped record. Notify lists (kind 30000, `d=notify`) are idempotent through
+their atomic replacement script and take no claim.
 
 ## User Preferences
 
@@ -244,16 +252,11 @@ Two properties are load-bearing:
   `until`, using `notify_list_history_limit` as the per-page size valve.
   Without historical replay, a restart against a fresh Redis silently drops
   every bell until each user republishes.
-- **Notify lists are exempt from the event claim.** `run()` claims every other
-  event before routing it, so two replicas cannot send the same push twice.
-  Notify lists send nothing, and `replace_notify_subscriptions` already rejects
-  any list not strictly newer than the stored one, so the claim prevents nothing
-  here. It does cost something: the claim is taken before routing and never
-  released, so a transient Redis error inside the handler leaves it standing and
-  the replay on the next restart skips the event as already-claimed. That
-  subscriber's bells stay dark for the full `processed_event_ttl_secs`.
-  `requires_event_claim` scopes the exemption with `is_notify_list`, the same
-  kind-plus-`d`-tag check the horizon exemption uses.
+- **Notify lists are idempotent without an event claim.**
+  `replace_notify_subscriptions` already rejects stale list state and reapplies
+  an exact replay as repair. Content events use per-recipient delivery claims,
+  while registration, deregistration, and preference events retain coarse
+  per-event claims.
 - **An empty `p` list is legitimate**, not malformed. It means the user unbelled
   everyone, and it must clear the forward set and remove them from every reverse
   index.
@@ -350,13 +353,16 @@ When the rate limit suppresses a new-post push, the video-coordinate record is
 still written. That video has been intentionally dropped for that watcher, and a
 later NIP-33 edit should not re-announce it as a fresh post.
 
-New-post fan-out is paged by `new_post_fanout_page_size` and each page is
-delivered with at most `new_post_delivery_concurrency` concurrent recipient
-sends. This is separate from the notify-list write cap: one user's list cannot
-stall Redis on write, and one popular creator's audience cannot turn a single
-video into one unbounded Redis read or unbounded sequential delivery loop. The
-page size is not a recipient cap; the handler continues until Redis returns
-cursor 0.
+New-post fan-out is durable and runs outside the event-handler loop. After inline
+mention delivery, the handler atomically queues an initial Redis job containing
+the video and cursor 0. A supervised worker leases one job, reads one `SSCAN`
+page sized by `new_post_fanout_page_size`, and delivers with at most
+`new_post_delivery_concurrency` concurrent recipient sends. Completing the page
+atomically removes it and queues the next cursor. A crashed worker's page is
+eligible again after `new_post_fanout_lease_secs`; recoverable failures use
+`new_post_fanout_retry_secs`. Successful per-recipient claims make these
+at-least-once page retries safe. The page size is not a recipient cap; jobs
+continue until Redis returns cursor 0.
 
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and
@@ -394,8 +400,11 @@ the fan-out follow-up rather than done by halves here.
 | `user_tokens:{pubkey}` | Set | FCM tokens registered for a pubkey |
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
 | `stale_tokens` | Sorted Set | Token timestamps for cleanup |
-| `dedup:{event_id}` | String | Per-event processing claim with TTL. Not taken for notify lists, which are idempotent by `created_at` and would be lost for the TTL if a failed handler left a claim standing |
+| `dedup:{event_id}` | String | Per-event processing claim with TTL for registration, deregistration, and preference control events |
+| `dedup:{event_id}:{recipient}` | String | Per-recipient content-delivery claim with TTL. Acquired before FCM, retained after any successful or ambiguous delivery, and released after confirmed retryable failure |
 | `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Per-recipient video delivery decision, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered or rate-limited bell writes its own |
+| `fanout:enqueued:{event_id}` | String | Initial new-post fan-out enqueue marker with the processed-event TTL |
+| `new_post_fanout_jobs` | Sorted Set | Durable new-post page jobs. The score is the next availability time or active lease deadline |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |
 | `notify_subs:{subscriber}` | Set | Creators this user has belled. Diffed against each incoming replacement list. |
 | `notify_subs_ts:{subscriber}` | String | `created_at:event_id` of the last applied notify list. Guards against out-of-order relay delivery of a replaceable event, and carries the id so a `created_at` tie resolves by NIP-01's lowest-id rule. Exact-id replays apply idempotently for repair. A bare integer written by an earlier build is read as a timestamp with no known id, which only makes the guard more conservative. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -358,11 +358,16 @@ page sized by `new_post_fanout_page_size`, and delivers with at most
 atomically removes it and queues the next cursor. A crashed worker's page is
 eligible again after `new_post_fanout_lease_secs`; recoverable failures use
 exponential backoff from `new_post_fanout_retry_secs` up to five minutes, while
-an FCM `Retry-After` remains a floor even when it is longer. A page is discarded
-with its remaining cursor chain after 12 total delivery attempts, which includes
-about 30 minutes of scheduled default backoff;
+an FCM `Retry-After` remains a floor even when it is longer, bounded by the job's
+remaining lifetime. A page is discarded after 12 total delivery attempts, which
+includes about 30 minutes of scheduled default backoff. When delivery already
+resolved a successor cursor, exhaustion queues that successor so one poison page
+does not drop every later watcher page;
 `push_new_post_fanout_retries_total{reason,outcome}` exposes scheduled and
-exhausted retries. Jobs also expire after the processed-event TTL. Graceful
+exhausted retries, plus ownerless preservation after a Redis operation error.
+That preservation path keeps the known queue member rather than trusting a
+possibly completed attempt swap, so it does not advance the durable attempt
+counter. Jobs also expire after the processed-event TTL. Graceful
 shutdown releases the active page immediately; a crash relies on lease expiry.
 Successful per-recipient claims make these at-least-once page retries safe. The
 page size is not a recipient cap; jobs continue until Redis returns cursor 0.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -362,7 +362,9 @@ an FCM `Retry-After` remains a floor even when it is longer, bounded by the job'
 remaining lifetime. A page is discarded after 12 total delivery attempts, which
 includes about 30 minutes of scheduled default backoff. When delivery already
 resolved a successor cursor, exhaustion queues that successor so one poison page
-does not drop every later watcher page;
+does not drop every later watcher page. The successor inherits the exhausted
+page's delay so a provider-wide outage cannot immediately march through the
+remaining chain;
 `push_new_post_fanout_retries_total{reason,outcome}` exposes scheduled and
 exhausted retries, plus ownerless preservation after a Redis operation error.
 That preservation path keeps the known queue member rather than trusting a
@@ -371,6 +373,10 @@ counter. Jobs also expire after the processed-event TTL. Graceful
 shutdown releases the active page immediately; a crash relies on lease expiry.
 Successful per-recipient claims make these at-least-once page retries safe. The
 page size is not a recipient cap; jobs continue until Redis returns cursor 0.
+Operators tuning page size or delivery concurrency should retain a lease of at
+least `ceil(page_size / concurrency) * 45 seconds`, plus headroom for Redis and
+profile work. The shipped defaults use 900 seconds for the FCM ceiling and five
+minutes of headroom.
 
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -357,12 +357,15 @@ page sized by `new_post_fanout_page_size`, and delivers with at most
 `new_post_delivery_concurrency` concurrent recipient sends. Completing the page
 atomically removes it and queues the next cursor. A crashed worker's page is
 eligible again after `new_post_fanout_lease_secs`; recoverable failures use
-exponential backoff from `new_post_fanout_retry_secs` up to five minutes. Jobs
-expire after the processed-event TTL instead of retrying and occupying Redis
-forever. Graceful shutdown releases the active page immediately; a crash relies
-on lease expiry. Successful per-recipient claims make these at-least-once page
-retries safe. The page size is not a recipient cap; jobs continue until Redis
-returns cursor 0.
+exponential backoff from `new_post_fanout_retry_secs` up to five minutes, while
+an FCM `Retry-After` remains a floor even when it is longer. A page is discarded
+with its remaining cursor chain after 12 total delivery attempts, which includes
+about 30 minutes of scheduled default backoff;
+`push_new_post_fanout_retries_total{reason,outcome}` exposes scheduled and
+exhausted retries. Jobs also expire after the processed-event TTL. Graceful
+shutdown releases the active page immediately; a crash relies on lease expiry.
+Successful per-recipient claims make these at-least-once page retries safe. The
+page size is not a recipient cap; jobs continue until Redis returns cursor 0.
 
 The rate limit is push-only. The in-app feed shows every post from belled
 creators, so a user who receives one push for a six-post burst opens the app and

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,15 @@ pub struct ServiceSettings {
     /// Maximum concurrent new-post deliveries for one watcher page.
     #[serde(default = "default_new_post_delivery_concurrency")]
     pub new_post_delivery_concurrency: usize,
+    /// Lease held while one worker processes a durable new-post page.
+    #[serde(default = "default_new_post_fanout_lease")]
+    pub new_post_fanout_lease_secs: u64,
+    /// Delay before retrying a durable new-post page after a recoverable failure.
+    #[serde(default = "default_new_post_fanout_retry")]
+    pub new_post_fanout_retry_secs: u64,
+    /// Idle poll interval for the durable new-post worker.
+    #[serde(default = "default_new_post_fanout_poll")]
+    pub new_post_fanout_poll_millis: u64,
     /// When set, only send notifications to these pubkeys (hex). Empty means no restriction.
     /// Accepts a comma-separated string (from env vars) or a YAML list.
     #[serde(default, deserialize_with = "deserialize_comma_separated")]
@@ -124,6 +133,18 @@ fn default_new_post_fanout_page_size() -> usize {
 
 fn default_new_post_delivery_concurrency() -> usize {
     50
+}
+
+fn default_new_post_fanout_lease() -> u64 {
+    3600
+}
+
+fn default_new_post_fanout_retry() -> u64 {
+    5
+}
+
+fn default_new_post_fanout_poll() -> u64 {
+    250
 }
 
 fn default_new_post_rate_limit() -> u64 {
@@ -304,7 +325,7 @@ impl Settings {
     /// `NOSTR_PUSH__SERVICE__ALLOWED_PUBKEYS` that way, so the same mechanism
     /// reaches every field below.
     fn validate(&self) -> Result<(), ConfigError> {
-        let must_be_positive: [(&str, u64, &str); 8] = [
+        let must_be_positive: [(&str, u64, &str); 11] = [
             (
                 "nostr.profile_cache_ttl_secs",
                 self.nostr.profile_cache_ttl_secs,
@@ -344,6 +365,21 @@ impl Settings {
                 "service.new_post_delivery_concurrency",
                 self.service.new_post_delivery_concurrency as u64,
                 "new-post fan-out cannot start delivery work",
+            ),
+            (
+                "service.new_post_fanout_lease_secs",
+                self.service.new_post_fanout_lease_secs,
+                "durable fan-out jobs can be claimed concurrently",
+            ),
+            (
+                "service.new_post_fanout_retry_secs",
+                self.service.new_post_fanout_retry_secs,
+                "recoverable fan-out failures retry in a tight loop",
+            ),
+            (
+                "service.new_post_fanout_poll_millis",
+                self.service.new_post_fanout_poll_millis,
+                "an idle worker spins continuously against Redis",
             ),
         ];
 
@@ -436,7 +472,7 @@ mod tests {
 
         // One case per field, because a loop over the same setter would pass
         // just as well against a `validate` that only checks the first.
-        let cases: [ZeroCase; 8] = [
+        let cases: [ZeroCase; 11] = [
             ("nostr.profile_cache_ttl_secs", |s| {
                 s.nostr.profile_cache_ttl_secs = 0
             }),
@@ -460,6 +496,15 @@ mod tests {
             }),
             ("service.new_post_delivery_concurrency", |s| {
                 s.service.new_post_delivery_concurrency = 0
+            }),
+            ("service.new_post_fanout_lease_secs", |s| {
+                s.service.new_post_fanout_lease_secs = 0
+            }),
+            ("service.new_post_fanout_retry_secs", |s| {
+                s.service.new_post_fanout_retry_secs = 0
+            }),
+            ("service.new_post_fanout_poll_millis", |s| {
+                s.service.new_post_fanout_poll_millis = 0
             }),
         ];
 
@@ -498,6 +543,9 @@ mod tests {
             let settings = load_runtime_settings(filename);
             assert!(settings.service.new_post_fanout_page_size > 0);
             assert!(settings.service.new_post_delivery_concurrency > 0);
+            assert!(settings.service.new_post_fanout_lease_secs > 0);
+            assert!(settings.service.new_post_fanout_retry_secs > 0);
+            assert!(settings.service.new_post_fanout_poll_millis > 0);
             assert!(
                 settings.service.new_post_delivery_concurrency
                     <= settings.service.new_post_fanout_page_size

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,19 +392,6 @@ impl Settings {
             }
         }
 
-        let page_waves = u64::try_from(self.service.new_post_fanout_page_size)
-            .unwrap_or(u64::MAX)
-            .div_ceil(
-                u64::try_from(self.service.new_post_delivery_concurrency).unwrap_or(u64::MAX),
-            );
-        let minimum_lease_secs =
-            page_waves.saturating_mul(crate::fcm_sender::FCM_OPERATION_TIMEOUT.as_secs());
-        if self.service.new_post_fanout_lease_secs < minimum_lease_secs {
-            return Err(ConfigError::Message(format!(
-                "service.new_post_fanout_lease_secs must be at least {minimum_lease_secs} for the configured page size and delivery concurrency"
-            )));
-        }
-
         Ok(())
     }
 
@@ -573,17 +560,5 @@ mod tests {
                     <= settings.service.new_post_fanout_page_size
             );
         }
-    }
-
-    #[test]
-    fn test_new_post_fanout_lease_covers_the_configured_page() {
-        let mut settings = Settings::new().unwrap();
-        settings.service.new_post_fanout_lease_secs = 899;
-
-        let error = settings.validate().unwrap_err().to_string();
-        assert!(
-            error.contains("must be at least 900"),
-            "the error must explain the configured page's minimum lease, got: {error}"
-        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,10 @@ fn default_new_post_delivery_concurrency() -> usize {
 }
 
 fn default_new_post_fanout_lease() -> u64 {
-    3600
+    // A 1,000-recipient page at concurrency 50 is 20 waves. Each FCM operation
+    // is bounded at 45 seconds, so 20 minutes covers the 15-minute send ceiling
+    // plus Redis/profile overhead while recovering a dead worker promptly.
+    1200
 }
 
 fn default_new_post_fanout_retry() -> u64 {
@@ -546,7 +549,7 @@ mod tests {
             let settings = load_runtime_settings(filename);
             assert!(settings.service.new_post_fanout_page_size > 0);
             assert!(settings.service.new_post_delivery_concurrency > 0);
-            assert!(settings.service.new_post_fanout_lease_secs > 0);
+            assert_eq!(settings.service.new_post_fanout_lease_secs, 1_200);
             assert!(settings.service.new_post_fanout_retry_secs > 0);
             assert!(settings.service.new_post_fanout_poll_millis > 0);
             assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,6 +392,19 @@ impl Settings {
             }
         }
 
+        let page_waves = u64::try_from(self.service.new_post_fanout_page_size)
+            .unwrap_or(u64::MAX)
+            .div_ceil(
+                u64::try_from(self.service.new_post_delivery_concurrency).unwrap_or(u64::MAX),
+            );
+        let minimum_lease_secs =
+            page_waves.saturating_mul(crate::fcm_sender::FCM_OPERATION_TIMEOUT.as_secs());
+        if self.service.new_post_fanout_lease_secs < minimum_lease_secs {
+            return Err(ConfigError::Message(format!(
+                "service.new_post_fanout_lease_secs must be at least {minimum_lease_secs} for the configured page size and delivery concurrency"
+            )));
+        }
+
         Ok(())
     }
 
@@ -549,7 +562,10 @@ mod tests {
             let settings = load_runtime_settings(filename);
             assert!(settings.service.new_post_fanout_page_size > 0);
             assert!(settings.service.new_post_delivery_concurrency > 0);
-            assert_eq!(settings.service.new_post_fanout_lease_secs, 1_200);
+            assert_eq!(
+                settings.service.new_post_fanout_lease_secs,
+                default_new_post_fanout_lease()
+            );
             assert!(settings.service.new_post_fanout_retry_secs > 0);
             assert!(settings.service.new_post_fanout_poll_millis > 0);
             assert!(
@@ -557,5 +573,17 @@ mod tests {
                     <= settings.service.new_post_fanout_page_size
             );
         }
+    }
+
+    #[test]
+    fn test_new_post_fanout_lease_covers_the_configured_page() {
+        let mut settings = Settings::new().unwrap();
+        settings.service.new_post_fanout_lease_secs = 899;
+
+        let error = settings.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("must be at least 900"),
+            "the error must explain the configured page's minimum lease, got: {error}"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ pub enum ServiceError {
 
     #[error("Operation cancelled")]
     Cancelled,
+
+    #[error("Retryable delivery failure; retry after {0:?}")]
+    RetryableDelivery(std::time::Duration),
 }
 
 impl IntoResponse for ServiceError {
@@ -113,6 +116,10 @@ impl IntoResponse for ServiceError {
             ServiceError::Cancelled => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Operation cancelled".to_string(),
+            ),
+            ServiceError::RetryableDelivery(delay) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("Retryable delivery failure; retry after {:?}", delay),
             ),
         };
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -16,9 +16,11 @@ use crate::{
 };
 use futures_util::{stream, StreamExt};
 use nostr_sdk::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::Receiver;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -72,26 +74,16 @@ pub fn is_beyond_replay_horizon(event: &Event) -> bool {
 
 /// Whether the handler loop should claim this event before routing it.
 ///
-/// The claim exists to stop two replicas sending the same push twice, and for
-/// every handler that sends a push it is the only thing standing between a
-/// duplicate and the user. Notify lists send nothing. They build persistent
-/// state through `replace_notify_subscriptions`, a single atomic Lua script that
-/// already rejects any list not strictly newer than the stored one, so
-/// concurrent replicas applying the same list are a no-op with or without the
-/// claim.
-///
-/// Meanwhile the claim is taken *before* routing and never released, so a
-/// transient Redis error inside the handler leaves it standing: the historical
-/// replay on the next restart skips the event as already-claimed, and that
-/// subscriber's bells stay dark until `processed_event_ttl_secs` expires, seven
-/// days by default. So the claim trades an outage of a user's subscriptions for
-/// deduplication the Lua script performs anyway.
-///
-/// Scoped by `is_notify_list` rather than kind alone, symmetric with
-/// `is_beyond_replay_horizon`: the idempotency argument rests on the Lua script,
-/// which only runs for `d=notify`.
+/// Control events mutate one event-scoped record and retain the coarse claim.
+/// Content delivery instead claims `(event_id, recipient)` immediately before
+/// FCM, so a failed or interrupted recipient cannot consume every recipient
+/// behind it. Notify lists remain idempotent through their atomic replacement
+/// script, and unrelated event kinds do no work here.
 pub fn requires_event_claim(event: &Event) -> bool {
-    !is_notify_list(event)
+    matches!(
+        event.kind.as_u16(),
+        KIND_REGISTRATION | KIND_DEREGISTRATION | KIND_PREFERENCES_UPDATE
+    )
 }
 
 /// Check if event is targeted to this service via p tag
@@ -637,6 +629,7 @@ async fn send_notifications_sequential(
     copy: &LazyEventCopy,
     token: CancellationToken,
 ) -> Result<()> {
+    let mut first_error = None;
     for target in targets {
         if token.is_cancelled() {
             info!(event_id = %event.id, "Notification sending cancelled");
@@ -664,10 +657,14 @@ async fn send_notifications_sequential(
                 error = %e,
                 "Failed to send notification"
             );
+            first_error.get_or_insert(e);
         }
     }
 
-    Ok(())
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 async fn send_notifications_bounded(
@@ -709,11 +706,11 @@ async fn send_notifications_bounded(
     // not sent yet return immediately. It does not close the window inside
     // `send_notification_to_user`, which still returns `Cancelled` between the
     // FCM send and the writes below it; that one predates this branch.
-    let mut cancelled = None;
+    let mut first_error = None;
     while let Some((recipient, result)) = deliveries.next().await {
         if let Err(e) = result {
             if matches!(e, crate::error::ServiceError::Cancelled) {
-                cancelled.get_or_insert(e);
+                first_error.get_or_insert(e);
                 continue;
             }
             error!(
@@ -722,10 +719,11 @@ async fn send_notifications_bounded(
                 error = %e,
                 "Failed to send notification"
             );
+            first_error.get_or_insert(e);
         }
     }
 
-    match cancelled {
+    match first_error {
         Some(e) => Err(e),
         None => Ok(()),
     }
@@ -763,22 +761,12 @@ async fn handle_video_content_event(
     token: CancellationToken,
 ) -> Result<()> {
     let mention_targets = deliverable_targets(video_mention_targets(event), &event.pubkey);
-    let mentioned: HashSet<PublicKey> = mention_targets
-        .iter()
-        .map(|target| target.recipient)
-        .collect();
-
-    // One copy for the whole event, spanning the mention pass and every watcher
-    // page. Building it per page would put the cost back on a per-page footing:
-    // `get_display_name` misses are never negatively cached, so a creator with
-    // no kind-0 metadata pays a five-second relay round-trip for each page, on
-    // the event-handler loop that every other user's notifications queue behind.
-    // `needs_content` is decided by the mention targets alone because `NewPost`
-    // does not render the event body, so no watcher page can widen it.
+    // Mentions remain inline and small. The resolved sender name, when mentions
+    // needed it, is carried into the durable watcher job so later pages do not
+    // repeat profile lookup work.
     let copy = LazyEventCopy::for_targets(&mention_targets);
 
-    let mut target_count = 0usize;
-    if !mention_targets.is_empty() {
+    let mention_result = if !mention_targets.is_empty() {
         info!(
             event_id = %event.id,
             kind = %event.kind,
@@ -786,77 +774,188 @@ async fn handle_video_content_event(
             notification_types = ?vec![(NotificationType::Mention.display_name(), mention_targets.len())],
             "Processing notification event"
         );
-        send_notifications_sequential(state, event, mention_targets, &copy, token.clone()).await?;
-        target_count += mentioned.len();
-    }
+        send_notifications_sequential(state, event, mention_targets, &copy, token.clone()).await
+    } else {
+        Ok(())
+    };
 
-    let page_size = state.settings.service.new_post_fanout_page_size;
-    let concurrency = state.settings.service.new_post_delivery_concurrency;
-    let mut cursor = 0;
+    let job = NewPostFanoutJob {
+        event_json: serde_json::to_string(event)?,
+        cursor: 0,
+        sender_name: copy.cell.get().map(|resolved| resolved.sender_name.clone()),
+    };
+    let job_json = serde_json::to_string(&job)?;
+    let enqueued = redis_store::enqueue_initial_fanout_job(
+        &state.redis_pool,
+        &event.id,
+        &job_json,
+        state.settings.service.processed_event_ttl_secs,
+    )
+    .await?;
+    debug!(event_id = %event.id, enqueued, "Queued durable new-post fan-out");
+
+    mention_result
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NewPostFanoutJob {
+    event_json: String,
+    cursor: u64,
+    sender_name: Option<String>,
+}
+
+/// Runs durable cursor-paged new-post fan-out outside the event-handler loop.
+pub async fn run_new_post_fanout(state: Arc<AppState>, token: CancellationToken) -> Result<()> {
+    info!("Starting durable new-post fan-out worker...");
+    let poll_interval = Duration::from_millis(state.settings.service.new_post_fanout_poll_millis);
+
     loop {
         if token.is_cancelled() {
-            info!(event_id = %event.id, "Notification sending cancelled");
-            return Err(crate::error::ServiceError::Cancelled);
+            break;
         }
 
-        let page = match redis_store::get_notify_watchers_page(
-            &state.redis_pool,
-            &event.pubkey,
-            cursor,
-            page_size,
+        let job = tokio::select! {
+            biased;
+            _ = token.cancelled() => break,
+            result = redis_store::claim_fanout_job(
+                &state.redis_pool,
+                state.settings.service.new_post_fanout_lease_secs,
+            ) => result,
+        };
+
+        match job {
+            Ok(Some(job_json)) => {
+                process_fanout_job(&state, &job_json, token.clone()).await?;
+            }
+            Ok(None) => {
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(poll_interval) => {}
+                }
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to claim durable new-post fan-out job");
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(poll_interval) => {}
+                }
+            }
+        }
+    }
+
+    info!("Durable new-post fan-out worker shut down.");
+    Ok(())
+}
+
+async fn process_fanout_job(
+    state: &AppState,
+    job_json: &str,
+    token: CancellationToken,
+) -> Result<()> {
+    let job: NewPostFanoutJob = match serde_json::from_str(job_json) {
+        Ok(job) => job,
+        Err(e) => {
+            error!(error = %e, "Discarding malformed durable new-post fan-out job");
+            redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
+            return Ok(());
+        }
+    };
+    let event: Event = match serde_json::from_str::<Event>(&job.event_json) {
+        Ok(event) if event.kind.as_u16() == KIND_VIDEO => event,
+        Ok(event) => {
+            error!(event_id = %event.id, kind = %event.kind, "Discarding non-video fan-out job");
+            redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
+            return Ok(());
+        }
+        Err(e) => {
+            error!(error = %e, "Discarding fan-out job with malformed event");
+            redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
+            return Ok(());
+        }
+    };
+
+    let page = match redis_store::get_notify_watchers_page(
+        &state.redis_pool,
+        &event.pubkey,
+        job.cursor,
+        state.settings.service.new_post_fanout_page_size,
+    )
+    .await
+    {
+        Ok(page) => page,
+        Err(e) => {
+            error!(event_id = %event.id, cursor = job.cursor, error = %e, "Failed to read durable watcher page; scheduling retry");
+            redis_store::retry_fanout_job(
+                &state.redis_pool,
+                job_json,
+                state.settings.service.new_post_fanout_retry_secs,
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let mentioned: HashSet<PublicKey> = video_mention_targets(&event)
+        .into_iter()
+        .map(|target| target.recipient)
+        .collect();
+    let targets = watcher_page_targets(page.watchers, &event.pubkey, &mentioned);
+    let copy = match &job.sender_name {
+        Some(sender_name) => LazyEventCopy::resolved(EventScopedCopy {
+            sender_name: sender_name.clone(),
+            formatted_content: None,
+        }),
+        None => LazyEventCopy::for_targets(&targets),
+    };
+
+    if !targets.is_empty() {
+        info!(
+            event_id = %event.id,
+            recipient_count = targets.len(),
+            cursor = job.cursor,
+            next_cursor = page.next_cursor,
+            "Processing durable new-post notification page"
+        );
+        if let Err(e) = send_notifications_bounded(
+            state,
+            &event,
+            targets,
+            &copy,
+            token,
+            state.settings.service.new_post_delivery_concurrency,
         )
         .await
         {
-            Ok(page) => page,
-            Err(e) => {
-                error!(
-                    event_id = %event.id,
-                    creator = %event.pubkey,
-                    cursor,
-                    error = %e,
-                    delivered_so_far = target_count,
-                    "Failed to read notify watcher page - abandoning the rest of the bell fan-out for this video"
-                );
-                break;
+            if matches!(e, crate::error::ServiceError::Cancelled) {
+                return Err(e);
             }
+            let retry_secs = match &e {
+                crate::error::ServiceError::RetryableDelivery(delay) => delay
+                    .as_secs()
+                    .max(state.settings.service.new_post_fanout_retry_secs),
+                _ => state.settings.service.new_post_fanout_retry_secs,
+            };
+            error!(event_id = %event.id, cursor = job.cursor, error = %e, "Durable watcher page was incomplete; scheduling retry");
+            redis_store::retry_fanout_job(&state.redis_pool, job_json, retry_secs).await?;
+            return Ok(());
+        }
+    }
+
+    let next_job = if page.next_cursor == 0 {
+        None
+    } else {
+        let next = NewPostFanoutJob {
+            event_json: job.event_json,
+            cursor: page.next_cursor,
+            sender_name: job
+                .sender_name
+                .or_else(|| copy.cell.get().map(|resolved| resolved.sender_name.clone())),
         };
-
-        let next_cursor = page.next_cursor;
-        let new_post_targets = watcher_page_targets(page.watchers, &event.pubkey, &mentioned);
-        if !new_post_targets.is_empty() {
-            let page_target_count = new_post_targets.len();
-            info!(
-                event_id = %event.id,
-                kind = %event.kind,
-                recipient_count = page_target_count,
-                notification_types = ?vec![(NotificationType::NewPost.display_name(), page_target_count)],
-                cursor,
-                next_cursor,
-                "Processing new-post notification page"
-            );
-            send_notifications_bounded(
-                state,
-                event,
-                new_post_targets,
-                &copy,
-                token.clone(),
-                concurrency,
-            )
-            .await?;
-            target_count += page_target_count;
-        }
-
-        if next_cursor == 0 {
-            break;
-        }
-        cursor = next_cursor;
-    }
-
-    if target_count == 0 {
-        debug!(event_id = %event.id, kind = %event.kind, "No recipients found for event");
-    }
-
-    Ok(())
+        Some(serde_json::to_string(&next)?)
+    };
+    redis_store::complete_fanout_job(&state.redis_pool, job_json, next_job.as_deref()).await
 }
 
 /// Find recipients for a reaction event (kind 7)
@@ -1036,8 +1135,7 @@ impl LazyEventCopy {
         }
     }
 
-    /// Pre-resolved copy, for tests that exercise delivery rather than copy.
-    #[cfg(test)]
+    /// Pre-resolved copy for durable pages and focused delivery tests.
     fn resolved(copy: EventScopedCopy) -> Self {
         Self {
             cell: tokio::sync::OnceCell::new_with(Some(copy)),
@@ -1505,6 +1603,28 @@ async fn send_notification_to_user(
         }
     }
 
+    let recipient_claim = tokio::select! {
+        biased;
+        _ = token.cancelled() => {
+            info!(event_id = %event_id, target_pubkey = %target_pubkey, "Cancelled before claiming recipient delivery.");
+            return Err(crate::error::ServiceError::Cancelled);
+        }
+        claim_result = redis_store::try_claim_recipient_event(
+            &state.redis_pool,
+            &event_id,
+            target_pubkey,
+            state.settings.service.processed_event_ttl_secs,
+        ) => claim_result?
+    };
+    let Some(recipient_claim) = recipient_claim else {
+        trace!(
+            event_id = %event_id,
+            target_pubkey = %target_pubkey,
+            "Skipping recipient already claimed for this event"
+        );
+        return Ok(());
+    };
+
     info!(
         event_id = %event_id,
         target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
@@ -1518,6 +1638,12 @@ async fn send_notification_to_user(
         biased;
         _ = token.cancelled() => {
             info!(event_id = %event_id, target_pubkey = %target_pubkey, "Cancelled while resolving the event copy.");
+            if let Err(e) = redis_store::release_recipient_event_claim(
+                &state.redis_pool,
+                &recipient_claim,
+            ).await {
+                error!(event_id = %event_id, target_pubkey = %target_pubkey, error = %e, "Failed to release unstarted recipient claim during cancellation");
+            }
             return Err(crate::error::ServiceError::Cancelled);
         }
         resolved = copy.get(state, event) => resolved
@@ -1554,6 +1680,7 @@ async fn send_notification_to_user(
     // FCM 5xx, a timeout — still summarised as `failed_count=0`, which reads as
     // "nothing went wrong" in exactly the logs an operator checks first.
     let mut failed_count = 0;
+    let mut retryable_failure = None;
 
     for (fcm_token, result) in results {
         if token.is_cancelled() {
@@ -1588,6 +1715,9 @@ async fn send_notification_to_user(
                     error = %reason,
                     "FCM send failed for token"
                 );
+                if let Err(fcm_sender::FcmError::RetryableInternal(delay)) = &result {
+                    retryable_failure = Some(*delay);
+                }
             }
         }
     }
@@ -1669,6 +1799,13 @@ async fn send_notification_to_user(
             } else {
                 info!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Removed invalid token");
             }
+        }
+    }
+
+    if success_count == 0 {
+        if let Some(delay) = retryable_failure {
+            redis_store::release_recipient_event_claim(&state.redis_pool, &recipient_claim).await?;
+            return Err(crate::error::ServiceError::RetryableDelivery(delay));
         }
     }
 
@@ -2549,6 +2686,15 @@ mod tests {
             .await
             .expect("video handling degrades to mentions");
 
+        let queued_job = NewPostFanoutJob {
+            event_json: serde_json::to_string(&event).unwrap(),
+            cursor: 0,
+            sender_name: Some(format_short_npub(&author.public_key())),
+        };
+        redis_store::complete_fanout_job(&pool, &serde_json::to_string(&queued_job).unwrap(), None)
+            .await
+            .unwrap();
+
         let _: () = redis::cmd("DEL")
             .arg(&watchers_key)
             .query_async(&mut *conn)
@@ -2719,6 +2865,28 @@ mod tests {
             .unwrap();
 
         let result = handle_video_content_event(&state, &event, CancellationToken::new()).await;
+        result.expect("the handler queues fan-out");
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "watcher delivery must not run on the event-handler loop"
+        );
+
+        for _ in 0..100 {
+            let Some(job_json) = redis_store::claim_fanout_job(
+                &pool,
+                state.settings.service.new_post_fanout_lease_secs,
+            )
+            .await
+            .expect("claim durable page") else {
+                break;
+            };
+            process_fanout_job(&state, &job_json, CancellationToken::new())
+                .await
+                .expect("process durable page");
+            if mock_sender.get_sent_messages().len() == WATCHERS {
+                break;
+            }
+        }
 
         for (idx, watcher) in watchers.iter().enumerate() {
             let _ = redis_store::remove_token(
@@ -2752,12 +2920,177 @@ mod tests {
             .await
             .unwrap();
 
-        result.expect("the fan-out completes");
         assert_eq!(
             mock_sender.get_sent_messages().len(),
             WATCHERS,
             "every watcher is notified, not just the ones on the first page"
         );
+    }
+
+    #[tokio::test]
+    async fn recipient_claims_recover_partial_delivery_without_resending_successes() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let first = Keys::generate().public_key();
+        let second = Keys::generate().public_key();
+        let first_token = format!("partial-first-{}", first.to_hex());
+        let second_token = format!("partial-second-{}", second.to_hex());
+        redis_store::add_or_update_token(&pool, &first, &first_token)
+            .await
+            .unwrap();
+        redis_store::add_or_update_token(&pool, &second, &second_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("partial delivery")
+            .tag(Tag::public_key(first))
+            .tag(Tag::public_key(second))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        send_notification_to_user(
+            &state,
+            &event,
+            &first,
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let targets = targets_of(NotificationType::Mention, vec![first, second]);
+        send_notifications_sequential(
+            &state,
+            &event,
+            targets,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            2,
+            "replay reaches the untouched recipient without duplicating the completed one"
+        );
+
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{}:{}", event.id.to_hex(), first.to_hex()))
+            .arg(format!("dedup:{}:{}", event.id.to_hex(), second.to_hex()))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &first, &first_token)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &second, &second_token)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn retryable_recipient_failure_releases_only_that_recipient_claim() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let first = Keys::generate().public_key();
+        let second = Keys::generate().public_key();
+        let first_token = format!("retry-first-{}", first.to_hex());
+        let second_token = format!("retry-second-{}", second.to_hex());
+        redis_store::add_or_update_token(&pool, &first, &first_token)
+            .await
+            .unwrap();
+        redis_store::add_or_update_token(&pool, &second, &second_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        mock_sender.set_error_for_token(
+            &second_token,
+            FcmError::RetryableInternal(Duration::from_secs(1)),
+        );
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("retryable partial delivery")
+            .tag(Tag::public_key(first))
+            .tag(Tag::public_key(second))
+            .sign_with_keys(&author)
+            .unwrap();
+        let targets = targets_of(NotificationType::Mention, vec![first, second]);
+
+        let first_pass = send_notifications_sequential(
+            &state,
+            &event,
+            targets.clone(),
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await;
+        assert!(matches!(
+            first_pass,
+            Err(crate::error::ServiceError::RetryableDelivery(_))
+        ));
+        assert_eq!(mock_sender.get_sent_messages().len(), 1);
+
+        mock_sender.clear();
+        send_notifications_sequential(
+            &state,
+            &event,
+            targets.clone(),
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "only the failed recipient retries"
+        );
+
+        send_notifications_sequential(
+            &state,
+            &event,
+            targets,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            mock_sender.get_sent_messages().len(),
+            1,
+            "successful retry is retained and cannot deliver twice"
+        );
+
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("dedup:{}:{}", event.id.to_hex(), first.to_hex()))
+            .arg(format!("dedup:{}:{}", event.id.to_hex(), second.to_hex()))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &first, &first_token)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &second, &second_token)
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -783,6 +783,10 @@ async fn handle_video_content_event(
         event_json: serde_json::to_string(event)?,
         cursor: 0,
         sender_name: copy.cell.get().map(|resolved| resolved.sender_name.clone()),
+        attempt: 0,
+        expires_at: Timestamp::now()
+            .as_secs()
+            .saturating_add(state.settings.service.processed_event_ttl_secs),
     };
     let job_json = serde_json::to_string(&job)?;
     let enqueued = redis_store::enqueue_initial_fanout_job(
@@ -802,6 +806,8 @@ struct NewPostFanoutJob {
     event_json: String,
     cursor: u64,
     sender_name: Option<String>,
+    attempt: u16,
+    expires_at: u64,
 }
 
 /// Runs durable cursor-paged new-post fan-out outside the event-handler loop.
@@ -825,7 +831,27 @@ pub async fn run_new_post_fanout(state: Arc<AppState>, token: CancellationToken)
 
         match job {
             Ok(Some(job_json)) => {
-                process_fanout_job(&state, &job_json, token.clone()).await?;
+                if let Err(e) = process_fanout_job(&state, &job_json, token.clone()).await {
+                    if matches!(e, crate::error::ServiceError::Cancelled) {
+                        if let Err(retry_error) =
+                            redis_store::rescore_fanout_job(&state.redis_pool, &job_json, 0).await
+                        {
+                            error!(error = %retry_error, "Failed to release cancelled fan-out page lease; lease expiry will recover it");
+                        }
+                        break;
+                    }
+
+                    error!(error = %e, "Durable fan-out page processing failed; preserving the leased page");
+                    if let Err(retry_error) = redis_store::rescore_fanout_job(
+                        &state.redis_pool,
+                        &job_json,
+                        state.settings.service.new_post_fanout_retry_secs,
+                    )
+                    .await
+                    {
+                        error!(error = %retry_error, "Failed to reschedule fan-out page after processing error; lease expiry will recover it");
+                    }
+                }
             }
             Ok(None) => {
                 tokio::select! {
@@ -876,6 +902,12 @@ async fn process_fanout_job(
         }
     };
 
+    if Timestamp::now().as_secs() >= job.expires_at {
+        warn!(event_id = %event.id, cursor = job.cursor, attempts = job.attempt, "Discarding expired durable fan-out page");
+        redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
+        return Ok(());
+    }
+
     let page = match redis_store::get_notify_watchers_page(
         &state.redis_pool,
         &event.pubkey,
@@ -887,12 +919,7 @@ async fn process_fanout_job(
         Ok(page) => page,
         Err(e) => {
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Failed to read durable watcher page; scheduling retry");
-            redis_store::retry_fanout_job(
-                &state.redis_pool,
-                job_json,
-                state.settings.service.new_post_fanout_retry_secs,
-            )
-            .await?;
+            schedule_fanout_retry(state, job_json, &job, 0).await?;
             return Ok(());
         }
     };
@@ -931,14 +958,12 @@ async fn process_fanout_job(
             if matches!(e, crate::error::ServiceError::Cancelled) {
                 return Err(e);
             }
-            let retry_secs = match &e {
-                crate::error::ServiceError::RetryableDelivery(delay) => delay
-                    .as_secs()
-                    .max(state.settings.service.new_post_fanout_retry_secs),
-                _ => state.settings.service.new_post_fanout_retry_secs,
+            let provider_delay = match &e {
+                crate::error::ServiceError::RetryableDelivery(delay) => delay.as_secs(),
+                _ => 0,
             };
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Durable watcher page was incomplete; scheduling retry");
-            redis_store::retry_fanout_job(&state.redis_pool, job_json, retry_secs).await?;
+            schedule_fanout_retry(state, job_json, &job, provider_delay).await?;
             return Ok(());
         }
     }
@@ -952,10 +977,34 @@ async fn process_fanout_job(
             sender_name: job
                 .sender_name
                 .or_else(|| copy.cell.get().map(|resolved| resolved.sender_name.clone())),
+            attempt: 0,
+            expires_at: job.expires_at,
         };
         Some(serde_json::to_string(&next)?)
     };
     redis_store::complete_fanout_job(&state.redis_pool, job_json, next_job.as_deref()).await
+}
+
+async fn schedule_fanout_retry(
+    state: &AppState,
+    current_job: &str,
+    job: &NewPostFanoutJob,
+    minimum_delay_secs: u64,
+) -> Result<()> {
+    const MAX_RETRY_DELAY_SECS: u64 = 300;
+
+    let mut retry = job.clone();
+    retry.attempt = retry.attempt.saturating_add(1);
+    let exponent = u32::from(retry.attempt.saturating_sub(1).min(6));
+    let backoff = state
+        .settings
+        .service
+        .new_post_fanout_retry_secs
+        .saturating_mul(1u64 << exponent)
+        .min(MAX_RETRY_DELAY_SECS);
+    let delay = backoff.max(minimum_delay_secs.min(MAX_RETRY_DELAY_SECS));
+    let retry_json = serde_json::to_string(&retry)?;
+    redis_store::retry_fanout_job(&state.redis_pool, current_job, &retry_json, delay).await
 }
 
 /// Find recipients for a reaction event (kind 7)
@@ -2049,6 +2098,12 @@ mod tests {
     use super::*;
     use crate::fcm_sender::{FcmClient, FcmError, MockFcmSender};
     use nostr_sdk::prelude::{Keys, SecretKey};
+    use std::sync::OnceLock;
+
+    fn fanout_test_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
 
     async fn test_redis_pool() -> Option<redis_store::RedisPool> {
         let redis_url =
@@ -2648,6 +2703,7 @@ mod tests {
         let Some(pool) = test_redis_pool().await else {
             return;
         };
+        let _fanout_guard = fanout_test_lock().lock().await;
         let author = Keys::generate();
         let mentioned = Keys::generate().public_key();
         let fcm_token = format!("mention_token_{}", EventId::all_zeros().to_hex());
@@ -2690,6 +2746,10 @@ mod tests {
             event_json: serde_json::to_string(&event).unwrap(),
             cursor: 0,
             sender_name: Some(format_short_npub(&author.public_key())),
+            attempt: 0,
+            expires_at: Timestamp::now()
+                .as_secs()
+                .saturating_add(state.settings.service.processed_event_ttl_secs),
         };
         redis_store::complete_fanout_job(&pool, &serde_json::to_string(&queued_job).unwrap(), None)
             .await
@@ -2814,6 +2874,7 @@ mod tests {
         let Some(pool) = test_redis_pool().await else {
             return;
         };
+        let _fanout_guard = fanout_test_lock().lock().await;
         const WATCHERS: usize = 150;
         const PAGE_SIZE: usize = 10;
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -907,6 +907,7 @@ async fn process_fanout_job(
     if fanout_job_expired(&job, Timestamp::now().as_secs()) {
         warn!(event_id = %event.id, cursor = job.cursor, attempts = job.attempt, "Discarding expired durable fan-out page");
         redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
+        crate::metrics::new_post_fanout_retry("lifetime", "expired");
         return Ok(());
     }
 
@@ -1019,8 +1020,17 @@ async fn schedule_fanout_retry(
         minimum_delay_secs,
         Timestamp::now().as_secs(),
     ) else {
-        redis_store::complete_fanout_job(&state.redis_pool, current_job, exhausted_next_job)
-            .await?;
+        if let Some(successor) = exhausted_next_job {
+            let delay = fanout_retry_delay(
+                state.settings.service.new_post_fanout_retry_secs,
+                MAX_FANOUT_ATTEMPTS,
+                minimum_delay_secs,
+            )
+            .min(job.expires_at.saturating_sub(Timestamp::now().as_secs()));
+            redis_store::retry_fanout_job(&state.redis_pool, current_job, successor, delay).await?;
+        } else {
+            redis_store::complete_fanout_job(&state.redis_pool, current_job, None).await?;
+        }
         crate::metrics::new_post_fanout_retry(reason, "exhausted");
         error!(
             cursor = job.cursor,
@@ -3464,7 +3474,11 @@ mod tests {
             .await
             .unwrap();
         assert!(current_score.is_none());
-        assert!(successor_score.is_some());
+        assert!(
+            successor_score
+                .is_some_and(|score| score > chrono::Utc::now().timestamp_millis() as f64),
+            "the successor should inherit backoff instead of becoming immediately claimable"
+        );
         redis::cmd("ZREM")
             .arg("new_post_fanout_jobs")
             .arg(&successor_json)

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -850,6 +850,8 @@ pub async fn run_new_post_fanout(state: Arc<AppState>, token: CancellationToken)
                     .await
                     {
                         error!(error = %retry_error, "Failed to reschedule fan-out page after processing error; lease expiry will recover it");
+                    } else {
+                        crate::metrics::new_post_fanout_retry("worker_error", "preserved");
                     }
                 }
             }
@@ -919,7 +921,7 @@ async fn process_fanout_job(
         Ok(page) => page,
         Err(e) => {
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Failed to read durable watcher page; scheduling retry");
-            schedule_fanout_retry(state, job_json, &job, 0, "watcher_page_read").await?;
+            schedule_fanout_retry(state, job_json, &job, 0, "watcher_page_read", None).await?;
             return Ok(());
         }
     };
@@ -962,27 +964,45 @@ async fn process_fanout_job(
                 crate::error::ServiceError::RetryableDelivery(delay) => delay.as_secs(),
                 _ => 0,
             };
+            let exhausted_next_job = fanout_successor_job(&job, page.next_cursor, &copy)?;
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Durable watcher page was incomplete; scheduling retry");
-            schedule_fanout_retry(state, job_json, &job, provider_delay, "delivery").await?;
+            schedule_fanout_retry(
+                state,
+                job_json,
+                &job,
+                provider_delay,
+                "delivery",
+                exhausted_next_job.as_deref(),
+            )
+            .await?;
             return Ok(());
         }
     }
 
-    let next_job = if page.next_cursor == 0 {
-        None
-    } else {
-        let next = NewPostFanoutJob {
-            event_json: job.event_json,
-            cursor: page.next_cursor,
-            sender_name: job
-                .sender_name
-                .or_else(|| copy.cell.get().map(|resolved| resolved.sender_name.clone())),
-            attempt: 0,
-            expires_at: job.expires_at,
-        };
-        Some(serde_json::to_string(&next)?)
-    };
+    let next_job = fanout_successor_job(&job, page.next_cursor, &copy)?;
     redis_store::complete_fanout_job(&state.redis_pool, job_json, next_job.as_deref()).await
+}
+
+fn fanout_successor_job(
+    job: &NewPostFanoutJob,
+    next_cursor: u64,
+    copy: &LazyEventCopy,
+) -> Result<Option<String>> {
+    if next_cursor == 0 {
+        return Ok(None);
+    }
+
+    let next = NewPostFanoutJob {
+        event_json: job.event_json.clone(),
+        cursor: next_cursor,
+        sender_name: job
+            .sender_name
+            .clone()
+            .or_else(|| copy.cell.get().map(|resolved| resolved.sender_name.clone())),
+        attempt: 0,
+        expires_at: job.expires_at,
+    };
+    Ok(Some(serde_json::to_string(&next)?))
 }
 
 async fn schedule_fanout_retry(
@@ -991,19 +1011,23 @@ async fn schedule_fanout_retry(
     job: &NewPostFanoutJob,
     minimum_delay_secs: u64,
     reason: &'static str,
+    exhausted_next_job: Option<&str>,
 ) -> Result<()> {
     let Some((retry, delay)) = next_fanout_retry(
         job,
         state.settings.service.new_post_fanout_retry_secs,
         minimum_delay_secs,
+        Timestamp::now().as_secs(),
     ) else {
-        redis_store::complete_fanout_job(&state.redis_pool, current_job, None).await?;
+        redis_store::complete_fanout_job(&state.redis_pool, current_job, exhausted_next_job)
+            .await?;
         crate::metrics::new_post_fanout_retry(reason, "exhausted");
         error!(
             cursor = job.cursor,
             attempts = MAX_FANOUT_ATTEMPTS,
             reason,
-            "Discarding durable new-post fan-out page and its remaining cursor chain after its retry budget was exhausted"
+            continued = exhausted_next_job.is_some(),
+            "Discarding durable new-post fan-out page after its retry budget was exhausted"
         );
         return Ok(());
     };
@@ -1017,6 +1041,7 @@ fn next_fanout_retry(
     job: &NewPostFanoutJob,
     base_delay_secs: u64,
     minimum_delay_secs: u64,
+    now: u64,
 ) -> Option<(NewPostFanoutJob, u64)> {
     // Twelve total attempts span about 30 minutes of default scheduled backoff
     // and 5-minute local cap. That rides out sustained provider backpressure
@@ -1026,7 +1051,8 @@ fn next_fanout_retry(
     }
     let mut retry = job.clone();
     retry.attempt = retry.attempt.saturating_add(1);
-    let delay = fanout_retry_delay(base_delay_secs, retry.attempt, minimum_delay_secs);
+    let delay = fanout_retry_delay(base_delay_secs, retry.attempt, minimum_delay_secs)
+        .min(job.expires_at.saturating_sub(now));
     Some((retry, delay))
 }
 
@@ -3329,10 +3355,10 @@ mod tests {
             expires_at: 1_000,
         };
 
-        let (first, first_delay) = next_fanout_retry(&initial, 5, 0).unwrap();
+        let (first, first_delay) = next_fanout_retry(&initial, 5, 0, 0).unwrap();
         let persisted = serde_json::to_string(&first).unwrap();
         let restored: NewPostFanoutJob = serde_json::from_str(&persisted).unwrap();
-        let (second, second_delay) = next_fanout_retry(&restored, 5, 0).unwrap();
+        let (second, second_delay) = next_fanout_retry(&restored, 5, 0, 0).unwrap();
 
         assert_eq!(first.attempt, 1);
         assert_eq!(first_delay, 5);
@@ -3353,12 +3379,98 @@ mod tests {
         };
 
         for expected_attempt in 1..MAX_FANOUT_ATTEMPTS {
-            let (retry, _) = next_fanout_retry(&job, 5, 0).unwrap();
+            let (retry, _) = next_fanout_retry(&job, 5, 0, 0).unwrap();
             assert_eq!(retry.attempt, expected_attempt);
             job = retry;
         }
 
-        assert!(next_fanout_retry(&job, 5, 0).is_none());
+        assert!(next_fanout_retry(&job, 5, 0, 0).is_none());
+    }
+
+    #[test]
+    fn durable_fanout_retry_preserves_provider_floor_within_job_lifetime() {
+        let job = NewPostFanoutJob {
+            event_json: "{}".to_string(),
+            cursor: 17,
+            sender_name: None,
+            attempt: 0,
+            expires_at: 10_000,
+        };
+
+        let (_, provider_delay) = next_fanout_retry(&job, 5, 3_600, 100).unwrap();
+        let (_, lifetime_clamped_delay) = next_fanout_retry(&job, 5, u64::MAX, 100).unwrap();
+
+        assert_eq!(provider_delay, 3_600);
+        assert_eq!(lifetime_clamped_delay, 9_900);
+    }
+
+    #[tokio::test]
+    async fn exhausted_fanout_page_preserves_its_known_successor() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let _guard = fanout_test_lock().lock().await;
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(MockFcmSender::new())),
+        );
+        let current = NewPostFanoutJob {
+            event_json: "{}".to_string(),
+            cursor: 17,
+            sender_name: None,
+            attempt: MAX_FANOUT_ATTEMPTS - 1,
+            expires_at: Timestamp::now().as_secs().saturating_add(3_600),
+        };
+        let successor = NewPostFanoutJob {
+            cursor: 23,
+            attempt: 0,
+            ..current.clone()
+        };
+        let current_json = serde_json::to_string(&current).unwrap();
+        let successor_json = serde_json::to_string(&successor).unwrap();
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("ZADD")
+            .arg("new_post_fanout_jobs")
+            .arg(0)
+            .arg(&current_json)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        drop(conn);
+
+        schedule_fanout_retry(
+            &state,
+            &current_json,
+            &current,
+            0,
+            "delivery",
+            Some(&successor_json),
+        )
+        .await
+        .unwrap();
+
+        let mut conn = pool.get().await.unwrap();
+        let current_score: Option<f64> = redis::cmd("ZSCORE")
+            .arg("new_post_fanout_jobs")
+            .arg(&current_json)
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+        let successor_score: Option<f64> = redis::cmd("ZSCORE")
+            .arg("new_post_fanout_jobs")
+            .arg(&successor_json)
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+        assert!(current_score.is_none());
+        assert!(successor_score.is_some());
+        redis::cmd("ZREM")
+            .arg("new_post_fanout_jobs")
+            .arg(&successor_json)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -842,6 +842,9 @@ pub async fn run_new_post_fanout(state: Arc<AppState>, token: CancellationToken)
                     }
 
                     error!(error = %e, "Durable fan-out page processing failed; preserving the leased page");
+                    // Keep the same member here: this path means the atomic
+                    // attempt swap itself may have failed, so constructing a
+                    // second swap only repeats the operation we cannot trust.
                     if let Err(retry_error) = redis_store::rescore_fanout_job(
                         &state.redis_pool,
                         &job_json,
@@ -902,7 +905,7 @@ async fn process_fanout_job(
         }
     };
 
-    if Timestamp::now().as_secs() >= job.expires_at {
+    if fanout_job_expired(&job, Timestamp::now().as_secs()) {
         warn!(event_id = %event.id, cursor = job.cursor, attempts = job.attempt, "Discarding expired durable fan-out page");
         redis_store::complete_fanout_job(&state.redis_pool, job_json, None).await?;
         return Ok(());
@@ -991,20 +994,28 @@ async fn schedule_fanout_retry(
     job: &NewPostFanoutJob,
     minimum_delay_secs: u64,
 ) -> Result<()> {
-    const MAX_RETRY_DELAY_SECS: u64 = 300;
-
     let mut retry = job.clone();
     retry.attempt = retry.attempt.saturating_add(1);
-    let exponent = u32::from(retry.attempt.saturating_sub(1).min(6));
-    let backoff = state
-        .settings
-        .service
-        .new_post_fanout_retry_secs
-        .saturating_mul(1u64 << exponent)
-        .min(MAX_RETRY_DELAY_SECS);
-    let delay = backoff.max(minimum_delay_secs.min(MAX_RETRY_DELAY_SECS));
+    let delay = fanout_retry_delay(
+        state.settings.service.new_post_fanout_retry_secs,
+        retry.attempt,
+        minimum_delay_secs,
+    );
     let retry_json = serde_json::to_string(&retry)?;
     redis_store::retry_fanout_job(&state.redis_pool, current_job, &retry_json, delay).await
+}
+
+fn fanout_retry_delay(base_secs: u64, attempt: u16, minimum_delay_secs: u64) -> u64 {
+    const MAX_RETRY_DELAY_SECS: u64 = 300;
+    let exponent = u32::from(attempt.saturating_sub(1).min(6));
+    base_secs
+        .saturating_mul(1u64 << exponent)
+        .min(MAX_RETRY_DELAY_SECS)
+        .max(minimum_delay_secs.min(MAX_RETRY_DELAY_SECS))
+}
+
+fn fanout_job_expired(job: &NewPostFanoutJob, now: u64) -> bool {
+    now >= job.expires_at
 }
 
 /// Find recipients for a reaction event (kind 7)
@@ -2742,21 +2753,10 @@ mod tests {
             .await
             .expect("video handling degrades to mentions");
 
-        let queued_job = NewPostFanoutJob {
-            event_json: serde_json::to_string(&event).unwrap(),
-            cursor: 0,
-            sender_name: Some(format_short_npub(&author.public_key())),
-            attempt: 0,
-            expires_at: Timestamp::now()
-                .as_secs()
-                .saturating_add(state.settings.service.processed_event_ttl_secs),
-        };
-        redis_store::complete_fanout_job(&pool, &serde_json::to_string(&queued_job).unwrap(), None)
-            .await
-            .unwrap();
-
         let _: () = redis::cmd("DEL")
             .arg(&watchers_key)
+            .arg("new_post_fanout_jobs")
+            .arg(format!("fanout:enqueued:{}", event.id.to_hex()))
             .query_async(&mut *conn)
             .await
             .unwrap();
@@ -3171,6 +3171,31 @@ mod tests {
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].recipient, watcher);
         assert_eq!(targets[0].notification_type, NotificationType::NewPost);
+    }
+
+    #[test]
+    fn durable_fanout_retry_backoff_is_bounded() {
+        assert_eq!(fanout_retry_delay(5, 1, 0), 5);
+        assert_eq!(fanout_retry_delay(5, 2, 0), 10);
+        assert_eq!(fanout_retry_delay(5, 7, 0), 300);
+        assert_eq!(fanout_retry_delay(5, u16::MAX, 0), 300);
+        assert_eq!(fanout_retry_delay(5, 1, 120), 120);
+        assert_eq!(fanout_retry_delay(5, 1, 3_600), 300);
+    }
+
+    #[test]
+    fn durable_fanout_job_expires_at_its_deadline() {
+        let job = NewPostFanoutJob {
+            event_json: "{}".to_string(),
+            cursor: 0,
+            sender_name: None,
+            attempt: 9,
+            expires_at: 100,
+        };
+
+        assert!(!fanout_job_expired(&job, 99));
+        assert!(fanout_job_expired(&job, 100));
+        assert!(fanout_job_expired(&job, 101));
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -39,6 +39,7 @@ const KIND_REGISTRATION: u16 = 3079;
 const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
 const KIND_VIDEO: u16 = 34236;
+const MAX_FANOUT_ATTEMPTS: u16 = 12;
 
 /// NIP-51 people list carrying new-post ("bell") subscriptions.
 const KIND_NOTIFY_LIST: u16 = 30000;
@@ -918,7 +919,7 @@ async fn process_fanout_job(
         Ok(page) => page,
         Err(e) => {
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Failed to read durable watcher page; scheduling retry");
-            schedule_fanout_retry(state, job_json, &job, 0).await?;
+            schedule_fanout_retry(state, job_json, &job, 0, "watcher_page_read").await?;
             return Ok(());
         }
     };
@@ -962,7 +963,7 @@ async fn process_fanout_job(
                 _ => 0,
             };
             error!(event_id = %event.id, cursor = job.cursor, error = %e, "Durable watcher page was incomplete; scheduling retry");
-            schedule_fanout_retry(state, job_json, &job, provider_delay).await?;
+            schedule_fanout_retry(state, job_json, &job, provider_delay, "delivery").await?;
             return Ok(());
         }
     }
@@ -989,25 +990,44 @@ async fn schedule_fanout_retry(
     current_job: &str,
     job: &NewPostFanoutJob,
     minimum_delay_secs: u64,
+    reason: &'static str,
 ) -> Result<()> {
-    let (retry, delay) = next_fanout_retry(
+    let Some((retry, delay)) = next_fanout_retry(
         job,
         state.settings.service.new_post_fanout_retry_secs,
         minimum_delay_secs,
-    );
+    ) else {
+        redis_store::complete_fanout_job(&state.redis_pool, current_job, None).await?;
+        crate::metrics::new_post_fanout_retry(reason, "exhausted");
+        error!(
+            cursor = job.cursor,
+            attempts = MAX_FANOUT_ATTEMPTS,
+            reason,
+            "Discarding durable new-post fan-out page and its remaining cursor chain after its retry budget was exhausted"
+        );
+        return Ok(());
+    };
     let retry_json = serde_json::to_string(&retry)?;
-    redis_store::retry_fanout_job(&state.redis_pool, current_job, &retry_json, delay).await
+    redis_store::retry_fanout_job(&state.redis_pool, current_job, &retry_json, delay).await?;
+    crate::metrics::new_post_fanout_retry(reason, "scheduled");
+    Ok(())
 }
 
 fn next_fanout_retry(
     job: &NewPostFanoutJob,
     base_delay_secs: u64,
     minimum_delay_secs: u64,
-) -> (NewPostFanoutJob, u64) {
+) -> Option<(NewPostFanoutJob, u64)> {
+    // Twelve total attempts span about 30 minutes of default scheduled backoff
+    // and 5-minute local cap. That rides out sustained provider backpressure
+    // without letting one permanently bad page churn for the seven-day event TTL.
+    if job.attempt.saturating_add(1) >= MAX_FANOUT_ATTEMPTS {
+        return None;
+    }
     let mut retry = job.clone();
     retry.attempt = retry.attempt.saturating_add(1);
     let delay = fanout_retry_delay(base_delay_secs, retry.attempt, minimum_delay_secs);
-    (retry, delay)
+    Some((retry, delay))
 }
 
 fn fanout_retry_delay(base_secs: u64, attempt: u16, minimum_delay_secs: u64) -> u64 {
@@ -1016,7 +1036,9 @@ fn fanout_retry_delay(base_secs: u64, attempt: u16, minimum_delay_secs: u64) -> 
     base_secs
         .saturating_mul(1u64 << exponent)
         .min(MAX_RETRY_DELAY_SECS)
-        .max(minimum_delay_secs.min(MAX_RETRY_DELAY_SECS))
+        // The cap applies to our exponential backoff, not the provider's explicit
+        // floor. Retrying before FCM's Retry-After would amplify backpressure.
+        .max(minimum_delay_secs)
 }
 
 fn fanout_job_expired(job: &NewPostFanoutJob, now: u64) -> bool {
@@ -1871,6 +1893,10 @@ async fn send_notification_to_user(
         }
     }
 
+    // The claim is per recipient, while FCM reports per token. Once any device
+    // receives the notification, retaining the recipient claim avoids resending
+    // to that successful device merely to retry a sibling token. Only an
+    // all-token retryable failure is safe to release and replay.
     if success_count == 0 {
         if let Some(delay) = retryable_failure {
             redis_store::release_recipient_event_claim(&state.redis_pool, &recipient_claim).await?;
@@ -3188,6 +3214,82 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test]
+    async fn one_success_retains_the_recipient_claim_when_a_sibling_token_is_retryable() {
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let live_token = format!("mixed-live-{}", recipient.to_hex());
+        let retryable_token = format!("mixed-retryable-{}", recipient.to_hex());
+        redis_store::add_or_update_token(&pool, &recipient, &live_token)
+            .await
+            .unwrap();
+        redis_store::add_or_update_token(&pool, &recipient, &retryable_token)
+            .await
+            .unwrap();
+
+        let mock_sender = MockFcmSender::new();
+        mock_sender.set_error_for_token(
+            &retryable_token,
+            FcmError::RetryableInternal(Duration::from_secs(1)),
+        );
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("mixed token delivery")
+            .tag(Tag::public_key(recipient))
+            .sign_with_keys(&author)
+            .unwrap();
+        let targets = targets_of(NotificationType::Mention, vec![recipient]);
+
+        send_notifications_sequential(
+            &state,
+            &event,
+            targets.clone(),
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(mock_sender.get_sent_messages().len(), 1);
+
+        mock_sender.clear();
+        send_notifications_sequential(
+            &state,
+            &event,
+            targets,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            mock_sender.get_sent_messages().is_empty(),
+            "recipient replay must not duplicate the token that already succeeded"
+        );
+
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!(
+                "dedup:{}:{}",
+                event.id.to_hex(),
+                recipient.to_hex()
+            ))
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &recipient, &live_token)
+            .await
+            .unwrap();
+        redis_store::remove_token(&pool, &recipient, &retryable_token)
+            .await
+            .unwrap();
+    }
+
     #[test]
     fn test_a_watcher_page_keeps_the_watchers_who_were_not_mentioned() {
         // Partial overlap: the mention pass already covers `mentioned`, so the
@@ -3214,7 +3316,7 @@ mod tests {
         assert_eq!(fanout_retry_delay(5, 7, 0), 300);
         assert_eq!(fanout_retry_delay(5, u16::MAX, 0), 300);
         assert_eq!(fanout_retry_delay(5, 1, 120), 120);
-        assert_eq!(fanout_retry_delay(5, 1, 3_600), 300);
+        assert_eq!(fanout_retry_delay(5, 1, 3_600), 3_600);
     }
 
     #[test]
@@ -3227,10 +3329,10 @@ mod tests {
             expires_at: 1_000,
         };
 
-        let (first, first_delay) = next_fanout_retry(&initial, 5, 0);
+        let (first, first_delay) = next_fanout_retry(&initial, 5, 0).unwrap();
         let persisted = serde_json::to_string(&first).unwrap();
         let restored: NewPostFanoutJob = serde_json::from_str(&persisted).unwrap();
-        let (second, second_delay) = next_fanout_retry(&restored, 5, 0);
+        let (second, second_delay) = next_fanout_retry(&restored, 5, 0).unwrap();
 
         assert_eq!(first.attempt, 1);
         assert_eq!(first_delay, 5);
@@ -3238,6 +3340,25 @@ mod tests {
         assert_eq!(second_delay, 10);
         assert_eq!(second.cursor, initial.cursor);
         assert_eq!(second.expires_at, initial.expires_at);
+    }
+
+    #[test]
+    fn durable_fanout_retry_stops_after_twelve_delivery_attempts() {
+        let mut job = NewPostFanoutJob {
+            event_json: "{}".to_string(),
+            cursor: 17,
+            sender_name: None,
+            attempt: 0,
+            expires_at: 1_000,
+        };
+
+        for expected_attempt in 1..MAX_FANOUT_ATTEMPTS {
+            let (retry, _) = next_fanout_retry(&job, 5, 0).unwrap();
+            assert_eq!(retry.attempt, expected_attempt);
+            job = retry;
+        }
+
+        assert!(next_fanout_retry(&job, 5, 0).is_none());
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -994,15 +994,24 @@ async fn schedule_fanout_retry(
     job: &NewPostFanoutJob,
     minimum_delay_secs: u64,
 ) -> Result<()> {
-    let mut retry = job.clone();
-    retry.attempt = retry.attempt.saturating_add(1);
-    let delay = fanout_retry_delay(
+    let (retry, delay) = next_fanout_retry(
+        job,
         state.settings.service.new_post_fanout_retry_secs,
-        retry.attempt,
         minimum_delay_secs,
     );
     let retry_json = serde_json::to_string(&retry)?;
     redis_store::retry_fanout_job(&state.redis_pool, current_job, &retry_json, delay).await
+}
+
+fn next_fanout_retry(
+    job: &NewPostFanoutJob,
+    base_delay_secs: u64,
+    minimum_delay_secs: u64,
+) -> (NewPostFanoutJob, u64) {
+    let mut retry = job.clone();
+    retry.attempt = retry.attempt.saturating_add(1);
+    let delay = fanout_retry_delay(base_delay_secs, retry.attempt, minimum_delay_secs);
+    (retry, delay)
 }
 
 fn fanout_retry_delay(base_secs: u64, attempt: u16, minimum_delay_secs: u64) -> u64 {
@@ -2970,6 +2979,11 @@ mod tests {
                     &creator,
                 ))
                 .arg(format!("dedup:{claim_key}"))
+                .arg(format!(
+                    "dedup:{}:{}",
+                    event.id.to_hex(),
+                    watcher.public_key().to_hex()
+                ))
                 .query_async(&mut *conn)
                 .await
                 .unwrap();
@@ -2977,6 +2991,8 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         let _: () = redis::cmd("DEL")
             .arg(format!("notify_watchers:{}", creator.to_hex()))
+            .arg("new_post_fanout_jobs")
+            .arg(format!("fanout:enqueued:{}", event.id.to_hex()))
             .query_async(&mut *conn)
             .await
             .unwrap();
@@ -3181,6 +3197,29 @@ mod tests {
         assert_eq!(fanout_retry_delay(5, u16::MAX, 0), 300);
         assert_eq!(fanout_retry_delay(5, 1, 120), 120);
         assert_eq!(fanout_retry_delay(5, 1, 3_600), 300);
+    }
+
+    #[test]
+    fn durable_fanout_retry_persists_each_attempt() {
+        let initial = NewPostFanoutJob {
+            event_json: "{}".to_string(),
+            cursor: 17,
+            sender_name: Some("Alice".to_string()),
+            attempt: 0,
+            expires_at: 1_000,
+        };
+
+        let (first, first_delay) = next_fanout_retry(&initial, 5, 0);
+        let persisted = serde_json::to_string(&first).unwrap();
+        let restored: NewPostFanoutJob = serde_json::from_str(&persisted).unwrap();
+        let (second, second_delay) = next_fanout_retry(&restored, 5, 0);
+
+        assert_eq!(first.attempt, 1);
+        assert_eq!(first_delay, 5);
+        assert_eq!(second.attempt, 2);
+        assert_eq!(second_delay, 10);
+        assert_eq!(second.cursor, initial.cursor);
+        assert_eq!(second.expires_at, initial.expires_at);
     }
 
     #[test]

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -50,6 +50,7 @@ const FCM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// fires first and yields the more specific error; this is the backstop that
 /// bounds whatever else the function grows to do.
 const FCM_OPERATION_TIMEOUT: Duration = Duration::from_secs(45);
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 fn build_http_client() -> Result<reqwest::Client, FcmError> {
     build_http_client_with(FCM_REQUEST_TIMEOUT, FCM_CONNECT_TIMEOUT)
@@ -166,10 +167,9 @@ fn classify_error(status: StatusCode, headers: &HeaderMap, body: &str) -> FcmErr
     let error_code = extract_fcm_error_code(body);
 
     if status.is_server_error() {
-        return match parse_retry_after(headers) {
-            Some(retry_after) => FcmError::RetryableInternal(retry_after),
-            None => FcmError::InternalError,
-        };
+        return FcmError::RetryableInternal(
+            parse_retry_after(headers).unwrap_or(DEFAULT_RETRY_AFTER),
+        );
     }
 
     // Deliberately NOT keyed on the 404 status alone. `TokenNotRegistered`
@@ -839,13 +839,13 @@ mod tests {
     }
 
     #[test]
-    fn server_error_without_retry_after_is_internal() {
+    fn server_error_without_retry_after_uses_default_retry_delay() {
         let error = classify_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             &header_map(&[]),
             r#"{"error":{"code":500,"message":"Internal error"}}"#,
         );
-        assert!(matches!(error, FcmError::InternalError));
+        assert!(matches!(error, FcmError::RetryableInternal(d) if d == DEFAULT_RETRY_AFTER));
     }
 
     #[test]

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -49,7 +49,7 @@ const FCM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Deliberately larger than `FCM_REQUEST_TIMEOUT` so the inner timeout normally
 /// fires first and yields the more specific error; this is the backstop that
 /// bounds whatever else the function grows to do.
-pub(crate) const FCM_OPERATION_TIMEOUT: Duration = Duration::from_secs(45);
+const FCM_OPERATION_TIMEOUT: Duration = Duration::from_secs(45);
 const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 fn build_http_client() -> Result<reqwest::Client, FcmError> {

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -166,7 +166,12 @@ fn classify_error(status: StatusCode, headers: &HeaderMap, body: &str) -> FcmErr
     let message = extract_error_message(body);
     let error_code = extract_fcm_error_code(body);
 
-    if status.is_server_error() {
+    // 429 is FCM's explicit backpressure signal, and a large new-post fan-out is
+    // exactly where it shows up. It carries the same "retry later" meaning as a
+    // 5xx and honours the same `Retry-After`, so it must be retryable: a 429 that
+    // sent nothing is unambiguous, and treating it as permanent strands the whole
+    // page's watchers for the recipient-claim TTL.
+    if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
         return FcmError::RetryableInternal(
             parse_retry_after(headers).unwrap_or(DEFAULT_RETRY_AFTER),
         );
@@ -849,6 +854,26 @@ mod tests {
     }
 
     #[test]
+    fn too_many_requests_is_retryable_and_honors_retry_after() {
+        let error = classify_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            &header_map(&[("Retry-After", "12")]),
+            r#"{"error":{"code":429,"message":"Quota exceeded."}}"#,
+        );
+        assert!(matches!(error, FcmError::RetryableInternal(d) if d == Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn too_many_requests_without_retry_after_uses_default_retry_delay() {
+        let error = classify_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            &header_map(&[]),
+            r#"{"error":{"code":429,"message":"Quota exceeded."}}"#,
+        );
+        assert!(matches!(error, FcmError::RetryableInternal(d) if d == DEFAULT_RETRY_AFTER));
+    }
+
+    #[test]
     fn not_found_with_unregistered_detail_marks_token_dead() {
         let error = classify_error(
             StatusCode::NOT_FOUND,
@@ -942,16 +967,18 @@ mod tests {
 
     #[test]
     fn client_error_body_is_preserved_rather_than_discarded() {
-        // The old library collapsed every non-400 4xx to "Unknown invalid
-        // request (no details provided)", losing the reason entirely.
+        // The old library collapsed every non-retryable 4xx to "Unknown invalid
+        // request (no details provided)", losing the reason entirely. (429 is no
+        // longer an example here: it is now retryable backpressure, not a
+        // permanent client error.)
         let error = classify_error(
-            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::BAD_REQUEST,
             &header_map(&[]),
-            r#"{"error":{"code":429,"message":"Quota exceeded for quota metric 'Send requests'"}}"#,
+            r#"{"error":{"code":400,"message":"Invalid value at 'message.token'","status":"INVALID_ARGUMENT"}}"#,
         );
         match error {
             FcmError::InvalidRequest(message) => {
-                assert!(message.contains("Quota exceeded"), "got: {message}")
+                assert!(message.contains("Invalid value"), "got: {message}")
             }
             other => panic!("expected InvalidRequest, got {other:?}"),
         }

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -49,7 +49,7 @@ const FCM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Deliberately larger than `FCM_REQUEST_TIMEOUT` so the inner timeout normally
 /// fires first and yields the more specific error; this is the backstop that
 /// bounds whatever else the function grows to do.
-const FCM_OPERATION_TIMEOUT: Duration = Duration::from_secs(45);
+pub(crate) const FCM_OPERATION_TIMEOUT: Duration = Duration::from_secs(45);
 const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 fn build_http_client() -> Result<reqwest::Client, FcmError> {
@@ -916,6 +916,16 @@ mod tests {
 
     #[test]
     fn too_many_requests_is_retryable_and_honors_retry_after() {
+        let error = classify_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            &header_map(&[("Retry-After", "12")]),
+            r#"{"error":{"code":429,"message":"Quota exceeded."}}"#,
+        );
+        assert!(matches!(error, FcmError::RetryableInternal(d) if d == Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn too_many_requests_preserves_an_hour_retry_after() {
         let error = classify_error(
             StatusCode::TOO_MANY_REQUESTS,
             &header_map(&[("Retry-After", "3600")]),

--- a/src/fcm_sender.rs
+++ b/src/fcm_sender.rs
@@ -918,10 +918,10 @@ mod tests {
     fn too_many_requests_is_retryable_and_honors_retry_after() {
         let error = classify_error(
             StatusCode::TOO_MANY_REQUESTS,
-            &header_map(&[("Retry-After", "12")]),
+            &header_map(&[("Retry-After", "3600")]),
             r#"{"error":{"code":429,"message":"Quota exceeded."}}"#,
         );
-        assert!(matches!(error, FcmError::RetryableInternal(d) if d == Duration::from_secs(12)));
+        assert!(matches!(error, FcmError::RetryableInternal(d) if d == Duration::from_secs(3_600)));
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -16,16 +16,22 @@ use tokio_util::sync::CancellationToken;
 pub enum CriticalTask {
     NostrListener,
     EventHandler,
+    NewPostFanout,
 }
 
 impl CriticalTask {
-    pub const ALL: [CriticalTask; 2] = [CriticalTask::NostrListener, CriticalTask::EventHandler];
+    pub const ALL: [CriticalTask; 3] = [
+        CriticalTask::NostrListener,
+        CriticalTask::EventHandler,
+        CriticalTask::NewPostFanout,
+    ];
 
     /// Stable identifier used in log fields and in the `/health` body.
     pub fn name(self) -> &'static str {
         match self {
             CriticalTask::NostrListener => "nostr_listener",
             CriticalTask::EventHandler => "event_handler",
+            CriticalTask::NewPostFanout => "new_post_fanout",
         }
     }
 }
@@ -35,6 +41,7 @@ impl CriticalTask {
 pub struct TaskHealth {
     nostr_listener: AtomicBool,
     event_handler: AtomicBool,
+    new_post_fanout: AtomicBool,
     unexpected_exit: AtomicBool,
 }
 
@@ -43,6 +50,7 @@ impl TaskHealth {
         Self {
             nostr_listener: AtomicBool::new(true),
             event_handler: AtomicBool::new(true),
+            new_post_fanout: AtomicBool::new(true),
             unexpected_exit: AtomicBool::new(false),
         }
     }
@@ -51,6 +59,7 @@ impl TaskHealth {
         match task {
             CriticalTask::NostrListener => &self.nostr_listener,
             CriticalTask::EventHandler => &self.event_handler,
+            CriticalTask::NewPostFanout => &self.new_post_fanout,
         }
     }
 
@@ -237,6 +246,7 @@ mod tests {
     fn task_names_are_stable() {
         assert_eq!(CriticalTask::NostrListener.name(), "nostr_listener");
         assert_eq!(CriticalTask::EventHandler.name(), "event_handler");
+        assert_eq!(CriticalTask::NewPostFanout.name(), "new_post_fanout");
     }
 
     /// The outage this guards against: an FCM 5xx panicked the event handler,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     tracing::info!("Event handler started");
 
+    // Start durable new-post fan-out worker
+    let state_fanout = Arc::clone(&app_state);
+    let token_fanout = token.clone();
+    tracker.spawn(
+        "new_post_fanout",
+        Some(CriticalTask::NewPostFanout),
+        OnReturn::Fatal,
+        async move {
+            if let Err(e) = event_handler::run_new_post_fanout(state_fanout, token_fanout).await {
+                tracing::error!("New-post fan-out worker failed: {}", e);
+            }
+            tracing::info!("New-post fan-out worker task finished.");
+        },
+    );
+    tracing::info!("New-post fan-out worker started");
+
     // Start cleanup service
     let state_cleanup = Arc::clone(&app_state);
     let token_cleanup = token.clone();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -41,7 +41,7 @@ pub fn init() -> PrometheusHandle {
     );
     metrics::describe_counter!(
         NEW_POST_FANOUT_RETRIES_TOTAL,
-        "Durable new-post fan-out retries, counted by bounded reason and outcome"
+        "Durable new-post fan-out retries and terminal expiry, counted by bounded reason and outcome"
     );
     metrics::describe_counter!(
         TOKENS_PRUNED_TOTAL,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,6 +8,7 @@ pub const EVENTS_PROCESSED_TOTAL: &str = "push_events_processed_total";
 pub const FCM_SENDS_ATTEMPTED_TOTAL: &str = "push_fcm_sends_attempted_total";
 pub const FCM_SENDS_SUCCEEDED_TOTAL: &str = "push_fcm_sends_succeeded_total";
 pub const FCM_SENDS_FAILED_TOTAL: &str = "push_fcm_sends_failed_total";
+pub const NEW_POST_FANOUT_RETRIES_TOTAL: &str = "push_new_post_fanout_retries_total";
 pub const TOKENS_PRUNED_TOTAL: &str = "push_tokens_pruned_total";
 pub const LAST_EVENT_PROCESSED_TIMESTAMP_SECONDS: &str =
     "push_last_event_processed_timestamp_seconds";
@@ -37,6 +38,10 @@ pub fn init() -> PrometheusHandle {
     metrics::describe_counter!(
         FCM_SENDS_FAILED_TOTAL,
         "Failed FCM deliveries, counted per device token and reason"
+    );
+    metrics::describe_counter!(
+        NEW_POST_FANOUT_RETRIES_TOTAL,
+        "Durable new-post fan-out retries, counted by bounded reason and outcome"
     );
     metrics::describe_counter!(
         TOKENS_PRUNED_TOTAL,
@@ -73,6 +78,15 @@ pub fn fcm_send_failed(reason: &'static str) {
     metrics::counter!(FCM_SENDS_FAILED_TOTAL, "reason" => reason).increment(1);
 }
 
+pub fn new_post_fanout_retry(reason: &'static str, outcome: &'static str) {
+    metrics::counter!(
+        NEW_POST_FANOUT_RETRIES_TOTAL,
+        "reason" => reason,
+        "outcome" => outcome
+    )
+    .increment(1);
+}
+
 pub fn tokens_pruned(reason: &'static str, count: u64) {
     metrics::counter!(TOKENS_PRUNED_TOTAL, "reason" => reason).increment(count);
 }
@@ -96,6 +110,7 @@ mod tests {
             fcm_send_attempted();
             fcm_send_succeeded();
             fcm_send_failed("unauthorized");
+            new_post_fanout_retry("delivery", "scheduled");
             tokens_pruned("invalid", 1);
         });
 
@@ -119,6 +134,12 @@ mod tests {
         );
         assert!(
             rendered.contains(r#"push_fcm_sends_failed_total{reason="unauthorized"} 1"#),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(
+                r#"push_new_post_fanout_retries_total{reason="delivery",outcome="scheduled"} 1"#
+            ),
             "{rendered}"
         );
         assert!(

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -944,6 +944,14 @@ mod tests {
         retry_fanout_job(&pool, first_job, retry_job, 0)
             .await
             .unwrap();
+        let mut conn = pool.get().await.unwrap();
+        let queued: usize = redis::cmd("ZCARD")
+            .arg(NEW_POST_FANOUT_JOBS_ZSET)
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+        drop(conn);
+        assert_eq!(queued, 1, "retry must remove the previous leased member");
         assert_eq!(
             claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
             Some(retry_job),

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -940,7 +940,17 @@ mod tests {
             "graceful shutdown can release a page without waiting for lease expiry"
         );
 
-        complete_fanout_job(&pool, first_job, Some(next_job))
+        let retry_job = r#"{"event":"first","cursor":0,"attempt":1}"#;
+        retry_fanout_job(&pool, first_job, retry_job, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
+            Some(retry_job),
+            "retry atomically replaces the leased member with its persisted attempt"
+        );
+
+        complete_fanout_job(&pool, retry_job, Some(next_job))
             .await
             .unwrap();
         assert_eq!(

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -405,6 +405,12 @@ pub async fn claim_fanout_job(pool: &RedisPool, lease_secs: u64) -> Result<Optio
 }
 
 /// Completes one page and atomically schedules its successor, if any.
+///
+/// Leases intentionally have no owner token. If a slow worker finishes after
+/// its lease expired and another worker reclaimed the page, both may deliver
+/// the page. The successor is inserted before the current member is removed, so
+/// that race can duplicate work but cannot remove the only copy of the next page.
+/// Recipient claims make the duplicate delivery harmless in the common case.
 pub async fn complete_fanout_job(
     pool: &RedisPool,
     current_job: &str,

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -432,8 +432,8 @@ pub async fn complete_fanout_job(
     Ok(())
 }
 
-/// Makes a leased fan-out job available again after a bounded delay.
-pub async fn retry_fanout_job(pool: &RedisPool, job: &str, delay_secs: u64) -> Result<()> {
+/// Makes the same leased fan-out job available again after a bounded delay.
+pub async fn rescore_fanout_job(pool: &RedisPool, job: &str, delay_secs: u64) -> Result<()> {
     let available_at = unix_time_millis()?.saturating_add(delay_secs.saturating_mul(1000));
     let mut conn = pool
         .get()
@@ -447,6 +447,34 @@ pub async fn retry_fanout_job(pool: &RedisPool, job: &str, delay_secs: u64) -> R
         .query_async::<()>(&mut *conn)
         .await
         .map_err(ServiceError::Redis)
+}
+
+/// Atomically replaces a failed page with its next retry attempt.
+pub async fn retry_fanout_job(
+    pool: &RedisPool,
+    current_job: &str,
+    retry_job: &str,
+    delay_secs: u64,
+) -> Result<()> {
+    const RETRY_SCRIPT: &str = r#"
+        redis.call('ZADD', KEYS[1], ARGV[3], ARGV[2])
+        redis.call('ZREM', KEYS[1], ARGV[1])
+        return 1
+    "#;
+    let available_at = unix_time_millis()?.saturating_add(delay_secs.saturating_mul(1000));
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    redis::Script::new(RETRY_SCRIPT)
+        .key(NEW_POST_FANOUT_JOBS_ZSET)
+        .arg(current_job)
+        .arg(retry_job)
+        .arg(available_at)
+        .invoke_async::<i64>(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+    Ok(())
 }
 
 // =============================================================================
@@ -904,6 +932,12 @@ mod tests {
             claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
             Some(first_job),
             "a crashed worker's page becomes available after its lease"
+        );
+        rescore_fanout_job(&pool, first_job, 0).await.unwrap();
+        assert_eq!(
+            claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
+            Some(first_job),
+            "graceful shutdown can release a page without waiting for lease expiry"
         );
 
         complete_fanout_job(&pool, first_job, Some(next_job))

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -410,6 +410,9 @@ pub async fn claim_fanout_job(pool: &RedisPool, lease_secs: u64) -> Result<Optio
 /// its lease expired and another worker reclaimed the page, both may deliver
 /// the page. The successor is inserted before the current member is removed, so
 /// that race can duplicate work but cannot remove the only copy of the next page.
+/// A stale worker can also reinsert a successor that another worker already
+/// completed, resurrecting an earlier chain segment; that is still duplicate
+/// work rather than page loss.
 /// Recipient claims make the duplicate delivery harmless in the common case.
 pub async fn complete_fanout_job(
     pool: &RedisPool,

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -14,6 +14,8 @@ use nostr_sdk::{EventId, PublicKey, Timestamp};
 use redis::{RedisResult, Value};
 use std::collections::HashSet;
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 // Type alias for the connection pool
 pub type RedisPool = Pool<RedisConnectionManager>;
@@ -21,6 +23,7 @@ pub type RedisPool = Pool<RedisConnectionManager>;
 // Redis key constants
 const STALE_TOKENS_ZSET: &str = "stale_tokens";
 const TOKEN_TO_PUBKEY_HASH: &str = "token_to_pubkey";
+const NEW_POST_FANOUT_JOBS_ZSET: &str = "new_post_fanout_jobs";
 
 /// Build key for user tokens set
 fn build_user_tokens_key(pubkey: &PublicKey) -> String {
@@ -276,6 +279,174 @@ pub async fn try_claim_event(
 
     // SET NX returns "OK" if the key was set, None if it already existed
     Ok(result.is_some())
+}
+
+/// Ownership token for a per-recipient event claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecipientEventClaim {
+    key: String,
+    value: String,
+}
+
+/// Claims one `(event_id, recipient)` delivery before it reaches FCM.
+pub async fn try_claim_recipient_event(
+    pool: &RedisPool,
+    event_id: &EventId,
+    recipient: &PublicKey,
+    ttl_seconds: u64,
+) -> Result<Option<RecipientEventClaim>> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    let claim = RecipientEventClaim {
+        key: format!("dedup:{}:{}", event_id.to_hex(), recipient.to_hex()),
+        value: Uuid::new_v4().to_string(),
+    };
+    let result: Option<String> = redis::cmd("SET")
+        .arg(&claim.key)
+        .arg(&claim.value)
+        .arg("NX")
+        .arg("EX")
+        .arg(ttl_seconds)
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    Ok(result.map(|_| claim))
+}
+
+/// Releases a claim only if it is still owned by this delivery attempt.
+pub async fn release_recipient_event_claim(
+    pool: &RedisPool,
+    claim: &RecipientEventClaim,
+) -> Result<bool> {
+    const RELEASE_SCRIPT: &str = r#"
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+          return redis.call('DEL', KEYS[1])
+        end
+        return 0
+    "#;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    let released: i64 = redis::Script::new(RELEASE_SCRIPT)
+        .key(&claim.key)
+        .arg(&claim.value)
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+    Ok(released == 1)
+}
+
+fn unix_time_millis() -> Result<u64> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| ServiceError::Internal(format!("System clock is before Unix epoch: {}", e)))?;
+    u64::try_from(duration.as_millis())
+        .map_err(|_| ServiceError::Internal("Unix timestamp does not fit in u64".to_string()))
+}
+
+/// Atomically records an event's initial durable fan-out job once.
+pub async fn enqueue_initial_fanout_job(
+    pool: &RedisPool,
+    event_id: &EventId,
+    job: &str,
+    marker_ttl_secs: u64,
+) -> Result<bool> {
+    const ENQUEUE_SCRIPT: &str = r#"
+        if redis.call('EXISTS', KEYS[1]) == 1 then
+          return 0
+        end
+        redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3])
+        redis.call('SET', KEYS[1], '1', 'EX', ARGV[1])
+        return 1
+    "#;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    let enqueued: i64 = redis::Script::new(ENQUEUE_SCRIPT)
+        .key(format!("fanout:enqueued:{}", event_id.to_hex()))
+        .key(NEW_POST_FANOUT_JOBS_ZSET)
+        .arg(marker_ttl_secs)
+        .arg(unix_time_millis()?)
+        .arg(job)
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+    Ok(enqueued == 1)
+}
+
+/// Claims the oldest available fan-out job until its lease expires.
+pub async fn claim_fanout_job(pool: &RedisPool, lease_secs: u64) -> Result<Option<String>> {
+    const CLAIM_SCRIPT: &str = r#"
+        local jobs = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', 0, 1)
+        if #jobs == 0 then
+          return nil
+        end
+        redis.call('ZADD', KEYS[1], ARGV[2], jobs[1])
+        return jobs[1]
+    "#;
+    let now = unix_time_millis()?;
+    let lease_millis = lease_secs.saturating_mul(1000);
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    redis::Script::new(CLAIM_SCRIPT)
+        .key(NEW_POST_FANOUT_JOBS_ZSET)
+        .arg(now)
+        .arg(now.saturating_add(lease_millis))
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)
+}
+
+/// Completes one page and atomically schedules its successor, if any.
+pub async fn complete_fanout_job(
+    pool: &RedisPool,
+    current_job: &str,
+    next_job: Option<&str>,
+) -> Result<()> {
+    const COMPLETE_SCRIPT: &str = r#"
+        if ARGV[2] ~= '' then
+          redis.call('ZADD', KEYS[1], 'NX', ARGV[3], ARGV[2])
+        end
+        redis.call('ZREM', KEYS[1], ARGV[1])
+        return 1
+    "#;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    redis::Script::new(COMPLETE_SCRIPT)
+        .key(NEW_POST_FANOUT_JOBS_ZSET)
+        .arg(current_job)
+        .arg(next_job.unwrap_or_default())
+        .arg(unix_time_millis()?)
+        .invoke_async::<i64>(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+    Ok(())
+}
+
+/// Makes a leased fan-out job available again after a bounded delay.
+pub async fn retry_fanout_job(pool: &RedisPool, job: &str, delay_secs: u64) -> Result<()> {
+    let available_at = unix_time_millis()?.saturating_add(delay_secs.saturating_mul(1000));
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+    redis::cmd("ZADD")
+        .arg(NEW_POST_FANOUT_JOBS_ZSET)
+        .arg("XX")
+        .arg(available_at)
+        .arg(job)
+        .query_async::<()>(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)
 }
 
 // =============================================================================
@@ -648,5 +819,110 @@ mod tests {
         let key = build_user_tokens_key(&pubkey);
         assert!(key.starts_with("user_tokens:"));
         assert!(key.contains(&pubkey.to_hex()));
+    }
+
+    #[tokio::test]
+    async fn durable_fanout_job_is_reclaimed_and_advances_atomically() {
+        let base_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+        let Ok(mut redis_url) = url::Url::parse(&base_url) else {
+            return;
+        };
+        // Keep the global production queue out of this lease-expiry test.
+        redis_url.set_path("/14");
+        let Ok(pool) = create_pool(redis_url.as_str(), 2).await else {
+            return;
+        };
+        let Ok(mut conn) = pool.get().await else {
+            return;
+        };
+        if redis::cmd("PING")
+            .query_async::<String>(&mut *conn)
+            .await
+            .is_err()
+        {
+            return;
+        }
+        let event_id = EventId::all_zeros();
+        redis::cmd("DEL")
+            .arg(format!("fanout:enqueued:{}", event_id.to_hex()))
+            .arg(NEW_POST_FANOUT_JOBS_ZSET)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        redis::cmd("SET")
+            .arg(NEW_POST_FANOUT_JOBS_ZSET)
+            .arg("wrong-type")
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        drop(conn);
+
+        let first_job = r#"{"event":"first","cursor":0}"#;
+        let next_job = r#"{"event":"first","cursor":9}"#;
+        assert!(
+            enqueue_initial_fanout_job(&pool, &event_id, first_job, 60)
+                .await
+                .is_err(),
+            "a broken queue must reject the enqueue"
+        );
+        let marker = get_cached_string(&pool, &format!("fanout:enqueued:{}", event_id.to_hex()))
+            .await
+            .unwrap();
+        assert!(
+            marker.is_none(),
+            "a failed queue write must not consume the event's enqueue marker"
+        );
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(NEW_POST_FANOUT_JOBS_ZSET)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
+        drop(conn);
+
+        assert!(enqueue_initial_fanout_job(&pool, &event_id, first_job, 60)
+            .await
+            .unwrap());
+        assert!(
+            !enqueue_initial_fanout_job(&pool, &event_id, first_job, 60)
+                .await
+                .unwrap(),
+            "an event replay must not enqueue a second initial page"
+        );
+
+        assert_eq!(
+            claim_fanout_job(&pool, 1).await.unwrap().as_deref(),
+            Some(first_job)
+        );
+        assert!(
+            claim_fanout_job(&pool, 1).await.unwrap().is_none(),
+            "a live lease prevents concurrent processing"
+        );
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert_eq!(
+            claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
+            Some(first_job),
+            "a crashed worker's page becomes available after its lease"
+        );
+
+        complete_fanout_job(&pool, first_job, Some(next_job))
+            .await
+            .unwrap();
+        assert_eq!(
+            claim_fanout_job(&pool, 30).await.unwrap().as_deref(),
+            Some(next_job),
+            "completion removes the current page and exposes its successor"
+        );
+        complete_fanout_job(&pool, next_job, None).await.unwrap();
+        assert!(claim_fanout_job(&pool, 30).await.unwrap().is_none());
+
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("DEL")
+            .arg(format!("fanout:enqueued:{}", event_id.to_hex()))
+            .arg(NEW_POST_FANOUT_JOBS_ZSET)
+            .query_async::<()>(&mut *conn)
+            .await
+            .unwrap();
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -144,6 +144,7 @@ mod tests {
         assert_eq!(body["pubkey"], "pubkey-hex");
         assert_eq!(body["tasks"]["event_handler"], true);
         assert_eq!(body["tasks"]["nostr_listener"], true);
+        assert_eq!(body["tasks"]["new_post_fanout"], true);
     }
 
     /// The probe behaviour the outage needed: a dead event handler must fail

--- a/tests/event_claim_test.rs
+++ b/tests/event_claim_test.rs
@@ -59,17 +59,7 @@ fn test_notify_lists_are_exempt_from_the_event_claim() {
 }
 
 #[test]
-fn test_the_exemption_does_not_cover_other_kind_30000_lists() {
-    // Same scoping as the replay-horizon exemption. The idempotency argument
-    // rests on the notify-list Lua script, which only runs for `d=notify`, so an
-    // unrelated people list keeps the claim.
-    assert!(event_handler::requires_event_claim(&list_event("mute")));
-}
-
-#[test]
-fn test_push_sending_events_still_claim() {
-    // Everything that actually sends a push depends on the claim to stop two
-    // replicas notifying the same user twice.
+fn test_content_events_use_recipient_claims_instead_of_event_claims() {
     let video = EventBuilder::new(Kind::from(34236u16), "video")
         .tag(Tag::identifier("vid-1"))
         .sign_with_keys(&Keys::generate())
@@ -81,9 +71,20 @@ fn test_push_sending_events_still_claim() {
         .sign_with_keys(&Keys::generate())
         .unwrap();
 
-    assert!(event_handler::requires_event_claim(&video));
-    assert!(event_handler::requires_event_claim(&reaction));
-    assert!(event_handler::requires_event_claim(&note));
+    assert!(!event_handler::requires_event_claim(&video));
+    assert!(!event_handler::requires_event_claim(&reaction));
+    assert!(!event_handler::requires_event_claim(&note));
+    assert!(!event_handler::requires_event_claim(&list_event("mute")));
+}
+
+#[test]
+fn test_control_events_keep_the_event_claim() {
+    for kind in [3079u16, 3080, 3083] {
+        let event = EventBuilder::new(Kind::from(kind), "ciphertext")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        assert!(event_handler::requires_event_claim(&event));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

A failure for one notification recipient could suppress every recipient still waiting on the same event.
Large new-post audiences also kept the main event handler busy until every watcher page finished.
This change makes recipient failures independently recoverable and moves watcher delivery into durable background work.

## What Changed

- Claim content delivery per event and recipient immediately before sending.
- Release claims after confirmed retryable failures while retaining successful or ambiguous deliveries.
- Queue new-post watcher pages in Redis with leases, bounded concurrency, exponential retry backoff, and expiry.
- Supervise the new worker through the existing health and shutdown lifecycle.
- Preserve mention ordering, preferences, rate limits, video-edit deduplication, and invalid-token cleanup.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Redis-backed tests covered partial-recipient replay, retryable claim release, lease recovery, immediate graceful rescheduling, atomic page advancement, retry-state persistence, and multi-page delivery.
The reusable Semantic PR workflow has no local command and will run only on GitHub.

## Risks

Watcher pages use at-least-once processing.
Completed recipient claims prevent page retries from resending successful deliveries, while lease expiry recovers a worker crash.

Issue #37's concurrency tuning remains separate because it depends on live FCM project quota evidence.

Closes #45
Addresses #37
