### PR TITLE
fix(deploy): complete intentional production rollouts

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -1,5 +1,6 @@
-# Builds once, pushes to all GCP Artifact Registry environments via docker-push-gcp.
-# Production push only on version tags (v*). Dispatch to IAC repo triggers ArgoCD sync.
+# Builds once, pushes to GCP Artifact Registry via docker-push-gcp, and dispatches
+# the matching environments to the IAC repo. Version tags and opted-in manual runs
+# include production as an intentional automatic promotion.
 #
 # Required GitHub Variables (repo-level):
 #   Per environment: WORKLOAD_IDENTITY_PROVIDER_{ENV}, SERVICE_ACCOUNT_{ENV}, GCP_PROJECT_ID_{ENV}
@@ -53,6 +54,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Test deploy payload contract
+        run: scripts/deploy-payload-contract-test.sh
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -82,6 +86,8 @@ jobs:
       packages: write
     outputs:
       tags: ${{ steps.tags.outputs.tags }}
+      deploy_payload: ${{ steps.deploy-payload.outputs.payload }}
+      include_production: ${{ steps.deploy-payload.outputs.include_production }}
 
     steps:
       - uses: actions/checkout@v6
@@ -92,6 +98,24 @@ jobs:
       - name: Generate image tags
         id: tags
         uses: divinevideo/divine-github-actions/generate-docker-tags@v1
+
+      - name: Prepare deploy payload
+        id: deploy-payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INCLUDE_PRODUCTION_INPUT: ${{ inputs.include_production }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          payload="$(scripts/build-deploy-payload.sh \
+            "$EVENT_NAME" \
+            "$REF" \
+            "$INCLUDE_PRODUCTION_INPUT" \
+            "$GITHUB_SHA" \
+            "$GITHUB_REPOSITORY" \
+            "$REF_NAME")"
+          echo "payload=$payload" >> "$GITHUB_OUTPUT"
+          echo "include_production=$(jq -r '.client_payload.environments | index("production") != null' <<<"$payload")" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
@@ -128,7 +152,7 @@ jobs:
           region: ${{ env.GCP_REGION }}
 
       - name: Push to Production
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.include_production)
+        if: steps.deploy-payload.outputs.include_production == 'true'
         uses: divinevideo/divine-github-actions/docker-push-gcp@v1
         with:
           image-name: divine-push-service:local
@@ -141,18 +165,22 @@ jobs:
           region: ${{ env.GCP_REGION }}
 
       - name: Summary
+        env:
+          INCLUDE_PRODUCTION: ${{ steps.deploy-payload.outputs.include_production }}
         run: |
-          echo "### Docker Image Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** divine-push-service" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:** ${{ steps.tags.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Environments:**" >> $GITHUB_STEP_SUMMARY
-          echo "- POC: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_POC }}/containers-poc/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Staging: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_STAGING }}/containers-staging/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ github.ref }}" == refs/tags/v* ]] || [[ "${{ inputs.include_production }}" == "true" ]]; then
-            echo "- Production: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_PRODUCTION }}/containers-production/divine-push-service\`" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "### Docker Image Published"
+            echo ""
+            echo "**Image:** divine-push-service"
+            echo "**Tags:** ${{ steps.tags.outputs.tags }}"
+            echo ""
+            echo "**Environments:**"
+            echo "- POC: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_POC }}/containers-poc/divine-push-service\`"
+            echo "- Staging: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_STAGING }}/containers-staging/divine-push-service\`"
+            if [[ "$INCLUDE_PRODUCTION" == "true" ]]; then
+              echo "- Production: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_PRODUCTION }}/containers-production/divine-push-service\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
     name: Trigger Deploy
@@ -162,15 +190,6 @@ jobs:
     environment: staging
 
     steps:
-      - name: Determine environments
-        id: envs
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]] || [[ "${{ inputs.include_production }}" == "true" ]]; then
-            echo 'environments=["poc","staging","production"]' >> $GITHUB_OUTPUT
-          else
-            echo 'environments=["poc","staging"]' >> $GITHUB_OUTPUT
-          fi
-
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -182,27 +201,29 @@ jobs:
 
       - name: Trigger image deploy
         env:
+          DISPATCH_PAYLOAD: ${{ needs.docker.outputs.deploy_payload }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          cat <<EOF | gh api repos/divinevideo/divine-iac-coreconfig/dispatches --input -
-          {
-            "event_type": "image-deploy",
-            "client_payload": {
-              "application": "divine-push-service",
-              "environments": ${{ steps.envs.outputs.environments }},
-              "images": [{"name": "divine-push-service", "tag": "${SHORT_SHA}"}],
-              "source_repo": "${{ github.repository }}",
-              "source_sha": "${{ github.sha }}",
-              "source_ref": "${{ github.ref_name }}"
-            }
-          }
-          EOF
+          if ! jq -e '
+            if (.client_payload.environments | index("production")) != null then
+              .client_payload.auto_promote == true
+            else
+              true
+            end
+          ' >/dev/null <<<"$DISPATCH_PAYLOAD"; then
+            echo "::error::Production deployment payload requires auto_promote: true"
+            exit 1
+          fi
 
-          echo "## Deploy Dispatched" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Application | divine-push-service |" >> $GITHUB_STEP_SUMMARY
-          echo "| Image Tag | \`${SHORT_SHA}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Environments | ${{ steps.envs.outputs.environments }} |" >> $GITHUB_STEP_SUMMARY
+          gh api repos/divinevideo/divine-iac-coreconfig/dispatches \
+            --input - <<<"$DISPATCH_PAYLOAD"
+
+          {
+            echo "## Deploy Dispatched"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Application | divine-push-service |"
+            echo "| Image Tag | \`$(jq -r '.client_payload.images[0].tag' <<<"$DISPATCH_PAYLOAD")\` |"
+            echo "| Environments | $(jq -c '.client_payload.environments' <<<"$DISPATCH_PAYLOAD") |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       include_production:
-        description: 'Also push to production registry'
+        description: 'Also push and deploy production (version tags always include production)'
         required: false
         default: false
         type: boolean
@@ -114,8 +114,9 @@ jobs:
             "$GITHUB_SHA" \
             "$GITHUB_REPOSITORY" \
             "$REF_NAME")"
+          include_production="$(jq -r '.client_payload.environments | index("production") != null' <<<"$payload")"
           echo "payload=$payload" >> "$GITHUB_OUTPUT"
-          echo "include_production=$(jq -r '.client_payload.environments | index("production") != null' <<<"$payload")" >> "$GITHUB_OUTPUT"
+          echo "include_production=$include_production" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
@@ -167,12 +168,13 @@ jobs:
       - name: Summary
         env:
           INCLUDE_PRODUCTION: ${{ steps.deploy-payload.outputs.include_production }}
+          TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           {
             echo "### Docker Image Published"
             echo ""
             echo "**Image:** divine-push-service"
-            echo "**Tags:** ${{ steps.tags.outputs.tags }}"
+            echo "**Tags:** $TAGS"
             echo ""
             echo "**Environments:**"
             echo "- POC: \`${{ env.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_POC }}/containers-poc/divine-push-service\`"

--- a/README.md
+++ b/README.md
@@ -150,9 +150,12 @@ The service authenticates to FCM per the app's `firebase` config:
 
 Production images are built and published by the `Build, Test & Push` GitHub Actions workflow (`.github/workflows/publish-and-release.yml`):
 
-- On every push to `main`, the workflow runs tests, builds a single Docker image, and pushes it to the POC, Test, and Staging Google Artifact Registry environments using Workload Identity federation.
-- Pushes to a `v*` tag (or a manual dispatch opting in) additionally publish to the Production registry.
-- After publishing, it dispatches an `image-deploy` event to `divinevideo/divine-iac-coreconfig`, which drives the ArgoCD rollout to the selected environments.
+- On every push to `main`, the workflow runs tests, builds a single Docker image, and pushes it to the POC and Staging Google Artifact Registry environments using Workload Identity federation.
+- Pushes to a `v*` tag additionally publish and deploy to Production as an intentional automatic promotion.
+- A manual workflow dispatch publishes and deploys to POC and Staging by default. Selecting `include_production` additionally publishes and deploys to Production as an intentional automatic promotion.
+- After publishing, the workflow dispatches an `image-deploy` event to `divinevideo/divine-iac-coreconfig`, which creates and automatically merges the deployment PR before checking the ArgoCD sync. Production payloads use `auto_promote: true`; they are not labeled as emergency hotfixes.
+
+Emergency production deployments use a direct `image-deploy` dispatch with `hotfix: true` under the platform deployment runbook. Use that path only when an incident requires bypassing the normal release workflow; ordinary version tags and manual production promotions must use this repository's workflow.
 
 The container is a multi-stage build on `debian:bookworm-slim` that bundles the release binary and the `config/` directory, and exposes port 8000.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Production images are built and published by the `Build, Test & Push` GitHub Act
 - A manual workflow dispatch publishes and deploys to POC and Staging by default. Selecting `include_production` additionally publishes and deploys to Production as an intentional automatic promotion.
 - After publishing, the workflow dispatches an `image-deploy` event to `divinevideo/divine-iac-coreconfig`, which creates and automatically merges the deployment PR before checking the ArgoCD sync. Production payloads use `auto_promote: true`; they are not labeled as emergency hotfixes.
 
-Emergency production deployments use a direct `image-deploy` dispatch with `hotfix: true` under the platform deployment runbook. Use that path only when an incident requires bypassing the normal release workflow; ordinary version tags and manual production promotions must use this repository's workflow.
+Emergency production deployments are an out-of-band platform operation that uses a direct `image-deploy` dispatch with `hotfix: true`. Use that path only when an incident requires bypassing the normal release workflow; ordinary version tags and manual production promotions must use this repository's workflow.
 
 The container is a multi-stage build on `debian:bookworm-slim` that bundles the release binary and the `config/` directory, and exposes port 8000.
 

--- a/scripts/build-deploy-payload.sh
+++ b/scripts/build-deploy-payload.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 6 ]]; then
+  echo "usage: $0 <event-name> <ref> <include-production> <sha> <repository> <ref-name>" >&2
+  exit 2
+fi
+
+event_name="$1"
+ref="$2"
+include_production_input="$3"
+sha="$4"
+repository="$5"
+ref_name="$6"
+
+include_production=false
+if [[ "$ref" == refs/tags/v* ]] ||
+  [[ "$event_name" == "workflow_dispatch" && "$include_production_input" == "true" ]]; then
+  include_production=true
+fi
+
+if [[ "$include_production" == "true" ]]; then
+  environments='["poc","staging","production"]'
+else
+  environments='["poc","staging"]'
+fi
+
+payload="$(
+  jq -cn \
+    --argjson environments "$environments" \
+    --arg image_tag "${sha:0:7}" \
+    --arg repository "$repository" \
+    --arg sha "$sha" \
+    --arg ref_name "$ref_name" \
+    --argjson include_production "$include_production" \
+    '{
+      event_type: "image-deploy",
+      client_payload: (
+        {
+          application: "divine-push-service",
+          environments: $environments,
+          images: [{name: "divine-push-service", tag: $image_tag}],
+          source_repo: $repository,
+          source_sha: $sha,
+          source_ref: $ref_name
+        }
+        + if $include_production then {auto_promote: true} else {} end
+      )
+    }'
+)"
+
+if ! jq -e '
+  if (.client_payload.environments | index("production")) != null then
+    .client_payload.auto_promote == true
+  else
+    true
+  end
+' >/dev/null <<<"$payload"; then
+  echo "production deployment payload requires auto_promote: true" >&2
+  exit 1
+fi
+
+printf '%s\n' "$payload"

--- a/scripts/deploy-payload-contract-test.sh
+++ b/scripts/deploy-payload-contract-test.sh
@@ -62,3 +62,8 @@ assert_payload \
   "manual dispatch without opt-in excludes production" \
   "workflow_dispatch" "refs/heads/main" "false" "main" \
   '["poc","staging"]' "false"
+
+assert_payload \
+  "manual dispatch of a version tag includes production" \
+  "workflow_dispatch" "refs/tags/v1.2.3" "false" "v1.2.3" \
+  '["poc","staging","production"]' "true"

--- a/scripts/deploy-payload-contract-test.sh
+++ b/scripts/deploy-payload-contract-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+builder="$script_dir/build-deploy-payload.sh"
+sha="0123456789abcdef0123456789abcdef01234567"
+repository="divinevideo/divine-push-service"
+
+assert_payload() {
+  local description="$1"
+  local event_name="$2"
+  local ref="$3"
+  local include_production_input="$4"
+  local ref_name="$5"
+  local expected_environments="$6"
+  local expected_auto_promote="$7"
+  local payload
+
+  payload="$($builder "$event_name" "$ref" "$include_production_input" "$sha" "$repository" "$ref_name")"
+
+  jq -e \
+    --argjson expected_environments "$expected_environments" \
+    --argjson expected_auto_promote "$expected_auto_promote" \
+    --arg sha "$sha" \
+    --arg repository "$repository" '
+      .event_type == "image-deploy"
+      and .client_payload.application == "divine-push-service"
+      and .client_payload.environments == $expected_environments
+      and .client_payload.images == [{"name":"divine-push-service","tag":"0123456"}]
+      and .client_payload.source_repo == $repository
+      and .client_payload.source_sha == $sha
+      and ((.client_payload.auto_promote // false) == $expected_auto_promote)
+      and (
+        if (.client_payload.environments | index("production")) != null then
+          .client_payload.auto_promote == true
+        else
+          (.client_payload | has("auto_promote") | not)
+        end
+      )
+    ' >/dev/null <<<"$payload"
+
+  echo "ok - $description"
+}
+
+assert_payload \
+  "push to main excludes production" \
+  "push" "refs/heads/main" "false" "main" \
+  '["poc","staging"]' "false"
+
+assert_payload \
+  "version tag authorizes production auto-promotion" \
+  "push" "refs/tags/v1.2.3" "false" "v1.2.3" \
+  '["poc","staging","production"]' "true"
+
+assert_payload \
+  "manual production opt-in authorizes auto-promotion" \
+  "workflow_dispatch" "refs/heads/main" "true" "main" \
+  '["poc","staging","production"]' "true"
+
+assert_payload \
+  "manual dispatch without opt-in excludes production" \
+  "workflow_dispatch" "refs/heads/main" "false" "main" \
+  '["poc","staging"]' "false"


### PR DESCRIPTION
## Problem

Manual production promotions and version-tag releases publish the production image, but their downstream deployment dispatch omits the authorization required by coreconfig. The source workflow therefore reports success while the production rollout fails validation and requires a misleading emergency-hotfix dispatch.

## Why this fix

The workflow now builds one tested dispatch payload for every release path. Version tags and manual runs with `include_production` include `production` and `auto_promote: true`, accurately recording an intentional promotion without adding a hotfix label. Main-branch and ordinary manual runs remain limited to POC and staging. The production push, workflow summary, and downstream dispatch all consume this same payload decision, and a fail-closed guard rejects any future production payload missing authorization.

This deliberately does not change coreconfig policy, add a production GitHub Environment, or wait for the downstream workflow conclusion. Emergency `hotfix: true` dispatches remain an out-of-band platform operation.

## Verification

- `scripts/deploy-payload-contract-test.sh`
- `bash -n scripts/build-deploy-payload.sh scripts/deploy-payload-contract-test.sh`
- `shellcheck scripts/build-deploy-payload.sh scripts/deploy-payload-contract-test.sh`
- `actionlint .github/workflows/publish-and-release.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --verbose`
- Negative guard check: a production payload with `auto_promote` removed is rejected

## Rollout

After merge, run the workflow manually with `include_production` selected and verify the downstream coreconfig deployment PR merges without a `hotfix` label and the ArgoCD sync succeeds.

Closes #59