### PR TITLE
docs(push): explain when device registrations are removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The service implements a draft push-notification protocol; see [docs/nip-xx-push
 - **User preferences** — users can opt in or out of notification kinds with a preferences event; sensible defaults apply otherwise.
 - **Deduplication** — atomic Redis `SET NX EX` per-event locks ensure each event is delivered once, even across replicas.
 - **Replay protection** — a configurable processing window (7 days by default) ignores stale events.
-- **Token cleanup** — a background task prunes stale tokens (older than 90 days by default) once a day.
+- **Token cleanup** — a daily background task prunes tokens with no registration or successful delivery for 90 days by default.
 - **Prometheus metrics** — relay ingestion, event processing, FCM delivery outcomes, and token pruning are exposed for monitoring.
 - **Optional allow-list** — `allowed_pubkeys` can restrict delivery to a specific set of recipients.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -386,6 +386,9 @@ the fan-out follow-up rather than done by halves here.
 
 ## Redis Keys
 
+The canonical registration and removal rules live in the push specification's
+[Token lifecycle](nip-xx-push-notifications.md#token-lifecycle) section.
+
 | Key Pattern | Type | Description |
 |-------------|------|-------------|
 | `user_tokens:{pubkey}` | Set | FCM tokens registered for a pubkey |

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -33,6 +33,9 @@ read it. It is not one of the control kinds above and carries no ciphertext.
 
 ### Registration (kind 3079)
 
+The `expiration` tag in this example is optional. Clients may include it for
+NIP-40 relay interoperability, but this service does not interpret it.
+
 ```json
 {
   "kind": 3079,
@@ -55,13 +58,14 @@ The content field contains the NIP-44 encrypted token payload. Example plaintext
 **Note:** The exact payload structure is implementation-specific. Services define their own required fields.
 
 **Rules:**
-- `p`, `app`, `expiration` MUST be present.
+- `p` and `app` MUST be present. `expiration` MAY be present.
 - `content` MUST be NIP-44 ciphertext; services MUST reject plaintext.
-- Expiration per NIP-40. Servers MUST ignore expired events. Clients SHOULD refresh early (30–90d).
+- This service does not use `expiration` to accept, reject, or remove a token.
 
 ### Deregistration (kind 3080)
 
-Same structure and rules as 3079.
+Uses the same encrypted token payload and required `p` and `app` tags as 3079.
+It MAY also carry an `expiration` tag under the same optional policy.
 
 ```json
 {
@@ -69,13 +73,28 @@ Same structure and rules as 3079.
   "pubkey": "<client-pubkey>",
   "tags": [
     ["p", "<push-service-pubkey>"],
-    ["app", "<app-id>"],
-    ["expiration", "<unix-seconds>"]
+    ["app", "<app-id>"]
   ],
   "content": nip44_encrypt({"token": "<platform-token>"}),
   "sig": "<signature>"
 }
 ```
+
+### Token lifecycle
+
+The service removes a stored registration under any of these conditions:
+
+- the client publishes an explicit kind 3080 deregistration;
+- the push provider returns a terminal token error such as `UNREGISTERED` or
+  `SENDER_ID_MISMATCH`; or
+- the token has not had a successful delivery for the configured
+  `token_max_age_days` inactivity window. Registration sets the initial
+  activity time, and every delivered push refreshes it.
+
+The control event's `expiration` timestamp does not determine how long the
+stored token remains valid. The inactivity policy can therefore remove a token
+that has received no pushes during the configured window, even when the
+provider has not reported it invalid.
 
 ### Notification Preferences (kind 3083) — optional
 
@@ -164,7 +183,7 @@ on the trigger event (see [Author subscriptions](#author-subscriptions-kind-3000
 
 1. **Encryption**: Reject plaintext for all event kinds. Content must be valid NIP-44 ciphertext.
 2. **App isolation**: Partition by app tag; ignore events with unknown app.
-3. **Expiration**: Ignore expired events (NIP-40).
+3. **Control-event age**: Ignore control events whose `created_at` is beyond the seven-day replay horizon.
 4. **Multiple devices**: Support multiple tokens per (pubkey, app).
 5. **Idempotency**: At most one notification per (recipient_pubkey, app, event_id).
 6. **Error handling**: Remove invalid tokens on provider errors.
@@ -176,13 +195,13 @@ on the trigger event (see [Author subscriptions](#author-subscriptions-kind-3000
 1. Encrypt with NIP-44 to service pubkey.
 2. Follow service's documentation for required payload fields.
 3. Stable app id per application.
-4. Refresh before expiration; deregister on logout.
+4. Register when the push session becomes ready, republish when the provider token rotates, and deregister on logout.
 5. Verify service identity via discovery.
 
 ## Security
 
 - **Token privacy**: Publishing {pubkey ↔ token} enables correlation; NIP-44 mitigates.
-- **Replay**: Expiration (NIP-40) bounds replays.
+- **Replay**: Control events older than the seven-day replay horizon are ignored, and repeat processing of the same event ID is suppressed for `processed_event_ttl_secs`.
 - **Rotation**: Refresh/rotate tokens to limit exposure.
 - **Isolation**: `app` tag prevents cross-app misuse.
 

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -86,9 +86,9 @@ The service removes a stored registration under any of these conditions:
 
 - the client publishes an explicit kind 3080 deregistration;
 - the push provider reports that the token is no longer registered or valid; or
-- the token has not had a successful delivery for the configured
-  `token_max_age_days` inactivity window. Registration sets the initial
-  activity time, and every delivered push refreshes it.
+- the token has had neither an accepted registration nor a successful delivery
+  during the configured `token_max_age_days` inactivity window. Each accepted
+  registration sets its activity time, and every delivered push refreshes it.
 
 The control event's `expiration` timestamp does not determine how long the
 stored token remains valid. The inactivity policy can therefore remove a token

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -92,8 +92,8 @@ The service removes a stored registration under any of these conditions:
 
 The control event's `expiration` timestamp does not determine how long the
 stored token remains valid. The inactivity policy can therefore remove a token
-that has received no pushes during the configured window, even when the
-provider has not reported it invalid.
+that has received no registrations or pushes during the configured window,
+even when the provider has not reported it invalid.
 
 ### Notification Preferences (kind 3083) — optional
 

--- a/docs/nip-xx-push-notifications.md
+++ b/docs/nip-xx-push-notifications.md
@@ -85,8 +85,7 @@ It MAY also carry an `expiration` tag under the same optional policy.
 The service removes a stored registration under any of these conditions:
 
 - the client publishes an explicit kind 3080 deregistration;
-- the push provider returns a terminal token error such as `UNREGISTERED` or
-  `SENDER_ID_MISMATCH`; or
+- the push provider reports that the token is no longer registered or valid; or
 - the token has not had a successful delivery for the configured
   `token_max_age_days` inactivity window. Registration sets the initial
   activity time, and every delivered push refreshes it.


### PR DESCRIPTION
## Summary

The draft push-notification specification said every registration and deregistration needed an expiration timestamp and that the service rejected expired events. The service has never interpreted that tag, so the published contract disagreed with both server and client behavior.

This change makes the expiration tag optional for relay interoperability and documents the lifecycle the service actually implements: explicit deregistration, terminal provider feedback, or the configured inactivity sweep. It also describes the existing replay controls without presenting the event expiration timestamp as one of them.

## Why this is the right fix

A registration timestamp is not evidence that a device has stopped working. The service already removes tokens on positive provider feedback and, since #54, refreshes token activity after successful delivery. Treating an event expiration timestamp as a separate deletion clock would restore the same time-based failure mode that activity tracking was introduced to avoid.

## What this deliberately leaves alone

- No server or client behavior changes.
- The service continues to accept an optional NIP-40 expiration tag without interpreting it.
- A token that receives neither a registration event nor a successful delivery during `token_max_age_days` can still be removed by the inactivity sweep; changing that policy is outside this issue.
- Future-dated event handling is unchanged.

## Verification

- `cargo fmt --check`
- `cargo test` — 190 tests and 1 doc test passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- Checked every remaining expiration reference for consistency

Closes #55
