### PR TITLE
fix(push): stop deregistering devices that are still receiving notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 ### Redis Keys
 - `user_tokens:{pubkey}` - Set of FCM tokens registered for a pubkey
 - `token_to_pubkey` - Hash mapping a token back to its owner
-- `stale_tokens` - Sorted set of token timestamps, for cleanup
+- `stale_tokens` - Sorted set scored by the last time a token was known good, for cleanup. Written at registration and again on every delivered push, so the sweep means "inactive" rather than "registered long ago". The refresh uses `ZADD XX GT`: `XX` so a token deregistered mid-send is not resurrected as an owner-less member, `GT` so a replica's clock cannot pull a live token toward the sweep
 - `user_preferences:{pubkey}` - User's notification preferences (JSON)
 - `dedup:{event_id}` - Per-event processing claim with TTL. Notify lists are exempt: they are idempotent by `created_at`, so the claim prevents nothing and a failed handler would otherwise strand the list for the TTL
 - `dedup:{kind}:{type}:{owner}:{d-tag}:{recipient}` - Per-recipient video delivery, so a NIP-33 edit does not re-notify. Scoped by notification type so a bell does not suppress a later mention on the same video. The scoping is one-directional: a delivered mention also writes the `newPost` record, because naming the video already tells the recipient it exists

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The service is a single async binary running four cooperating tasks: a Nostr lis
 ### Prerequisites
 
 - Rust 1.85+
-- Redis
+- Redis 6.2+
 - A Firebase project with FCM enabled, and a service-account credentials file
 
 ### Development

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -393,7 +393,7 @@ the fan-out follow-up rather than done by halves here.
 |-------------|------|-------------|
 | `user_tokens:{pubkey}` | Set | FCM tokens registered for a pubkey |
 | `token_to_pubkey` | Hash | Reverse mapping from token to owner pubkey |
-| `stale_tokens` | Sorted Set | Token timestamps for cleanup |
+| `stale_tokens` | Sorted Set | Last time each token was known good, for cleanup. Scored at registration and refreshed on every delivered push, so the sweep deletes devices that have gone quiet rather than devices that merely registered a long time ago. The refresh is `ZADD XX GT`: `XX` never re-creates a token deregistered between the send and the refresh, `GT` never lowers a score |
 | `dedup:{event_id}` | String | Per-event processing claim with TTL. Not taken for notify lists, which are idempotent by `created_at` and would be lost for the TTL if a failed handler left a claim standing |
 | `dedup:34236:{type}:{owner}:{d-tag}:{recipient}` | String | Per-recipient video delivery decision, retained for the configured coordinate TTL (one year by default). `{type}` is the notification type (`newPost`, `mention`), so a bell and a mention for the same video coordinate keep independent records. A delivered mention writes both records, since naming the video already tells the recipient it exists; a delivered or rate-limited bell writes its own |
 | `user_preferences:{pubkey}` | String | JSON notification preferences |

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1547,7 +1547,10 @@ async fn send_notification_to_user(
 
     // Process results
     let mut tokens_to_remove = Vec::new();
-    let mut success_count = 0;
+    // Doubles as the success count. A delivered push is the only evidence this
+    // service gets that a device still exists, so the tokens are worth keeping
+    // rather than just counting.
+    let mut delivered_tokens = Vec::new();
     // Counted separately from `tokens_to_remove`: a dead token is a *pruned*
     // token, not the only way a send fails. Reporting only removals meant an
     // outage where every send failed for some other reason — bad credentials,
@@ -1565,8 +1568,8 @@ async fn send_notification_to_user(
 
         match classify_send_outcome(&result) {
             SendOutcome::Delivered => {
-                success_count += 1;
                 trace!(target_pubkey = %target_pubkey, token_prefix = %truncated_token, "Successfully sent notification");
+                delivered_tokens.push(fcm_token);
             }
             SendOutcome::FailedAndPrune => {
                 failed_count += 1;
@@ -1592,6 +1595,8 @@ async fn send_notification_to_user(
         }
     }
 
+    let success_count = delivered_tokens.len();
+
     info!(
         event_id = %event_id,
         target_pubkey = %target_pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string()),
@@ -1600,6 +1605,29 @@ async fn send_notification_to_user(
         pruned_count = tokens_to_remove.len(),
         "FCM notification send summary"
     );
+
+    // A delivered push is proof the device is still there, so it has to move the
+    // token away from the staleness sweep. Without this the score is only ever
+    // written at registration, and `cleanup_stale_tokens` deletes devices that
+    // are actively receiving notifications but have not re-registered inside the
+    // window — silently, with no error anywhere.
+    //
+    // Log and continue rather than `?`, for the same reason as the bookkeeping
+    // below: the push has already shipped, and propagating here would report a
+    // delivered notification as failed and skip the writes that follow.
+    if !delivered_tokens.is_empty() {
+        if let Err(e) =
+            redis_store::refresh_token_activity(&state.redis_pool, &delivered_tokens).await
+        {
+            error!(
+                event_id = %event_id,
+                target_pubkey = %target_pubkey,
+                error = %e,
+                "Failed to refresh token activity after a delivered push; the sweep may \
+                 deregister a live device"
+            );
+        }
+    }
 
     // Open the rate-limit window only on a delivered push.
     //
@@ -2428,6 +2456,139 @@ mod tests {
             copy.cell.get().map(|c| c.sender_name.as_str()),
             Some(format_short_npub(&author.public_key()).as_str()),
             "a delivered push resolves the copy the payload is built from"
+        );
+
+        redis_store::remove_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
+    }
+
+    /// The sweep in `cleanup_stale_tokens` reads this score and nothing else.
+    /// Documented in AGENTS.md; the constant is private to `redis_store`.
+    async fn staleness_score(pool: &redis_store::RedisPool, token: &str) -> Option<u64> {
+        let mut conn = pool.get().await.unwrap();
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg("stale_tokens")
+            .arg(token)
+            .query_async(&mut *conn)
+            .await
+            .unwrap();
+        score.map(|s| s as u64)
+    }
+
+    async fn backdate_staleness_score(pool: &redis_store::RedisPool, token: &str, score: u64) {
+        let mut conn = pool.get().await.unwrap();
+        redis::cmd("ZADD")
+            .arg("stale_tokens")
+            .arg(score)
+            .arg(token)
+            .query_async::<i64>(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_delivered_push_refreshes_the_tokens_staleness_score() {
+        // A device that keeps receiving pushes is by definition not stale, so
+        // the sweep must not delete it 90 days after its last *registration*.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let recipient = Keys::generate();
+        let fcm_token = format!("staleness-live-{}", recipient.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let registered_at = Timestamp::now().as_secs() - 80 * 24 * 60 * 60;
+        backdate_staleness_score(&pool, &fcm_token, registered_at).await;
+
+        let mock_sender = MockFcmSender::new();
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("hello")
+            .tag(Tag::public_key(recipient.public_key()))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        send_notification_to_user(
+            &state,
+            &event,
+            &recipient.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(mock_sender.get_sent_messages().len(), 1);
+        let score = staleness_score(&pool, &fcm_token)
+            .await
+            .expect("a delivered token stays tracked");
+        assert!(
+            score > registered_at,
+            "a delivered push left the token at its registration score ({score}), \
+             so the sweep still measures age rather than inactivity"
+        );
+
+        redis_store::remove_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_send_leaves_the_staleness_score_alone() {
+        // Only a delivered push is evidence the device is alive. An auth
+        // failure or an FCM outage says nothing about the token, and treating
+        // it as activity would keep dead tokens alive forever.
+        let Some(pool) = test_redis_pool().await else {
+            return;
+        };
+        let author = Keys::generate();
+        let recipient = Keys::generate();
+        let fcm_token = format!("staleness-failed-{}", recipient.public_key().to_hex());
+        redis_store::add_or_update_token(&pool, &recipient.public_key(), &fcm_token)
+            .await
+            .unwrap();
+
+        let registered_at = Timestamp::now().as_secs() - 80 * 24 * 60 * 60;
+        backdate_staleness_score(&pool, &fcm_token, registered_at).await;
+
+        let mock_sender = MockFcmSender::new();
+        mock_sender.set_error_for_token(
+            &fcm_token,
+            FcmError::Unauthorized("credentials rejected".to_string()),
+        );
+        let state = test_app_state(
+            crate::config::Settings::new().unwrap(),
+            pool.clone(),
+            FcmClient::new_with_impl(Box::new(mock_sender.clone())),
+        );
+        let event = EventBuilder::text_note("hello")
+            .tag(Tag::public_key(recipient.public_key()))
+            .sign_with_keys(&author)
+            .unwrap();
+
+        send_notification_to_user(
+            &state,
+            &event,
+            &recipient.public_key(),
+            NotificationType::Mention,
+            &test_copy(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            staleness_score(&pool, &fcm_token).await,
+            Some(registered_at),
+            "a failed send must not count as proof the device is alive"
         );
 
         redis_store::remove_token(&pool, &recipient.public_key(), &fcm_token)

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -161,6 +161,51 @@ pub async fn remove_token(pool: &RedisPool, pubkey: &PublicKey, token: &str) -> 
     }
 }
 
+/// Records that a push reached these tokens, so the sweep below measures
+/// inactivity rather than time since registration.
+///
+/// The score was previously written only by `add_or_update_token`, which made
+/// the sweep delete devices that were still receiving notifications but had not
+/// re-registered inside the window.
+///
+/// Two flags carry the correctness here, and neither is decoration:
+/// - `XX` never creates a member. A token deregistered or swept between the
+///   send and this call must stay gone; re-adding it would leave a tracked
+///   token with no `token_to_pubkey` owner and no user-set membership, which
+///   nothing clears until it ages out a second full max-age window.
+/// - `GT` never lowers a score. Replicas stamp this from their own clocks, so
+///   without it a peer running behind could pull a live token toward the sweep
+///   — the exact outcome recording activity exists to prevent.
+///
+/// Returns the number of tokens whose score actually moved.
+pub async fn refresh_token_activity(pool: &RedisPool, tokens: &[String]) -> Result<usize> {
+    if tokens.is_empty() {
+        return Ok(0);
+    }
+
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| ServiceError::Internal(format!("Failed to get Redis connection: {}", e)))?;
+
+    let now_timestamp = Timestamp::now().as_secs();
+
+    // One command for the whole batch: a delivery fans out over every token a
+    // recipient registered, and this runs on the delivery path.
+    let mut cmd = redis::cmd("ZADD");
+    cmd.arg(STALE_TOKENS_ZSET).arg("XX").arg("GT").arg("CH");
+    for token in tokens {
+        cmd.arg(now_timestamp).arg(token);
+    }
+
+    let changed: usize = cmd
+        .query_async(&mut *conn)
+        .await
+        .map_err(ServiceError::Redis)?;
+
+    Ok(changed)
+}
+
 /// Cleans up stale tokens based on their last_seen timestamp.
 pub async fn cleanup_stale_tokens(pool: &RedisPool, max_age_seconds: i64) -> Result<usize> {
     let mut conn = pool

--- a/tests/token_activity_test.rs
+++ b/tests/token_activity_test.rs
@@ -1,0 +1,164 @@
+//! Staleness-score refresh for tokens a push was actually delivered to.
+//!
+//! The cleanup sweep deletes by the `stale_tokens` score, and until now that
+//! score was written only at registration. These cover the contract that makes
+//! the sweep mean "inactive" instead of "registered long ago".
+
+use divine_push_service::redis_store;
+use nostr_sdk::{Keys, Timestamp};
+
+/// Documented in AGENTS.md; the constant itself is private to `redis_store`.
+const STALE_TOKENS_ZSET: &str = "stale_tokens";
+
+const DAY_SECS: u64 = 24 * 60 * 60;
+
+async fn test_pool() -> Option<redis_store::RedisPool> {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let pool = redis_store::create_pool(&redis_url, 5).await.ok()?;
+    let mut conn = pool.get().await.ok()?;
+    let pong: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut *conn).await;
+    drop(conn);
+    pong.ok().map(|_| pool)
+}
+
+async fn score_of(pool: &redis_store::RedisPool, token: &str) -> Option<u64> {
+    let mut conn = pool.get().await.unwrap();
+    let score: Option<f64> = redis::cmd("ZSCORE")
+        .arg(STALE_TOKENS_ZSET)
+        .arg(token)
+        .query_async(&mut *conn)
+        .await
+        .unwrap();
+    score.map(|s| s as u64)
+}
+
+async fn backdate(pool: &redis_store::RedisPool, token: &str, score: u64) {
+    let mut conn = pool.get().await.unwrap();
+    redis::cmd("ZADD")
+        .arg(STALE_TOKENS_ZSET)
+        .arg(score)
+        .arg(token)
+        .query_async::<i64>(&mut *conn)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_refresh_moves_a_registered_tokens_score_forward() {
+    let Some(pool) = test_pool().await else {
+        println!("Skipping test: Redis not available");
+        return;
+    };
+    let owner = Keys::generate();
+    let token = format!("refresh-forward-{}", owner.public_key().to_hex());
+
+    redis_store::add_or_update_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+
+    // A device registered 80 days ago and never re-registered: 10 days from
+    // deletion under the 90-day sweep.
+    let registered_at = Timestamp::now().as_secs() - 80 * DAY_SECS;
+    backdate(&pool, &token, registered_at).await;
+
+    let refreshed = redis_store::refresh_token_activity(&pool, std::slice::from_ref(&token))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        refreshed, 1,
+        "the one live token should have been refreshed"
+    );
+    let score = score_of(&pool, &token).await.expect("token still tracked");
+    assert!(
+        score > registered_at,
+        "a delivered push must move the token away from the sweep, but the score stayed at {score}"
+    );
+    assert!(
+        Timestamp::now().as_secs() - score < 60,
+        "the refreshed score should be roughly now, got {score}"
+    );
+
+    redis_store::remove_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_refresh_never_resurrects_a_token_that_is_no_longer_registered() {
+    let Some(pool) = test_pool().await else {
+        println!("Skipping test: Redis not available");
+        return;
+    };
+    let owner = Keys::generate();
+    let token = format!("refresh-absent-{}", owner.public_key().to_hex());
+
+    // Deregistered — or swept — between the send and the refresh. Re-adding it
+    // would leave a tracked token with no owner and no user-set membership,
+    // which the sweep can only clear after another full max-age window.
+    redis_store::add_or_update_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+    redis_store::remove_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+
+    let refreshed = redis_store::refresh_token_activity(&pool, std::slice::from_ref(&token))
+        .await
+        .unwrap();
+
+    assert_eq!(refreshed, 0, "a token nobody tracks must not be refreshed");
+    assert!(
+        score_of(&pool, &token).await.is_none(),
+        "the refresh re-created a deregistered token in the staleness set"
+    );
+}
+
+#[tokio::test]
+async fn a_refresh_never_moves_a_score_backwards() {
+    let Some(pool) = test_pool().await else {
+        println!("Skipping test: Redis not available");
+        return;
+    };
+    let owner = Keys::generate();
+    let token = format!("refresh-backwards-{}", owner.public_key().to_hex());
+
+    redis_store::add_or_update_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+
+    // A replica with a fast clock stamped the score ahead of this one's `now`.
+    // Taking the lower value would pull the token closer to the sweep, which is
+    // the opposite of what recording activity is for.
+    let ahead = Timestamp::now().as_secs() + 10 * DAY_SECS;
+    backdate(&pool, &token, ahead).await;
+
+    redis_store::refresh_token_activity(&pool, std::slice::from_ref(&token))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        score_of(&pool, &token).await,
+        Some(ahead),
+        "a refresh must never lower a token's score"
+    );
+
+    redis_store::remove_token(&pool, &owner.public_key(), &token)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_refresh_of_no_tokens_touches_redis_not_at_all() {
+    let Some(pool) = test_pool().await else {
+        println!("Skipping test: Redis not available");
+        return;
+    };
+
+    let refreshed = redis_store::refresh_token_activity(&pool, &[])
+        .await
+        .unwrap();
+
+    assert_eq!(refreshed, 0, "an empty refresh is a no-op, not an error");
+}


### PR DESCRIPTION
## Summary
- A delivered push now refreshes the device token's score in the `stale_tokens` sorted set, so the 90-day cleanup sweep deletes devices that have gone quiet instead of devices that merely registered a long time ago.
- Only a *delivered* push counts. A failed send leaves the score untouched.
- The refresh is one `ZADD stale_tokens XX GT CH` for the whole batch of a recipient's tokens.

## Motivation

The cleanup sweep deletes a device token 90 days after its score in `stale_tokens`. That score was written in exactly one place — `add_or_update_token`, at registration — and nothing ever moved it afterwards.

So the sweep was measuring time since the device last *registered*, not time since it was last reachable. A device that had been receiving push notifications the entire time was deleted anyway, silently, with no error surfaced on any path. The user just stops getting notifications and has no way to know why.

The devices this hits hardest are the ones that cannot recover on their own. iOS grants background refresh only to apps the user opens regularly, and never to a force-quit app. Android's periodic work is deferrable and gets skipped under Doze. A dormant install cannot re-register itself — and a push notification is the one thing that would bring the user back to the app to trigger a re-registration. The sweep switches that off precisely for the users who need it.

## Why this fix

A delivered push is the only positive evidence this service ever gets that a device still exists. Recording it makes the sweep mean "inactive", which is what the 90-day window was always intended to mean.

Failed sends deliberately do not count. An auth failure or an FCM outage says nothing about whether the token is good, and treating those as activity would keep genuinely dead tokens alive forever — the opposite of what #47 just fixed.

Both `ZADD` flags are load bearing, and each is pinned by a test that fails if the flag is removed:

- **`XX`** never creates a member. A token deregistered or swept between the send and this write must stay gone. Re-adding it would leave a tracked token with no `token_to_pubkey` owner and no membership in any user set — an orphan that nothing clears until it ages out a second full max-age window.
- **`GT`** never lowers a score. Replicas stamp this from their own clocks, so without it a peer running behind could pull a live token *toward* the sweep, which is the exact outcome this change exists to prevent.

## What this deliberately leaves alone

- **A user who receives no notifications at all for 90 days is still swept.** Delivery-based refresh cannot help someone nothing is being delivered to. That residual gap needs provider feedback as the authority, not a timer.
- **The NIP-40 `expiration` tag is still ignored.** `docs/nip-xx-push-notifications.md` requires an `expiration` tag and says servers MUST ignore expired events; the service does neither, and its 90-day sweep agrees with the client's 90-day `expiration` by coincidence rather than by design. That is a spec decision, not an implementation detail, so it is filed separately rather than settled here.
- **No change to the sweep itself**, its inclusive boundary, or `token_max_age_days`.
- **No change to pruning.** Dead-token detection landed in #47 and is untouched.

## Related Issue
- Closes #43. The first half of that issue (dead tokens never pruned) landed in #47; this is the second half.
- The NIP-40 `expiration` spec decision that was tangled into #43 is split out into #55 and is deliberately not addressed here.

## Testing

Local, against Redis 7.4.11 in Docker:

- `cargo test` — 190 passed, 0 failed.
- `cargo clippy --all-targets --all-features` — clean.
- `cargo fmt --check` — clean.

Six new tests. Each was watched failing before the implementation existed:

| Test | Pins |
|---|---|
| `a_refresh_moves_a_registered_tokens_score_forward` | the score actually moves |
| `a_refresh_never_resurrects_a_token_that_is_no_longer_registered` | the `XX` flag |
| `a_refresh_never_moves_a_score_backwards` | the `GT` flag |
| `a_refresh_of_no_tokens_touches_redis_not_at_all` | empty batch is a no-op, not an error |
| `test_a_delivered_push_refreshes_the_tokens_staleness_score` | the wiring, end to end through `send_notification_to_user` |
| `test_a_failed_send_leaves_the_staleness_score_alone` | a failed send is not treated as proof of life |

The two flag tests were verified as real guards by mutation: removing `XX` fails the resurrection test and only that test; removing `GT` fails the backwards test and only that test.

`ZADD ... XX GT` semantics were also checked directly against Redis 7.4.11 before being relied on: `XX` does not create an absent member, `GT` does not lower an existing score, and a multi-member call silently skips the absent ones.

## Protocol / Ops Notes

- **Requires Redis 6.2+** for the `GT` flag. Dev and CI run Redis 7; the cluster manifests pin 8.4. No action needed, but it is a real floor now.
- **No migration, no backfill.** Existing scores stay valid — they are already "last known good", just only ever written at registration. Tokens start being refreshed on the next delivered push.
- **One extra Redis round trip per recipient per delivered notification**, batched into a single command across all of that recipient's tokens.
- New `error!` log `"Failed to refresh token activity after a delivered push; the sweep may deregister a live device"`. It logs and continues rather than propagating: the push has already shipped, so failing here would report a delivered notification as failed and skip the bookkeeping that follows it.
- The `stale_tokens` key description in `AGENTS.md` and `docs/developer-guide.md` is updated, since what the score means has changed.

## Sensitive Information Check
- Confirmed. No partner, customer, or brand names, and no real user identifiers. Test tokens and pubkeys are generated per-run.

