### PR TITLE
fix(relay): recover silent event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Any setting can be overridden with the `NOSTR_PUSH__` prefix and `__` as the nes
 | `NOSTR_PUSH__SERVICE__PRIVATE_KEY_HEX` | Yes | Service's Nostr private key (hex), used for NIP-44 decryption |
 | `NOSTR_PUSH__REDIS__URL` | No | Redis connection URL (overrides the config file) |
 | `NOSTR_PUSH__NOSTR__RELAY_URL` | No | Nostr relay to subscribe to |
-| `NOSTR_PUSH__NOSTR__EVENT_SILENCE_TIMEOUT_SECS` | No | Quiet period before resubscribing, then failing health if silence continues (default `300`) |
+| `NOSTR_PUSH__NOSTR__EVENT_SILENCE_TIMEOUT_SECS` | No | Quiet period before the listener resubscribes, and the window after any resubscribe before it fails health (default `300`) |
 | `APP_ENV` | No | Selects the config file (default `development`) |
 | `RUST_LOG` | No | Log level (default `info`) |
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Any setting can be overridden with the `NOSTR_PUSH__` prefix and `__` as the nes
 | `NOSTR_PUSH__SERVICE__PRIVATE_KEY_HEX` | Yes | Service's Nostr private key (hex), used for NIP-44 decryption |
 | `NOSTR_PUSH__REDIS__URL` | No | Redis connection URL (overrides the config file) |
 | `NOSTR_PUSH__NOSTR__RELAY_URL` | No | Nostr relay to subscribe to |
+| `NOSTR_PUSH__NOSTR__EVENT_SILENCE_TIMEOUT_SECS` | No | Quiet period before resubscribing, then failing health if silence continues (default `300`) |
 | `APP_ENV` | No | Selects the config file (default `development`) |
 | `RUST_LOG` | No | Log level (default `info`) |
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -2,7 +2,11 @@
 
 nostr:
   relay_url: "wss://relay.divine.video"
-  event_silence_timeout_secs: 300  # Resubscribe after 5 quiet minutes; fail health after 5 more
+  # Quiet window the listener tolerates before acting on relay silence.
+  # A cold silence resubscribes once, then fails health if a second window
+  # passes with no event. A relay CLOSED resubscribes immediately, so there
+  # the next quiet window is the one that fails health.
+  event_silence_timeout_secs: 300
   profile_relays:
     - wss://relay.divine.video
     - wss://purplepag.es

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -2,6 +2,7 @@
 
 nostr:
   relay_url: "wss://relay.divine.video"
+  event_silence_timeout_secs: 300  # Resubscribe after 5 quiet minutes; fail health after 5 more
   profile_relays:
     - wss://relay.divine.video
     - wss://purplepag.es

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -2,7 +2,11 @@
 
 nostr:
   relay_url: "wss://relay.divine.video"
-  event_silence_timeout_secs: 300  # Resubscribe after 5 quiet minutes; fail health after 5 more
+  # Quiet window the listener tolerates before acting on relay silence.
+  # A cold silence resubscribes once, then fails health if a second window
+  # passes with no event. A relay CLOSED resubscribes immediately, so there
+  # the next quiet window is the one that fails health.
+  event_silence_timeout_secs: 300
   profile_relays:
     - wss://relay.divine.video
     - wss://purplepag.es

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -2,6 +2,7 @@
 
 nostr:
   relay_url: "wss://relay.divine.video"
+  event_silence_timeout_secs: 300  # Resubscribe after 5 quiet minutes; fail health after 5 more
   profile_relays:
     - wss://relay.divine.video
     - wss://purplepag.es

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,10 @@ pub struct Settings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct NostrSettings {
     pub relay_url: String,
+    /// Maximum silence before the listener resubscribes, and the recovery
+    /// window before continued silence makes the listener unhealthy.
+    #[serde(default = "default_event_silence_timeout")]
+    pub event_silence_timeout_secs: u64,
     #[serde(default)]
     pub profile_relays: Vec<String>,
     #[serde(default = "default_profile_cache_ttl")]
@@ -48,6 +52,10 @@ pub struct NostrSettings {
     /// changing it to affect anything.
     #[serde(default = "default_query_timeout")]
     pub query_timeout_secs: u64,
+}
+
+fn default_event_silence_timeout() -> u64 {
+    300
 }
 
 fn default_profile_cache_ttl() -> u64 {
@@ -304,7 +312,12 @@ impl Settings {
     /// `NOSTR_PUSH__SERVICE__ALLOWED_PUBKEYS` that way, so the same mechanism
     /// reaches every field below.
     fn validate(&self) -> Result<(), ConfigError> {
-        let must_be_positive: [(&str, u64, &str); 8] = [
+        let must_be_positive: [(&str, u64, &str); 9] = [
+            (
+                "nostr.event_silence_timeout_secs",
+                self.nostr.event_silence_timeout_secs,
+                "the event-flow watchdog would continuously resubscribe and fail health",
+            ),
             (
                 "nostr.profile_cache_ttl_secs",
                 self.nostr.profile_cache_ttl_secs,
@@ -436,7 +449,10 @@ mod tests {
 
         // One case per field, because a loop over the same setter would pass
         // just as well against a `validate` that only checks the first.
-        let cases: [ZeroCase; 8] = [
+        let cases: [ZeroCase; 9] = [
+            ("nostr.event_silence_timeout_secs", |s| {
+                s.nostr.event_silence_timeout_secs = 0
+            }),
             ("nostr.profile_cache_ttl_secs", |s| {
                 s.nostr.profile_cache_ttl_secs = 0
             }),

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -27,6 +27,9 @@ const KIND_PREFERENCES_UPDATE: u16 = 3083;
 /// NIP-51 people list carrying new-post ("bell") subscriptions.
 const KIND_NOTIFY_LIST: u16 = 30000;
 
+const NOTIFICATION_SUBSCRIPTION_ID: &str = "divine-notifications";
+const NOTIFY_LIST_SUBSCRIPTION_ID: &str = "divine-notify-lists";
+
 /// How long to wait for the initial relay connection before treating startup as
 /// failed. A listener exit now stops the process, so this must be long enough to
 /// absorb a slow handshake and short enough that a genuinely unreachable relay
@@ -102,7 +105,8 @@ impl NostrListener {
             .await?;
 
         // Subscribe to live events
-        self.subscribe_to_live_events(&token).await?;
+        let since = Timestamp::now() - Duration::from_secs(60 * 60);
+        self.subscribe_to_live_events(&token, since).await?;
 
         // Main event loop
         self.process_live_events(event_tx, service_pubkey, token)
@@ -332,7 +336,11 @@ impl NostrListener {
         Ok(())
     }
 
-    async fn subscribe_to_live_events(&self, token: &CancellationToken) -> Result<()> {
+    async fn subscribe_to_live_events(
+        &self,
+        token: &CancellationToken,
+        since: Timestamp,
+    ) -> Result<()> {
         let mut all_kinds = vec![
             // Control kinds
             Kind::from(KIND_REGISTRATION),
@@ -357,9 +365,6 @@ impl NostrListener {
             }
         }
 
-        // Look back 1 hour to catch any recent events
-        let since = Timestamp::now() - Duration::from_secs(60 * 60);
-
         let filter = Filter::new().kinds(all_kinds.clone()).since(since);
 
         info!(
@@ -373,7 +378,11 @@ impl NostrListener {
                 info!("Cancelled before live subscription");
                 return Ok(());
             }
-            sub_result = self.state.nostr_client.subscribe(filter, None) => {
+            sub_result = self.state.nostr_client.subscribe_with_id(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                filter,
+                None,
+            ) => {
                 match sub_result {
                     Ok(_output) => {
                         info!("Successfully subscribed to diVine notification kinds");
@@ -402,7 +411,11 @@ impl NostrListener {
                 info!("Cancelled before notify-list subscription");
                 return Ok(());
             }
-            sub_result = self.state.nostr_client.subscribe(notify_filter, None) => {
+            sub_result = self.state.nostr_client.subscribe_with_id(
+                SubscriptionId::new(NOTIFY_LIST_SUBSCRIPTION_ID),
+                notify_filter,
+                None,
+            ) => {
                 match sub_result {
                     Ok(_output) => {
                         info!("Successfully subscribed to notify lists");
@@ -448,15 +461,9 @@ trait SubscriptionRecovery: Send + Sync {
 #[async_trait]
 impl SubscriptionRecovery for NostrListener {
     async fn resubscribe(&self) -> Result<()> {
-        let relay = self
-            .state
-            .nostr_client
-            .relay(self.state.settings.nostr.relay_url.as_str())
-            .await?;
-        relay.resubscribe().await.map_err(|error| {
-            ServiceError::Internal(format!("Failed to resubscribe to main relay: {error}"))
-        })?;
-        Ok(())
+        let token = CancellationToken::new();
+        self.subscribe_to_live_events(&token, Timestamp::now())
+            .await
     }
 }
 

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -913,6 +913,69 @@ mod tests {
         assert!(health.had_unexpected_exit());
     }
 
+    /// Resumed event flow must rearm the watchdog after a silence recovery.
+    ///
+    /// This is what keeps an ordinary quiet spell from compounding into a
+    /// restart. The first silent window resubscribes and arms
+    /// `recovery_attempted`; once events reach the handler again that flag has
+    /// to clear, so the *next* silent window resubscribes as well instead of
+    /// taking the failure branch. The test above only covers the opposite
+    /// direction, where flow never resumes and the listener is meant to die.
+    #[tokio::test(start_paused = true)]
+    async fn resumed_flow_rearms_the_watchdog_after_a_silence_recovery() {
+        let (notify_tx, notify_rx) = broadcast::channel(8);
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+        let silence_timeout = Duration::from_secs(30);
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                silence_timeout,
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        advance(silence_timeout).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            recovery.calls.load(Ordering::SeqCst),
+            1,
+            "the first silent window must resubscribe"
+        );
+
+        notify_tx
+            .send(live_event(&Keys::generate(), "flow resumed"))
+            .expect("send live event");
+        event_rx.recv().await.expect("forward the resumed event");
+
+        advance(silence_timeout).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !loop_handle.is_finished(),
+            "resumed flow must clear the recovery flag, not leave the listener one quiet window from exit"
+        );
+        assert_eq!(
+            recovery.calls.load(Ordering::SeqCst),
+            2,
+            "a later silent window must resubscribe again rather than fail the listener"
+        );
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("cancellation should stop cleanly");
+    }
+
     #[tokio::test(start_paused = true)]
     async fn our_closed_subscription_resubscribes_immediately() {
         let (notify_tx, notify_rx) = broadcast::channel(2);

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -29,6 +29,10 @@ const KIND_NOTIFY_LIST: u16 = 30000;
 
 const NOTIFICATION_SUBSCRIPTION_ID: &str = "divine-notifications";
 const NOTIFY_LIST_SUBSCRIPTION_ID: &str = "divine-notify-lists";
+/// Replays events that may have arrived while the subscription was stalled.
+/// Successful event IDs remain claimed for seven days in the runtime config,
+/// so this one-hour overlap recovers gaps without redelivering pushes.
+const LIVE_EVENT_LOOKBACK: Duration = Duration::from_secs(60 * 60);
 
 /// How long to wait for the initial relay connection before treating startup as
 /// failed. A listener exit now stops the process, so this must be long enough to
@@ -74,6 +78,17 @@ fn notify_list_live_filter(since: Timestamp) -> Filter {
         .since(since)
 }
 
+fn live_subscription_since() -> Timestamp {
+    Timestamp::now() - LIVE_EVENT_LOOKBACK
+}
+
+fn is_owned_subscription(subscription_id: &SubscriptionId) -> bool {
+    matches!(
+        subscription_id.as_str(),
+        NOTIFICATION_SUBSCRIPTION_ID | NOTIFY_LIST_SUBSCRIPTION_ID
+    )
+}
+
 pub struct NostrListener {
     state: Arc<AppState>,
 }
@@ -105,8 +120,8 @@ impl NostrListener {
             .await?;
 
         // Subscribe to live events
-        let since = Timestamp::now() - Duration::from_secs(60 * 60);
-        self.subscribe_to_live_events(&token, since).await?;
+        self.subscribe_to_live_events(&token, live_subscription_since())
+            .await?;
 
         // Main event loop
         self.process_live_events(event_tx, service_pubkey, token)
@@ -467,15 +482,14 @@ impl NostrListener {
 
 #[async_trait]
 trait SubscriptionRecovery: Send + Sync {
-    async fn resubscribe(&self) -> Result<()>;
+    async fn resubscribe(&self, since: Timestamp) -> Result<()>;
 }
 
 #[async_trait]
 impl SubscriptionRecovery for NostrListener {
-    async fn resubscribe(&self) -> Result<()> {
+    async fn resubscribe(&self, since: Timestamp) -> Result<()> {
         let token = CancellationToken::new();
-        self.subscribe_to_live_events(&token, Timestamp::now())
-            .await
+        self.subscribe_to_live_events(&token, since).await
     }
 }
 
@@ -514,7 +528,7 @@ async fn run_live_loop(
                 }
 
                 warn!(?silence_timeout, "Nostr event flow is silent; resubscribing to the main relay");
-                recovery.resubscribe().await?;
+                recovery.resubscribe(live_subscription_since()).await?;
                 recovery_attempted = true;
                 silence_deadline = Instant::now() + silence_timeout;
             }
@@ -552,6 +566,18 @@ async fn run_live_loop(
                                 }
                             }
                             RelayPoolNotification::Message { relay_url, message } => {
+                                if let RelayMessage::Closed { subscription_id, .. } = &message {
+                                    if !recovery_attempted
+                                        && is_owned_subscription(subscription_id.as_ref())
+                                    {
+                                        warn!(%relay_url, subscription_id = %subscription_id, ?message, "Relay closed a live subscription; resubscribing");
+                                        recovery.resubscribe(live_subscription_since()).await?;
+                                        recovery_attempted = true;
+                                        silence_deadline = Instant::now() + silence_timeout;
+                                        continue;
+                                    }
+                                }
+
                                 match message {
                                     RelayMessage::Closed { .. } | RelayMessage::Notice(_) => {
                                         info!(%relay_url, ?message, "Received relay message");
@@ -599,6 +625,7 @@ mod tests {
     use super::*;
     use crate::health::{CriticalTask, OnReturn, TaskHealth, TaskTracker};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
     use tokio::sync::mpsc;
     use tokio::time::{advance, timeout};
 
@@ -609,12 +636,14 @@ mod tests {
     #[derive(Default)]
     struct MockRecovery {
         calls: AtomicUsize,
+        since: Mutex<Vec<Timestamp>>,
     }
 
     #[async_trait]
     impl SubscriptionRecovery for MockRecovery {
-        async fn resubscribe(&self) -> Result<()> {
+        async fn resubscribe(&self, since: Timestamp) -> Result<()> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            self.since.lock().expect("since lock").push(since);
             Ok(())
         }
     }
@@ -628,6 +657,13 @@ mod tests {
                     .sign_with_keys(keys)
                     .expect("sign test event"),
             ),
+        }
+    }
+
+    fn relay_message(message: RelayMessage<'static>) -> RelayPoolNotification {
+        RelayPoolNotification::Message {
+            relay_url: RelayUrl::parse("wss://relay.example").expect("valid relay url"),
+            message,
         }
     }
 
@@ -767,6 +803,13 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+        let since = recovery.since.lock().expect("since lock")[0];
+        let lookback = Timestamp::now().as_secs() - since.as_secs();
+        assert!(
+            (LIVE_EVENT_LOOKBACK.as_secs() - 1..=LIVE_EVENT_LOOKBACK.as_secs() + 1)
+                .contains(&lookback),
+            "recovery must replay the one-hour window, got {lookback} seconds"
+        );
         assert!(health.is_alive(CriticalTask::NostrListener));
 
         advance(silence_timeout).await;
@@ -774,5 +817,94 @@ mod tests {
 
         assert!(!health.is_alive(CriticalTask::NostrListener));
         assert!(health.had_unexpected_exit());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn our_closed_subscription_resubscribes_immediately() {
+        let (notify_tx, notify_rx) = broadcast::channel(2);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "error: closed by relay",
+            )))
+            .expect("send CLOSED");
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(30),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("cancellation should stop cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unrelated_closed_subscription_does_not_resubscribe() {
+        let (notify_tx, notify_rx) = broadcast::channel(2);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new("another-component"),
+                "error: closed by relay",
+            )))
+            .expect("send CLOSED");
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(30),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 0);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("cancellation should stop cleanly");
+    }
+
+    #[test]
+    fn only_service_owned_subscription_ids_trigger_recovery() {
+        assert!(is_owned_subscription(&SubscriptionId::new(
+            NOTIFICATION_SUBSCRIPTION_ID
+        )));
+        assert!(is_owned_subscription(&SubscriptionId::new(
+            NOTIFY_LIST_SUBSCRIPTION_ID
+        )));
+        assert!(!is_owned_subscription(&SubscriptionId::new(
+            "another-component"
+        )));
     }
 }

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -8,12 +8,14 @@ use crate::{
     event_handler::EventContext,
     state::AppState,
 };
+use async_trait::async_trait;
 use nostr_sdk::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast::{self, error::RecvError};
 use tokio::sync::mpsc::Sender;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -111,8 +113,11 @@ impl NostrListener {
     }
 
     async fn is_connected(&self) -> bool {
-        let relays = self.state.nostr_client.relays().await;
-        !relays.is_empty() && relays.values().any(|s| s.is_connected())
+        self.state
+            .nostr_client
+            .relay(self.state.settings.nostr.relay_url.as_str())
+            .await
+            .is_ok_and(|relay| relay.is_connected())
     }
 
     async fn ensure_connected(&self) -> Result<()> {
@@ -423,8 +428,34 @@ impl NostrListener {
 
         info!("Processing live events...");
 
-        run_live_loop(notifications, event_tx, service_pubkey, token).await;
+        run_live_loop(
+            notifications,
+            event_tx,
+            service_pubkey,
+            token,
+            Duration::from_secs(self.state.settings.nostr.event_silence_timeout_secs),
+            self,
+        )
+        .await
+    }
+}
 
+#[async_trait]
+trait SubscriptionRecovery: Send + Sync {
+    async fn resubscribe(&self) -> Result<()>;
+}
+
+#[async_trait]
+impl SubscriptionRecovery for NostrListener {
+    async fn resubscribe(&self) -> Result<()> {
+        let relay = self
+            .state
+            .nostr_client
+            .relay(self.state.settings.nostr.relay_url.as_str())
+            .await?;
+        relay.resubscribe().await.map_err(|error| {
+            ServiceError::Internal(format!("Failed to resubscribe to main relay: {error}"))
+        })?;
         Ok(())
     }
 }
@@ -441,7 +472,12 @@ async fn run_live_loop(
     event_tx: Sender<(Box<Event>, EventContext)>,
     service_pubkey: PublicKey,
     token: CancellationToken,
-) {
+    silence_timeout: Duration,
+    recovery: &dyn SubscriptionRecovery,
+) -> Result<()> {
+    let mut recovery_attempted = false;
+    let mut silence_deadline = Instant::now() + silence_timeout;
+
     loop {
         tokio::select! {
             biased;
@@ -450,11 +486,28 @@ async fn run_live_loop(
                 break;
             }
 
+            _ = tokio::time::sleep_until(silence_deadline) => {
+                if recovery_attempted {
+                    return Err(ServiceError::Internal(format!(
+                        "Nostr event flow did not resume within {:?} after resubscribing",
+                        silence_timeout
+                    )));
+                }
+
+                warn!(?silence_timeout, "Nostr event flow is silent; resubscribing to the main relay");
+                recovery.resubscribe().await?;
+                recovery_attempted = true;
+                silence_deadline = Instant::now() + silence_timeout;
+            }
+
             res = notifications.recv() => {
                 match res {
                     Ok(notification) => {
                         match notification {
                             RelayPoolNotification::Event { event, .. } => {
+                                recovery_attempted = false;
+                                silence_deadline = Instant::now() + silence_timeout;
+
                                 if event.pubkey == service_pubkey {
                                     debug!("Skipping event from service account");
                                     continue;
@@ -480,7 +533,14 @@ async fn run_live_loop(
                                 }
                             }
                             RelayPoolNotification::Message { relay_url, message } => {
-                                debug!(%relay_url, ?message, "Received relay message");
+                                match message {
+                                    RelayMessage::Closed { .. } | RelayMessage::Notice(_) => {
+                                        info!(%relay_url, ?message, "Received relay message");
+                                    }
+                                    _ => {
+                                        debug!(%relay_url, ?message, "Received relay message");
+                                    }
+                                }
                             }
                             RelayPoolNotification::Shutdown => {
                                 info!("Received shutdown notification");
@@ -511,17 +571,34 @@ async fn run_live_loop(
             }
         }
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::health::{CriticalTask, OnReturn, TaskHealth, TaskTracker};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::mpsc;
-    use tokio::time::timeout;
+    use tokio::time::{advance, timeout};
 
     /// A test's patience for the loop making progress. Generous enough not to
     /// flake on a loaded CI box, short enough to fail instead of hanging.
     const PATIENCE: Duration = Duration::from_secs(5);
+
+    #[derive(Default)]
+    struct MockRecovery {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SubscriptionRecovery for MockRecovery {
+        async fn resubscribe(&self) -> Result<()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
 
     fn live_event(keys: &Keys, content: &str) -> RelayPoolNotification {
         RelayPoolNotification::Event {
@@ -554,12 +631,18 @@ mod tests {
             notify_tx.send(live_event(&keys, content)).expect("send");
         }
 
-        let loop_handle = tokio::spawn(run_live_loop(
-            notify_rx,
-            event_tx,
-            Keys::generate().public_key(),
-            CancellationToken::new(),
-        ));
+        let loop_handle = tokio::spawn(async move {
+            let recovery = MockRecovery::default();
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+                &recovery,
+            )
+            .await
+        });
 
         let first = timeout(PATIENCE, event_rx.recv())
             .await
@@ -579,7 +662,8 @@ mod tests {
         timeout(PATIENCE, loop_handle)
             .await
             .expect("loop did not stop once the channel closed")
-            .expect("live loop panicked");
+            .expect("live loop panicked")
+            .expect("closed channel should stop cleanly");
     }
 
     /// The other half of the same decision: `Closed` really is terminal, so
@@ -598,10 +682,13 @@ mod tests {
                 event_tx,
                 Keys::generate().public_key(),
                 CancellationToken::new(),
+                Duration::from_secs(60),
+                &MockRecovery::default(),
             ),
         )
         .await
-        .expect("loop spun on a closed channel instead of stopping");
+        .expect("loop spun on a closed channel instead of stopping")
+        .expect("closed channel should stop cleanly");
     }
 
     /// Cancellation still wins over a pending receive.
@@ -614,9 +701,59 @@ mod tests {
 
         timeout(
             PATIENCE,
-            run_live_loop(notify_rx, event_tx, Keys::generate().public_key(), token),
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token,
+                Duration::from_secs(60),
+                &MockRecovery::default(),
+            ),
         )
         .await
-        .expect("loop ignored cancellation");
+        .expect("loop ignored cancellation")
+        .expect("cancellation should stop cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_subscription_resubscribes_then_fails_listener_health() {
+        let (_notify_tx, notify_rx) = broadcast::channel::<RelayPoolNotification>(2);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let silence_timeout = Duration::from_secs(30);
+        let recovery = Arc::new(MockRecovery::default());
+        let health = Arc::new(TaskHealth::new());
+        let token = CancellationToken::new();
+        let mut tracker = TaskTracker::new(Arc::clone(&health), token.clone());
+
+        let recovery_for_task = Arc::clone(&recovery);
+        tracker.spawn(
+            "nostr_listener",
+            Some(CriticalTask::NostrListener),
+            OnReturn::Fatal,
+            async move {
+                let _ = run_live_loop(
+                    notify_rx,
+                    event_tx,
+                    Keys::generate().public_key(),
+                    token,
+                    silence_timeout,
+                    recovery_for_task.as_ref(),
+                )
+                .await;
+            },
+        );
+
+        tokio::task::yield_now().await;
+        advance(silence_timeout).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+        assert!(health.is_alive(CriticalTask::NostrListener));
+
+        advance(silence_timeout).await;
+        tracker.wait().await;
+
+        assert!(!health.is_alive(CriticalTask::NostrListener));
+        assert!(health.had_unexpected_exit());
     }
 }

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -384,8 +384,14 @@ impl NostrListener {
                 None,
             ) => {
                 match sub_result {
-                    Ok(_output) => {
+                    Ok(output) if !output.success.is_empty() => {
                         info!("Successfully subscribed to diVine notification kinds");
+                    }
+                    Ok(output) => {
+                        error!(failed = ?output.failed, "Failed to send notification subscription to the main relay");
+                        return Err(ServiceError::Internal(
+                            "Notification subscription did not reach the main relay".to_string(),
+                        ));
                     }
                     Err(e) => {
                         error!("Failed to subscribe to notification kinds: {}", e);
@@ -417,8 +423,14 @@ impl NostrListener {
                 None,
             ) => {
                 match sub_result {
-                    Ok(_output) => {
+                    Ok(output) if !output.success.is_empty() => {
                         info!("Successfully subscribed to notify lists");
+                    }
+                    Ok(output) => {
+                        error!(failed = ?output.failed, "Failed to send notify-list subscription to the main relay");
+                        return Err(ServiceError::Internal(
+                            "Notify-list subscription did not reach the main relay".to_string(),
+                        ));
                     }
                     Err(e) => {
                         error!("Failed to subscribe to notify lists: {}", e);

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -989,6 +989,13 @@ mod tests {
             .expect("cancellation should stop cleanly");
     }
 
+    /// A second closure of an already-recovered subscription must fail the
+    /// listener rather than replay again.
+    ///
+    /// The closure reason deliberately carries no `rate-limited:` prefix. That
+    /// prefix would add a real five-second `RATE_LIMIT_RECOVERY_BACKOFF` sleep
+    /// to a test bounded by an equally long `PATIENCE`, leaving the assertion
+    /// to race its own timeout. The backoff has its own test below.
     #[tokio::test]
     async fn a_second_owned_closed_message_fails_instead_of_replaying_again() {
         let (notify_tx, notify_rx) = broadcast::channel(4);
@@ -998,7 +1005,7 @@ mod tests {
         notify_tx
             .send(relay_message(RelayMessage::closed(
                 SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
-                "rate-limited: slow down",
+                "error: closed by relay",
             )))
             .expect("send first CLOSED");
         notify_tx
@@ -1007,7 +1014,7 @@ mod tests {
         notify_tx
             .send(relay_message(RelayMessage::closed(
                 SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
-                "rate-limited: slow down",
+                "error: closed by relay",
             )))
             .expect("send second CLOSED");
 

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -33,6 +33,13 @@ const NOTIFY_LIST_SUBSCRIPTION_ID: &str = "divine-notify-lists";
 /// Successful event IDs remain claimed for seven days in the runtime config,
 /// so this one-hour overlap recovers gaps without redelivering pushes.
 const LIVE_EVENT_LOOKBACK: Duration = Duration::from_secs(60 * 60);
+/// Give a relay time to clear a rate-limit window before replaying an hour of
+/// traffic. An immediate retry is likely to receive the same rejection.
+const RATE_LIMIT_RECOVERY_BACKOFF: Duration = Duration::from_secs(5);
+/// Both owned subscriptions can be closed by one relay-side action. Keep the
+/// first recovery open briefly so the queued closure for its sibling is not
+/// mistaken for a rejection of the replacement subscription.
+const CLOSED_RECOVERY_GRACE: Duration = Duration::from_secs(5);
 
 /// How long to wait for the initial relay connection before treating startup as
 /// failed. A listener exit now stops the process, so this must be long enough to
@@ -147,8 +154,12 @@ impl NostrListener {
             .await?;
 
         // Subscribe to live events
-        self.subscribe_to_live_events(&token, live_subscription_since())
-            .await?;
+        if !self
+            .subscribe_to_live_events(&token, live_subscription_since())
+            .await?
+        {
+            return Ok(());
+        }
 
         // Main event loop
         self.process_live_events(event_tx, service_pubkey, token)
@@ -386,8 +397,9 @@ impl NostrListener {
         &self,
         token: &CancellationToken,
         since: Timestamp,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let all_kinds = notification_event_kinds(&self.state.settings.notification.event_kinds);
+        let main_relay_url = RelayUrl::parse(&self.state.settings.nostr.relay_url)?;
 
         let filter = Filter::new().kinds(all_kinds.clone()).since(since);
 
@@ -400,7 +412,7 @@ impl NostrListener {
             biased;
             _ = token.cancelled() => {
                 info!("Cancelled before live subscription");
-                return Ok(());
+                return Ok(false);
             }
             sub_result = self.state.nostr_client.subscribe_with_id(
                 SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
@@ -408,13 +420,13 @@ impl NostrListener {
                 None,
             ) => {
                 match sub_result {
-                    Ok(output) if !output.success.is_empty() => {
-                        info!("Successfully subscribed to diVine notification kinds");
+                    Ok(output) if output.success.contains(&main_relay_url) => {
+                        info!("Queued notification subscription for the main relay");
                     }
                     Ok(output) => {
-                        error!(failed = ?output.failed, "Failed to send notification subscription to the main relay");
+                        error!(failed = ?output.failed, "Failed to enqueue notification subscription for the main relay");
                         return Err(ServiceError::Internal(
-                            "Notification subscription did not reach the main relay".to_string(),
+                            "Notification subscription was not queued for the main relay".to_string(),
                         ));
                     }
                     Err(e) => {
@@ -439,7 +451,7 @@ impl NostrListener {
             biased;
             _ = token.cancelled() => {
                 info!("Cancelled before notify-list subscription");
-                return Ok(());
+                return Ok(false);
             }
             sub_result = self.state.nostr_client.subscribe_with_id(
                 SubscriptionId::new(NOTIFY_LIST_SUBSCRIPTION_ID),
@@ -447,13 +459,13 @@ impl NostrListener {
                 None,
             ) => {
                 match sub_result {
-                    Ok(output) if !output.success.is_empty() => {
-                        info!("Successfully subscribed to notify lists");
+                    Ok(output) if output.success.contains(&main_relay_url) => {
+                        info!("Queued notify-list subscription for the main relay");
                     }
                     Ok(output) => {
-                        error!(failed = ?output.failed, "Failed to send notify-list subscription to the main relay");
+                        error!(failed = ?output.failed, "Failed to enqueue notify-list subscription for the main relay");
                         return Err(ServiceError::Internal(
-                            "Notify-list subscription did not reach the main relay".to_string(),
+                            "Notify-list subscription was not queued for the main relay".to_string(),
                         ));
                     }
                     Err(e) => {
@@ -464,7 +476,7 @@ impl NostrListener {
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     async fn process_live_events(
@@ -491,14 +503,27 @@ impl NostrListener {
 
 #[async_trait]
 trait SubscriptionRecovery: Send + Sync {
-    async fn resubscribe(&self, since: Timestamp) -> Result<()>;
+    async fn resubscribe(&self, since: Timestamp, token: &CancellationToken) -> Result<bool>;
 }
 
 #[async_trait]
 impl SubscriptionRecovery for NostrListener {
-    async fn resubscribe(&self, since: Timestamp) -> Result<()> {
-        let token = CancellationToken::new();
-        self.subscribe_to_live_events(&token, since).await
+    async fn resubscribe(&self, since: Timestamp, token: &CancellationToken) -> Result<bool> {
+        self.subscribe_to_live_events(token, since).await
+    }
+}
+
+#[derive(Debug)]
+struct ClosedRecovery {
+    trigger_id: SubscriptionId,
+    started_at: Instant,
+    sibling_closed: bool,
+    flow_resumed: bool,
+}
+
+impl ClosedRecovery {
+    fn healthy_grace_elapsed(&self) -> bool {
+        self.flow_resumed && self.started_at.elapsed() >= CLOSED_RECOVERY_GRACE
     }
 }
 
@@ -518,7 +543,7 @@ async fn run_live_loop(
     recovery: &dyn SubscriptionRecovery,
 ) -> Result<()> {
     let mut recovery_attempted = false;
-    let mut closed_recovery_attempted = false;
+    let mut closed_recovery: Option<ClosedRecovery> = None;
     let mut silence_deadline = Instant::now() + silence_timeout;
 
     loop {
@@ -538,7 +563,12 @@ async fn run_live_loop(
                 }
 
                 warn!(?silence_timeout, "Nostr event flow is silent; resubscribing to the main relay");
-                recovery.resubscribe(live_subscription_since()).await?;
+                if !recovery
+                    .resubscribe(live_subscription_since(), &token)
+                    .await?
+                {
+                    break;
+                }
                 recovery_attempted = true;
                 silence_deadline = Instant::now() + silence_timeout;
             }
@@ -548,8 +578,6 @@ async fn run_live_loop(
                     Ok(notification) => {
                         match notification {
                             RelayPoolNotification::Event { event, .. } => {
-                                recovery_attempted = false;
-                                silence_deadline = Instant::now() + silence_timeout;
                                 crate::metrics::event_received();
 
                                 if event.pubkey == service_pubkey {
@@ -573,22 +601,72 @@ async fn run_live_loop(
                                             error!("Failed to send live event: {}", e);
                                             break;
                                         }
+
+                                        recovery_attempted = false;
+                                        silence_deadline = Instant::now() + silence_timeout;
+                                        if let Some(state) = closed_recovery.as_mut() {
+                                            state.flow_resumed = true;
+                                        }
                                     }
                                 }
                             }
                             RelayPoolNotification::Message { relay_url, message } => {
-                                if let RelayMessage::Closed { subscription_id, .. } = &message {
+                                if let RelayMessage::Closed { subscription_id, message: reason } = &message {
                                     if is_owned_subscription(subscription_id.as_ref()) {
-                                        if recovery_attempted || closed_recovery_attempted {
+                                        if closed_recovery
+                                            .as_ref()
+                                            .is_some_and(ClosedRecovery::healthy_grace_elapsed)
+                                        {
+                                            closed_recovery = None;
+                                        }
+
+                                        if let Some(state) = closed_recovery.as_mut() {
+                                            let is_stale_sibling = state.started_at.elapsed()
+                                                < CLOSED_RECOVERY_GRACE
+                                                && subscription_id.as_ref() != &state.trigger_id
+                                                && !state.sibling_closed;
+                                            if is_stale_sibling {
+                                                state.sibling_closed = true;
+                                                info!(%relay_url, subscription_id = %subscription_id, "Ignoring sibling closure queued before subscription recovery");
+                                                continue;
+                                            }
+
                                             return Err(ServiceError::Internal(format!(
                                                 "Relay closed recovered subscription {subscription_id}"
                                             )));
                                         }
 
+                                        if recovery_attempted {
+                                            return Err(ServiceError::Internal(format!(
+                                                "Relay closed subscription {subscription_id} during event-flow recovery"
+                                            )));
+                                        }
+
                                         warn!(%relay_url, subscription_id = %subscription_id, ?message, "Relay closed a live subscription; resubscribing");
-                                        recovery.resubscribe(live_subscription_since()).await?;
+                                        if MachineReadablePrefix::parse(reason)
+                                            == Some(MachineReadablePrefix::RateLimited)
+                                        {
+                                            warn!(?RATE_LIMIT_RECOVERY_BACKOFF, "Relay rate-limited a live subscription; backing off before recovery");
+                                            tokio::select! {
+                                                biased;
+                                                _ = token.cancelled() => break,
+                                                _ = tokio::time::sleep(RATE_LIMIT_RECOVERY_BACKOFF) => {}
+                                            }
+                                        }
+
+                                        if !recovery
+                                            .resubscribe(live_subscription_since(), &token)
+                                            .await?
+                                        {
+                                            break;
+                                        }
                                         recovery_attempted = true;
-                                        closed_recovery_attempted = true;
+                                        closed_recovery = Some(ClosedRecovery {
+                                            trigger_id: subscription_id.as_ref().clone(),
+                                            started_at: Instant::now(),
+                                            sibling_closed: false,
+                                            flow_resumed: false,
+                                        });
                                         silence_deadline = Instant::now() + silence_timeout;
                                         continue;
                                     }
@@ -657,10 +735,10 @@ mod tests {
 
     #[async_trait]
     impl SubscriptionRecovery for MockRecovery {
-        async fn resubscribe(&self, since: Timestamp) -> Result<()> {
+        async fn resubscribe(&self, since: Timestamp, _token: &CancellationToken) -> Result<bool> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.since.lock().expect("since lock").push(since);
-            Ok(())
+            Ok(true)
         }
     }
 
@@ -952,6 +1030,188 @@ mod tests {
         assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn sibling_closures_trigger_one_recovery() {
+        let (notify_tx, notify_rx) = broadcast::channel(4);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+
+        for subscription_id in [NOTIFICATION_SUBSCRIPTION_ID, NOTIFY_LIST_SUBSCRIPTION_ID] {
+            notify_tx
+                .send(relay_message(RelayMessage::closed(
+                    SubscriptionId::new(subscription_id),
+                    "error: relay restart",
+                )))
+                .expect("send CLOSED");
+        }
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(60),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("stale sibling closure must not fail recovery");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn healthy_flow_allows_a_later_closed_recovery() {
+        let (notify_tx, notify_rx) = broadcast::channel(8);
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(60),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "error: first closure",
+            )))
+            .expect("send first CLOSED");
+        notify_tx
+            .send(live_event(&Keys::generate(), "healthy traffic"))
+            .expect("send live event");
+        event_rx.recv().await.expect("forward healthy event");
+        advance(CLOSED_RECOVERY_GRACE).await;
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "error: later closure",
+            )))
+            .expect("send later CLOSED");
+        tokio::task::yield_now().await;
+
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 2);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("healthy flow must reset closed recovery");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limited_closure_backs_off_before_recovery() {
+        let (notify_tx, notify_rx) = broadcast::channel(2);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "rate-limited: slow down",
+            )))
+            .expect("send CLOSED");
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(60),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 0);
+        advance(RATE_LIMIT_RECOVERY_BACKOFF - Duration::from_secs(1)).await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 0);
+        advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("cancellation should stop cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn downstream_backpressure_does_not_trigger_recovery() {
+        let (notify_tx, notify_rx) = broadcast::channel(2);
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let recovery = Arc::new(MockRecovery::default());
+        let token = CancellationToken::new();
+        let keys = Keys::generate();
+        let queued = live_event(&keys, "already queued");
+        let RelayPoolNotification::Event { event, .. } = queued else {
+            unreachable!("live_event always constructs an event")
+        };
+        event_tx
+            .send((event, EventContext::Live))
+            .await
+            .expect("pre-fill event channel");
+
+        notify_tx
+            .send(live_event(&keys, "blocked by downstream"))
+            .expect("send live event");
+
+        let recovery_for_task = Arc::clone(&recovery);
+        let token_for_task = token.clone();
+        let loop_handle = tokio::spawn(async move {
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                token_for_task,
+                Duration::from_secs(30),
+                recovery_for_task.as_ref(),
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        advance(Duration::from_secs(30)).await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 0);
+
+        event_rx.recv().await.expect("drain pre-filled event");
+        event_rx.recv().await.expect("forward blocked event");
+        advance(Duration::from_secs(29)).await;
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 0);
+
+        token.cancel();
+        loop_handle
+            .await
+            .expect("live loop panicked")
+            .expect("cancellation should stop cleanly");
+    }
+
     #[test]
     fn only_service_owned_subscription_ids_trigger_recovery() {
         assert!(is_owned_subscription(&SubscriptionId::new(
@@ -963,26 +1223,5 @@ mod tests {
         assert!(!is_owned_subscription(&SubscriptionId::new(
             "another-component"
         )));
-    }
-
-    #[test]
-    fn shipped_configs_do_not_subscribe_to_contact_lists() {
-        for filename in ["settings.yaml", "settings.development.yaml"] {
-            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("config")
-                .join(filename);
-            let settings: crate::config::Settings = config::Config::builder()
-                .add_source(config::File::from(path).required(true))
-                .build()
-                .expect("build config")
-                .try_deserialize()
-                .expect("deserialize config");
-            let subscribed_kinds = notification_event_kinds(&settings.notification.event_kinds);
-
-            assert!(
-                !subscribed_kinds.contains(&Kind::from(3_u16)),
-                "{filename} must not subscribe the relay listener to kind 3"
-            );
-        }
     }
 }

--- a/src/nostr_listener.rs
+++ b/src/nostr_listener.rs
@@ -518,6 +518,7 @@ async fn run_live_loop(
     recovery: &dyn SubscriptionRecovery,
 ) -> Result<()> {
     let mut recovery_attempted = false;
+    let mut closed_recovery_attempted = false;
     let mut silence_deadline = Instant::now() + silence_timeout;
 
     loop {
@@ -577,12 +578,17 @@ async fn run_live_loop(
                             }
                             RelayPoolNotification::Message { relay_url, message } => {
                                 if let RelayMessage::Closed { subscription_id, .. } = &message {
-                                    if !recovery_attempted
-                                        && is_owned_subscription(subscription_id.as_ref())
-                                    {
+                                    if is_owned_subscription(subscription_id.as_ref()) {
+                                        if recovery_attempted || closed_recovery_attempted {
+                                            return Err(ServiceError::Internal(format!(
+                                                "Relay closed recovered subscription {subscription_id}"
+                                            )));
+                                        }
+
                                         warn!(%relay_url, subscription_id = %subscription_id, ?message, "Relay closed a live subscription; resubscribing");
                                         recovery.resubscribe(live_subscription_since()).await?;
                                         recovery_attempted = true;
+                                        closed_recovery_attempted = true;
                                         silence_deadline = Instant::now() + silence_timeout;
                                         continue;
                                     }
@@ -903,6 +909,47 @@ mod tests {
             .await
             .expect("live loop panicked")
             .expect("cancellation should stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn a_second_owned_closed_message_fails_instead_of_replaying_again() {
+        let (notify_tx, notify_rx) = broadcast::channel(4);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        let recovery = MockRecovery::default();
+
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "rate-limited: slow down",
+            )))
+            .expect("send first CLOSED");
+        notify_tx
+            .send(live_event(&Keys::generate(), "traffic between closures"))
+            .expect("send event");
+        notify_tx
+            .send(relay_message(RelayMessage::closed(
+                SubscriptionId::new(NOTIFICATION_SUBSCRIPTION_ID),
+                "rate-limited: slow down",
+            )))
+            .expect("send second CLOSED");
+
+        let error = timeout(
+            PATIENCE,
+            run_live_loop(
+                notify_rx,
+                event_tx,
+                Keys::generate().public_key(),
+                CancellationToken::new(),
+                Duration::from_secs(60),
+                &recovery,
+            ),
+        )
+        .await
+        .expect("live loop did not react to repeated CLOSED")
+        .expect_err("a repeated owned CLOSED must fail the listener");
+
+        assert!(error.to_string().contains(NOTIFICATION_SUBSCRIPTION_ID));
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A relay connection can stay open after its event subscriptions stop delivering, leaving a pod healthy but ineffective.
This change watches event flow, reissues stalled subscriptions, and fails listener health when recovery does not restore delivery.

Closes #56.

## What Changed

- Added a configurable five-minute event-silence timeout. One silent interval reissues both live subscriptions; another fails the supervised listener so the process restarts.
- Gave both subscriptions stable IDs and reacts immediately when the relay closes either owned ID. Closures for both IDs from the same relay-side action share one recovery attempt; a repeated rejection of a recovered subscription fails the listener instead of entering a replay loop.
- Backs off briefly after a rate-limited closure before replaying, then allows a later recovery after healthy event flow has resumed.
- Replays from a one-hour `since` timestamp on startup and recovery so events from the stalled window can be processed. Successful event IDs are retained for seven days in the shipped configuration, preventing duplicate push delivery from the overlap.
- Requires subscription requests to be queued specifically for the configured main relay, checks connectivity for that relay specifically, and raises `CLOSED` and `NOTICE` messages to info logs.
- Resets the silence deadline only after an event reaches the handler queue, so downstream backpressure does not masquerade as relay silence.
- Threads shutdown cancellation through recovery subscriptions.
- Preserved the receive metrics from main and the removal of unsupported kind 3 from the shipped configuration.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

The reusable Semantic PR workflow has no local command and was not run locally.
I did not test against the production relay or restart any deployed workload.

Regression coverage includes paired owned-subscription closures, repeated recovered-subscription rejection, rate-limit backoff, recovery after healthy traffic resumes, event-flow silence, unrelated closures, downstream handler backpressure, cancellation, and listener health propagation.

## Risks

The two owned subscriptions share a five-second recovery grace period. One closure for the sibling ID during that period is treated as belonging to the same relay-side action; a genuine immediate rejection of only that sibling would instead be detected by the event-silence watchdog if flow does not resume.

The silence timer tracks the combined event stream, so ordinary traffic cannot prove that the low-volume notify-list subscription remains active. An explicit `CLOSED` for that subscription is handled immediately, but silent relay-side loss without a message remains detectable only through broader delivery monitoring.

The one-hour timestamp asks the relay for the stalled window; any relay-side response cap can still limit how much history is returned.
