### PR TITLE
fix(push): stop subscribing to unsupported follow lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,6 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 |------|------|-------------|
 | Like | 7 | Reactions to user's notes |
 | Comment | 1 | Replies to user's notes |
-| Follow | 3 | New followers |
 | Mention | 1 | Notes mentioning user |
 | Repost | 16 | Reposts of user's notes |
 | NewPost | 34236 | A belled creator published a video (recipients from `notify_watchers`, not `p` tags) |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The service subscribes to trigger events on its relay and notifies the tagged re
 
 New-post notifications are the one type not anchored to a `p` tag on the trigger event. Recipients come from the subscriber's own NIP-51 list (kind 30000, `d=notify`), so the service resolves them from a Redis reverse index rather than from the video. They are rate-limited to one push per (subscriber, creator) per hour, and fan-out is paged and delivered with bounded concurrency so one popular creator cannot force one unbounded Redis read or sequential delivery loop. The in-app feed is not throttled. See [the protocol doc](docs/nip-xx-push-notifications.md) for the list shape.
 
-Divine video comments are NIP-22 `kind:1111` and notify both the root video author and the direct parent author (deduplicated when they coincide). Follows (kind 3) are defined in the protocol and subscribed to, but new-follow notifications are **not currently emitted** — that requires diffing contact-list state, which is not yet implemented.
+Divine video comments are NIP-22 `kind:1111` and notify both the root video author and the direct parent author (deduplicated when they coincide). Follow notifications are not handled by this service, so it does not subscribe to kind 3 contact lists.
 
 Each FCM message carries a stable `data` payload with routing and presentation fields. Routing to the correct video uses the authoritative addressable coordinate from the triggering event, never a coordinate synthesized from the recipient's pubkey. The full payload contract is documented in the [developer guide](docs/developer-guide.md#fcm-payload-format).
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -40,7 +40,6 @@ notification:
   # Event kinds to subscribe to for notification triggers
   event_kinds:
     - 1      # Text notes (comments, mentions)
-    - 3      # Contact list (follows)
     - 7      # Reactions/likes (NIP-25)
     - 16     # Generic reposts (NIP-18)
     - 1111   # NIP-22 comments
@@ -50,7 +49,6 @@ notification:
   default_preferences:
     kinds:
       - 1      # Text notes (comments, mentions)
-      - 3      # Contact list (follows)
       - 7      # Reactions/likes
       - 16     # Reposts
       - 30023  # Long-form content

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -41,7 +41,6 @@ notification:
   # Event kinds to subscribe to for notification triggers
   event_kinds:
     - 1      # Text notes (comments, mentions)
-    - 3      # Contact list (follows)
     - 7      # Reactions/likes (NIP-25)
     - 16     # Generic reposts (NIP-18)
     - 1111   # NIP-22 comments
@@ -51,7 +50,6 @@ notification:
   default_preferences:
     kinds:
       - 1      # Text notes (comments, mentions)
-      - 3      # Contact list (follows)
       - 7      # Reactions/likes
       - 16     # Reposts
       - 30023  # Long-form content

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -22,7 +22,7 @@ sequenceDiagram
     Push->>Redis: Store token for pubkey
 
     Note over App,Device: Notification Delivery
-    Relay->>Push: New event (like, comment, follow, etc.)
+    Relay->>Push: New event (like, comment, mention, etc.)
     Push->>Redis: Check recipient has registered token
     Push->>Redis: Check dedup (SET NX EX)
     Push->>Redis: Check user preferences
@@ -50,13 +50,10 @@ The service watches for these event kinds and notifies the tagged recipient:
 | Like | 7 | Reaction to user's note (p-tag) |
 | Comment | 1 | Reply to user's note (p-tag, with e-tag reference) |
 | Comment | 1111 | NIP-22 comment on a user's video or article (notifies root author `P` and parent author `p`) |
-| Follow | 3 | New contact list including user (p-tag) |
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Mention | 34236 | Addressable video tagging user (p-tag) |
 | Repost | 16 | Repost of user's note (p-tag) |
 | NewPost | 34236 | A creator the user belled published a video. The only type whose recipients do not come from a `p` tag — see [New-post subscriptions](#new-post-subscriptions-bells) |
-
-> **Note:** Follow (kind 3) is defined but **not currently emitted** — the handler skips kind 3 because new-follow detection requires diffing contact-list state, which is not yet implemented. Likes, comments, mentions, reposts, and new posts are the types actually delivered today.
 
 > **Note:** diVine video comments are NIP-22 `kind:1111`, not `kind:1`. They notify both the **root author** (uppercase `P` — the video owner, so they hear about comments on their video) and the **direct parent author** (lowercase `p` — for a reply, the parent comment's author). The two coincide for a top-level comment and are deduplicated. Every such push carries the authoritative root-video coordinate (see [Routing & attribution contract](#routing--attribution-contract)), so a reply to someone else's comment still routes to the correct video instead of a guessed one.
 
@@ -99,15 +96,15 @@ For a kind 34236 video mention, the triggering event is itself the addressable t
 
 > **Clients MUST NOT** synthesize a video coordinate by pairing `referencedDTag` (or any d-tag) with the *recipient's* pubkey. The recipient is not necessarily the video owner — e.g. a reply to another user's comment, or a mention — and doing so attributes the notification to the wrong (or a nonexistent) video. Use `referencedAuthorPubkey` / `referencedAddress` for ownership; fall back to `referencedEventId` when no coordinate is present.
 
-When the triggering event is not addressable and carries no addressable reference (a follow, a mention in a plain note, or a like on a comment), the `referenced*` video fields are omitted and the client falls back to `referencedEventId`, then to the actor's profile.
+When the triggering event is not addressable and carries no addressable reference (a mention in a plain note or a like on a comment), the `referenced*` video fields are omitted and the client falls back to `referencedEventId`, then to the actor's profile.
 
 #### Authoritative (routing / attribution)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | string | `like`, `comment`, `follow`, `mention`, `repost`, or `newPost`. Match the exact string: the first five are lowercase, `newPost` is camelCase |
-| `eventId` | hex | The Nostr event that triggered the notification (the like/comment/repost/follow event itself); stable id for dedup and a routing fallback |
-| `senderPubkey` | hex | Pubkey of the actor who triggered the event; routes follows and otherwise-unresolved taps |
+| `type` | string | `like`, `comment`, `mention`, `repost`, or `newPost`. Match the exact string: the first four are lowercase, `newPost` is camelCase |
+| `eventId` | hex | The Nostr event that triggered the notification (the like/comment/mention/repost/video event itself); stable id for dedup and a routing fallback |
+| `senderPubkey` | hex | Pubkey of the actor who triggered the event; routes otherwise-unresolved taps |
 | `receiverPubkey` | hex | Pubkey of the notification recipient |
 | `referencedEventId` | hex | (optional) Target event. For a direct kind 34236 trigger this is the video event's own id. Otherwise it is root-aware: the NIP-22 uppercase `E` root scope when present, else the lowercase `e` tag — so comments anchor to the root video, not the parent comment |
 | `referencedAddress` | string | (optional) Authoritative addressable target coordinate `kind:pubkey:d-tag`. Built from a direct kind 34236 trigger's own identity, or taken from the event's `A` (NIP-22 root) or `a` tag for an indirect reference |
@@ -126,7 +123,7 @@ When the triggering event is not addressable and carries no addressable referenc
 | `eventKind` | string | Triggering Nostr event kind as a string (e.g. "7") |
 | `timestamp` | string | Unix timestamp of the triggering event as a string |
 
-The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and follows/plain-note mentions omit them.
+The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and plain-note mentions omit them.
 
 ### iOS APNS shape
 
@@ -197,10 +194,10 @@ Notify lists (kind 30000, `d=notify`) are the exception: they send no push, and 
 Users can optionally send a Kind 3083 event to control which notification types they receive. The decrypted content is:
 
 ```json
-{ "kinds": [1, 3, 7, 16] }
+{ "kinds": [1, 7, 16] }
 ```
 
-This is a list of event kinds the user wants notifications for. If no preferences are set, the service uses defaults: text notes (1), follows (3), reactions (7), reposts (16), long-form content (30023), and videos from subscribed creators (34236).
+This is a list of event kinds the user wants notifications for. If no preferences are set, the service uses defaults: text notes (1), reactions (7), reposts (16), long-form content (30023), and videos from subscribed creators (34236). Kind 3 contact lists are not notification triggers in this service.
 
 ## New-post subscriptions ("bells")
 

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -89,14 +89,14 @@ Clients MAY send a preferences event to control which notification types they re
     ["p", "<push-service-pubkey>"],
     ["app", "<app-id>"]
   ],
-  "content": nip44_encrypt({"kinds": [1, 3, 7, 16]}),
+  "content": nip44_encrypt({"kinds": [1, 7, 16]}),
   "sig": "<signature>"
 }
 ```
 
 The decrypted content is a JSON object with a `kinds` array listing the event kinds the user wants notifications for:
 ```json
-{ "kinds": [1, 3, 7, 16] }
+{ "kinds": [1, 7, 16] }
 ```
 
 An empty `kinds` array disables all notifications. Services SHOULD define sensible defaults for users who have not sent a preferences event.
@@ -152,7 +152,7 @@ a prolific author otherwise trains users into disabling notifications entirely.
 
 ## Notification Triggers
 
-Services define which events trigger notifications. A typical single-app service watches for specific event kinds (reactions, replies, follows, mentions, reposts) and notifies users who are tagged or referenced.
+Services define which events trigger notifications. A typical single-app service watches for specific event kinds (reactions, replies, mentions, reposts) and notifies users who are tagged or referenced.
 
 Services MAY support additional trigger logic beyond kind matching, including
 recipient sets that come from subscriber-published state rather than from tags

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -89,14 +89,14 @@ Clients MAY send a preferences event to control which notification types they re
     ["p", "<push-service-pubkey>"],
     ["app", "<app-id>"]
   ],
-  "content": nip44_encrypt({"kinds": [1, 7, 16]}),
+  "content": nip44_encrypt({"kinds": [1, 3, 7, 16]}),
   "sig": "<signature>"
 }
 ```
 
 The decrypted content is a JSON object with a `kinds` array listing the event kinds the user wants notifications for:
 ```json
-{ "kinds": [1, 7, 16] }
+{ "kinds": [1, 3, 7, 16] }
 ```
 
 An empty `kinds` array disables all notifications. Services SHOULD define sensible defaults for users who have not sent a preferences event.
@@ -152,7 +152,7 @@ a prolific author otherwise trains users into disabling notifications entirely.
 
 ## Notification Triggers
 
-Services define which events trigger notifications. A typical single-app service watches for specific event kinds (reactions, replies, mentions, reposts) and notifies users who are tagged or referenced.
+Services define which events trigger notifications. A typical single-app service watches for specific event kinds (reactions, replies, follows, mentions, reposts) and notifies users who are tagged or referenced.
 
 Services MAY support additional trigger logic beyond kind matching, including
 recipient sets that come from subscriber-published state rather than from tags

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_runtime_config_event_kinds_match_defaults() {
+    fn test_runtime_config_kinds_match_defaults() {
         let expected_event_kinds = default_event_kinds();
         let expected_preference_kinds = default_preference_kinds();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,7 +218,6 @@ pub struct NotificationSettings {
 fn default_event_kinds() -> Vec<u64> {
     vec![
         1,     // Text notes (comments, mentions)
-        3,     // Contact list (follows)
         7,     // Reactions/likes (NIP-25)
         16,    // Generic reposts (NIP-18)
         1111,  // NIP-22 comments
@@ -238,7 +237,6 @@ pub struct DefaultPreferences {
 fn default_preference_kinds() -> Vec<u16> {
     vec![
         1,     // Text notes (comments, mentions)
-        3,     // Contact list (follows)
         7,     // Reactions/likes
         16,    // Reposts
         30023, // Long-form content
@@ -386,7 +384,7 @@ mod tests {
     fn test_default_preferences() {
         let prefs = DefaultPreferences::default();
         assert!(prefs.kinds.contains(&1)); // Text notes
-        assert!(prefs.kinds.contains(&3)); // Follows
+        assert!(!prefs.kinds.contains(&3)); // Contact lists are not notification triggers
         assert!(prefs.kinds.contains(&7)); // Likes
         assert!(prefs.kinds.contains(&16)); // Reposts
         assert!(prefs.kinds.contains(&30023)); // Long-form
@@ -396,7 +394,7 @@ mod tests {
     fn test_default_event_kinds() {
         let kinds = default_event_kinds();
         assert!(kinds.contains(&1)); // Text notes
-        assert!(kinds.contains(&3)); // Contact list
+        assert!(!kinds.contains(&3)); // Contact lists are not notification triggers
         assert!(kinds.contains(&7)); // Reactions
         assert!(kinds.contains(&16)); // Reposts
         assert!(kinds.contains(&1111)); // NIP-22 comments
@@ -406,13 +404,18 @@ mod tests {
 
     #[test]
     fn test_runtime_config_event_kinds_match_defaults() {
-        let expected = default_event_kinds();
+        let expected_event_kinds = default_event_kinds();
+        let expected_preference_kinds = default_preference_kinds();
 
         for filename in ["settings.yaml", "settings.development.yaml"] {
             let settings = load_runtime_settings(filename);
             assert_eq!(
-                settings.notification.event_kinds, expected,
+                settings.notification.event_kinds, expected_event_kinds,
                 "{filename} must stay in sync with default_event_kinds()"
+            );
+            assert_eq!(
+                settings.notification.default_preferences.kinds, expected_preference_kinds,
+                "{filename} must stay in sync with default_preference_kinds()"
             );
         }
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -3,7 +3,7 @@
 //! Handles Nostr events and routes them to appropriate notification handlers.
 //! Supports:
 //! - Token registration/deregistration (kinds 3079/3080)
-//! - Notification types: likes, comments, follows, mentions, reposts
+//! - Notification types: likes, comments, mentions, reposts, and new posts
 
 use crate::{
     crypto::CryptoService,
@@ -569,12 +569,6 @@ async fn handle_content_event(
         // and the direct parent author (lowercase `p`). create_fcm_payload
         // attaches the authoritative root-video target from the uppercase `A`.
         targets_of(NotificationType::Comment, find_comment_recipients(event))
-    } else if kind_num == 3 {
-        // Kind 3: Contact list - notify newly followed users
-        // Note: This would require tracking previous contact list state
-        // For now, we skip this as it requires state comparison
-        debug!(event_id = %event_id, "Contact list event - follow notifications not yet implemented");
-        return Ok(());
     } else if kind_num == 16 {
         // Kind 16: Repost - notify the author of the reposted event
         targets_of(NotificationType::Repost, find_repost_recipients(event))
@@ -976,10 +970,7 @@ struct EventScopedCopy {
 fn renders_event_content(notification_type: NotificationType) -> bool {
     match notification_type {
         NotificationType::Comment | NotificationType::Mention => true,
-        NotificationType::Like
-        | NotificationType::Follow
-        | NotificationType::Repost
-        | NotificationType::NewPost => false,
+        NotificationType::Like | NotificationType::Repost | NotificationType::NewPost => false,
     }
 }
 
@@ -1715,11 +1706,6 @@ fn create_fcm_payload(
             );
             (title, body)
         }
-        NotificationType::Follow => {
-            let title = "New follower".to_string();
-            let body = format!("{} started following you", sender_name);
-            (title, body)
-        }
         NotificationType::Mention => {
             let title = "You were mentioned".to_string();
             let body = format!(
@@ -2273,7 +2259,6 @@ mod tests {
         assert!(renders_event_content(NotificationType::Mention));
 
         assert!(!renders_event_content(NotificationType::Like));
-        assert!(!renders_event_content(NotificationType::Follow));
         assert!(!renders_event_content(NotificationType::Repost));
         assert!(!renders_event_content(NotificationType::NewPost));
     }

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -21,7 +21,6 @@ impl Default for UserPreferences {
         Self {
             kinds: vec![
                 1,     // Text notes (comments, mentions)
-                3,     // Contact list (follows)
                 7,     // Reactions/likes
                 16,    // Reposts
                 30023, // Long-form content
@@ -51,7 +50,6 @@ impl UserPreferences {
 pub enum NotificationType {
     Like,
     Comment,
-    Follow,
     Mention,
     Repost,
     /// A creator the recipient subscribed to published a new video.
@@ -68,7 +66,6 @@ impl NotificationType {
         match self {
             NotificationType::Like => 7,
             NotificationType::Comment => 1,
-            NotificationType::Follow => 3,
             NotificationType::Mention => 1, // Same as Comment - both are kind 1
             NotificationType::Repost => 16,
             // Distinct from Mention's kind 1 even though video mentions also
@@ -87,7 +84,6 @@ impl NotificationType {
         match self {
             NotificationType::Like => "like",
             NotificationType::Comment => "comment",
-            NotificationType::Follow => "follow",
             NotificationType::Mention => "mention",
             NotificationType::Repost => "repost",
             NotificationType::NewPost => "newPost",
@@ -189,7 +185,7 @@ mod tests {
     fn test_default_preferences() {
         let prefs = UserPreferences::default();
         assert!(prefs.kinds.contains(&1));
-        assert!(prefs.kinds.contains(&3));
+        assert!(!prefs.kinds.contains(&3));
         assert!(prefs.kinds.contains(&7));
         assert!(prefs.kinds.contains(&16));
         assert!(prefs.kinds.contains(&30023));
@@ -199,7 +195,6 @@ mod tests {
     fn test_notification_type_kind_mapping() {
         assert_eq!(NotificationType::Like.kind(), 7);
         assert_eq!(NotificationType::Comment.kind(), 1);
-        assert_eq!(NotificationType::Follow.kind(), 3);
         assert_eq!(NotificationType::Mention.kind(), 1);
         assert_eq!(NotificationType::Repost.kind(), 16);
     }
@@ -217,7 +212,6 @@ mod tests {
         assert!(NotificationType::Like.is_enabled(&prefs));
         assert!(!NotificationType::Comment.is_enabled(&prefs));
         assert!(!NotificationType::Mention.is_enabled(&prefs));
-        assert!(!NotificationType::Follow.is_enabled(&prefs));
     }
 
     #[test]
@@ -246,7 +240,7 @@ mod tests {
     #[test]
     fn test_new_post_disabled_when_prefs_omit_video_kind() {
         let prefs = UserPreferences {
-            kinds: vec![1, 3, 7, 16, 30023],
+            kinds: vec![1, 7, 16, 30023],
         };
         assert!(!NotificationType::NewPost.is_enabled(&prefs));
     }

--- a/tests/preferences_test.rs
+++ b/tests/preferences_test.rs
@@ -45,7 +45,7 @@ fn test_pubkey() -> String {
 
 fn default_prefs() -> DefaultPreferences {
     DefaultPreferences {
-        kinds: vec![1, 3, 7, 16, 30023],
+        kinds: vec![1, 7, 16, 30023],
     }
 }
 
@@ -66,6 +66,7 @@ async fn test_preferences_roundtrip() {
         .expect("Should get default preferences");
 
     assert!(prefs.kinds.contains(&1));
+    assert!(!prefs.kinds.contains(&3));
     assert!(prefs.kinds.contains(&7));
     assert!(prefs.kinds.contains(&16));
 
@@ -136,7 +137,6 @@ async fn test_notification_type_filtering_with_kinds() {
 
     assert!(NotificationType::Like.is_enabled(&prefs)); // kind 7 ✓
     assert!(!NotificationType::Comment.is_enabled(&prefs)); // kind 1 ✗
-    assert!(!NotificationType::Follow.is_enabled(&prefs)); // kind 3 ✗
     assert!(!NotificationType::Mention.is_enabled(&prefs)); // kind 1 ✗
     assert!(NotificationType::Repost.is_enabled(&prefs)); // kind 16 ✓
 }
@@ -168,7 +168,7 @@ async fn test_preferences_update() {
 
     // Set initial preferences - all kinds enabled
     let initial = UserPreferences {
-        kinds: vec![1, 3, 7, 16, 30023],
+        kinds: vec![1, 7, 16, 30023],
     };
 
     preferences::set_user_preferences(&pool, &pubkey, &initial)
@@ -209,7 +209,6 @@ fn test_build_preferences_key_format() {
 fn test_notification_type_display_names() {
     assert_eq!(NotificationType::Like.display_name(), "like");
     assert_eq!(NotificationType::Comment.display_name(), "comment");
-    assert_eq!(NotificationType::Follow.display_name(), "follow");
     assert_eq!(NotificationType::Mention.display_name(), "mention");
     assert_eq!(NotificationType::Repost.display_name(), "repost");
 }
@@ -218,7 +217,6 @@ fn test_notification_type_display_names() {
 fn test_notification_type_kind_values() {
     assert_eq!(NotificationType::Like.kind(), 7);
     assert_eq!(NotificationType::Comment.kind(), 1);
-    assert_eq!(NotificationType::Follow.kind(), 3);
     assert_eq!(NotificationType::Mention.kind(), 1); // Same as Comment
     assert_eq!(NotificationType::Repost.kind(), 16);
 }
@@ -243,7 +241,6 @@ fn test_empty_preferences_disables_all() {
 
     assert!(!NotificationType::Like.is_enabled(&prefs));
     assert!(!NotificationType::Comment.is_enabled(&prefs));
-    assert!(!NotificationType::Follow.is_enabled(&prefs));
     assert!(!NotificationType::Mention.is_enabled(&prefs));
     assert!(!NotificationType::Repost.is_enabled(&prefs));
 }


### PR DESCRIPTION
## Summary

The service subscribes to every kind 3 contact-list update even though it cannot identify new follows and never sends a follow notification.
This change removes that unused traffic and the dead follow preference and payload path.

## What Changed

- Removed kind 3 from relay subscription and default preference lists.
- Removed unreachable follow notification handling and copy.
- Updated service docs and tests while keeping generic protocol examples service-neutral.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Three Redis-backed preference tests skipped locally because Redis was unavailable.
CI provisions Redis and will exercise them.
The Semantic PR reusable workflow has no local command and will run after the PR opens.

## Risks

Existing kind 3083 preferences can retain a kind 3 entry, but it is inert because no notification type maps to it.
Follow delivery remains out of scope and is tracked in [divinevideo/divine-funnelcake#204](https://github.com/divinevideo/divine-funnelcake/issues/204).
Kind 30023 behavior is unchanged.

Closes #46
