### PR TITLE
feat(push): notify users about moderation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Any setting can be overridden with the `NOSTR_PUSH__` prefix and `__` as the nes
 | `NOSTR_PUSH__REDIS__URL` | No | Redis connection URL (overrides the config file) |
 | `NOSTR_PUSH__NOSTR__RELAY_URL` | No | Nostr relay to subscribe to |
 | `NOSTR_PUSH__NOSTR__EVENT_SILENCE_TIMEOUT_SECS` | No | Quiet period before the listener resubscribes, and the window after any resubscribe before it fails health (default `300`) |
+| `NOSTR_PUSH__SERVER__INTERNAL_API_TOKEN` | No | Shared bearer token that enables authenticated internal push requests |
 | `APP_ENV` | No | Selects the config file (default `development`) |
 | `RUST_LOG` | No | Log level (default `info`) |
 

--- a/config/settings.development.yaml
+++ b/config/settings.development.yaml
@@ -59,8 +59,10 @@ notification:
       - 1      # Text notes (comments, mentions)
       - 7      # Reactions/likes
       - 16     # Reposts
+      - 1059   # Direct messages from classified internal hooks
       - 30023  # Long-form content
       - 34236  # Videos from subscribed creators (new-post "bells")
 
 server:
   listen_addr: "0.0.0.0:8000"
+  # Set via NOSTR_PUSH__SERVER__INTERNAL_API_TOKEN to enable trusted push hooks.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -60,8 +60,10 @@ notification:
       - 1      # Text notes (comments, mentions)
       - 7      # Reactions/likes
       - 16     # Reposts
+      - 1059   # Direct messages from classified internal hooks
       - 30023  # Long-form content
       - 34236  # Videos from subscribed creators (new-post "bells")
 
 server:
   listen_addr: "0.0.0.0:8000"
+  # Set via NOSTR_PUSH__SERVER__INTERNAL_API_TOKEN to enable trusted push hooks.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -43,8 +43,8 @@ See [NIP-XX Push Notifications](nip-xx-push-notifications.md) for the full proto
 
 ## Notification Types
 
-The service supports these notification types. Direct-message payload handling
-is prepared but not enabled; all other rows are watched in production config.
+The service supports these notification types. Direct messages enter through an
+authenticated internal hook; all other rows are watched in production config.
 
 | Type | Event Kind | Trigger |
 |------|-----------|---------|
@@ -54,7 +54,7 @@ is prepared but not enabled; all other rows are watched in production config.
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Mention | 34236 | Addressable video tagging user (p-tag) |
 | Repost | 16 | Repost of user's note (p-tag) |
-| DirectMessage | 1059 | Prepared only. Enabling ingestion waits on the privileged-reader versus internal-hook architecture decision; a raw gift wrap does not reveal whether it is an incoming chat message, sender self-copy, reaction, or file message |
+| DirectMessage | 1059 | Triggered only by the authenticated internal hook. The relay listener deliberately does not ingest gift wraps because a raw wrap does not reveal whether it is chat, a sender self-copy, a reaction, or a file message |
 | NewPost | 34236 | A creator the user belled published a video. The only type whose recipients do not come from a `p` tag — see [New-post subscriptions](#new-post-subscriptions-bells) |
 
 > **Note:** diVine video comments are NIP-22 `kind:1111`, not `kind:1`. They notify both the **root author** (uppercase `P` — the video owner, so they hear about comments on their video) and the **direct parent author** (lowercase `p` — for a reply, the parent comment's author). The two coincide for a top-level comment and are deduplicated. Every such push carries the authoritative root-video coordinate (see [Routing & attribution contract](#routing--attribution-contract)), so a reply to someone else's comment still routes to the correct video instead of a guessed one.
@@ -129,6 +129,26 @@ When the triggering event is not addressable and carries no addressable referenc
 | `receiverNpub` | bech32 | Bech32-encoded npub of the recipient |
 | `eventKind` | string | Triggering Nostr event kind as a string (e.g. "7") |
 | `timestamp` | string | (omitted for `directMessage`) Unix timestamp of the triggering event as a string |
+
+### Internal direct-message hook
+
+Trusted senders request a generic direct-message push with
+`POST /internal/v1/direct-message` and the bearer token configured through
+`NOSTR_PUSH__SERVER__INTERNAL_API_TOKEN`. The endpoint is unavailable when the
+token is unset.
+
+```json
+{
+  "eventId": "<gift-wrap event id>",
+  "recipientPubkey": "<recipient hex pubkey>",
+  "messageType": "moderation_notice"
+}
+```
+
+`messageType` accepts `moderation_notice` and `report_outcome`. This explicit
+classification is the reason the hook can trigger a message push while the raw
+kind-1059 relay stream cannot. The event id supplies replay deduplication; none
+of the request fields add sender or content metadata to the FCM payload.
 
 The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and plain-note mentions omit them.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -155,10 +155,11 @@ Manual moderator replies and automated community warnings remain outside the
 classified hook until their message classes are added to both services.
 
 Do not configure callers until Divine Mobile can publish kind 1059 in its
-notification preferences and has bumped its published-kinds schema version.
-Older clients replace the server's stored kind list without 1059, which leaves
-direct-message pushes disabled for that user. The mobile schema bump marks
-existing preferences dirty and republishes the expanded list during rollout.
+notification preferences, has bumped its published-kinds schema version, and
+routes `directMessage` notification taps to the message inbox. Older clients
+replace the server's stored kind list without 1059, which leaves direct-message
+pushes disabled for that user. The mobile schema bump marks existing preferences
+dirty and republishes the expanded list during rollout.
 
 A `204` means the request was processed, not that FCM reached a device. Missing
 tokens, disabled preferences, an existing delivery claim, and terminal FCM

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -160,6 +160,13 @@ Older clients replace the server's stored kind list without 1059, which leaves
 direct-message pushes disabled for that user. The mobile schema bump marks
 existing preferences dirty and republishes the expanded list during rollout.
 
+A `204` means the request was processed, not that FCM reached a device. Missing
+tokens, disabled preferences, an existing delivery claim, and terminal FCM
+failures are successful no-op outcomes under the existing delivery contract.
+An all-token retryable FCM failure releases the claim and returns `5xx`, but the
+moderation caller is deliberately best-effort and does not retry; push failure
+must never delay or fail the moderation action.
+
 The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and plain-note mentions omit them.
 
 ### iOS APNS shape

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -150,6 +150,16 @@ classification is the reason the hook can trigger a message push while the raw
 kind-1059 relay stream cannot. The event id supplies replay deduplication; none
 of the request fields add sender or content metadata to the FCM payload.
 
+This initial contract covers automated moderation notices and report outcomes.
+Manual moderator replies and automated community warnings remain outside the
+classified hook until their message classes are added to both services.
+
+Do not configure callers until Divine Mobile can publish kind 1059 in its
+notification preferences and has bumped its published-kinds schema version.
+Older clients replace the server's stored kind list without 1059, which leaves
+direct-message pushes disabled for that user. The mobile schema bump marks
+existing preferences dirty and republishes the expanded list during rollout.
+
 The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and plain-note mentions omit them.
 
 ### iOS APNS shape

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -43,7 +43,8 @@ See [NIP-XX Push Notifications](nip-xx-push-notifications.md) for the full proto
 
 ## Notification Types
 
-The service watches for these event kinds and notifies the tagged recipient:
+The service supports these notification types. Direct-message payload handling
+is prepared but not enabled; all other rows are watched in production config.
 
 | Type | Event Kind | Trigger |
 |------|-----------|---------|
@@ -53,13 +54,19 @@ The service watches for these event kinds and notifies the tagged recipient:
 | Mention | 1 | Note mentioning user (p-tag, no e-tag reference) |
 | Mention | 34236 | Addressable video tagging user (p-tag) |
 | Repost | 16 | Repost of user's note (p-tag) |
+| DirectMessage | 1059 | Prepared only. Enabling ingestion waits on the privileged-reader versus internal-hook architecture decision; a raw gift wrap does not reveal whether it is an incoming chat message, sender self-copy, reaction, or file message |
 | NewPost | 34236 | A creator the user belled published a video. The only type whose recipients do not come from a `p` tag — see [New-post subscriptions](#new-post-subscriptions-bells) |
 
 > **Note:** diVine video comments are NIP-22 `kind:1111`, not `kind:1`. They notify both the **root author** (uppercase `P` — the video owner, so they hear about comments on their video) and the **direct parent author** (lowercase `p` — for a reply, the parent comment's author). The two coincide for a top-level comment and are deduplicated. Every such push carries the authoritative root-video coordinate (see [Routing & attribution contract](#routing--attribution-contract)), so a reply to someone else's comment still routes to the correct video instead of a guessed one.
 
 ## FCM Payload Format
 
-The FCM message carries **no top-level `notification` field** — the `data` map below is always present and is identical in shape for every notification type (only the `title`/`body` strings differ); every `data` value is a string. Per-platform delivery then diverges so that **one incoming push produces exactly one visible banner**:
+The FCM message carries **no top-level `notification` field**. The `data` map
+below is always present and every value is a string. Direct-message payloads are
+the privacy-preserving exception to the social-notification shape: they omit
+`senderPubkey`, `senderName`, `timestamp`, and all `referenced*` fields because a
+gift wrap reveals no real sender or inner event. Per-platform delivery then
+diverges so that **one incoming push produces exactly one visible banner**:
 
 - **Android** — data-only (top-level `notification` unset) with `android.priority` set to `high`. Android does not auto-display data messages, so the app renders the single banner itself from the `data` fields; high priority lets FCM wake an idle device promptly for this user-visible notification.
 - **iOS** — the service attaches an APNS override: `aps.alert` (title/body) + `mutable-content: 1`, push-type `alert`, priority 10. The OS presents the single banner; a Notification Service Extension (if shipped) uses `mutable-content` to *enrich* that same banner, never to create a second one. `content-available` is deliberately omitted — see [Avoiding duplicate banners](#avoiding-duplicate-banners).
@@ -102,9 +109,9 @@ When the triggering event is not addressable and carries no addressable referenc
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | string | `like`, `comment`, `mention`, `repost`, or `newPost`. Match the exact string: the first four are lowercase, `newPost` is camelCase |
+| `type` | string | `like`, `comment`, `mention`, `repost`, `directMessage`, or `newPost`. Match the exact camelCase strings |
 | `eventId` | hex | The Nostr event that triggered the notification (the like/comment/mention/repost/video event itself); stable id for dedup and a routing fallback |
-| `senderPubkey` | hex | Pubkey of the actor who triggered the event; routes otherwise-unresolved taps |
+| `senderPubkey` | hex | (omitted for `directMessage`) Pubkey of the actor who triggered the event; routes otherwise-unresolved taps |
 | `receiverPubkey` | hex | Pubkey of the notification recipient |
 | `referencedEventId` | hex | (optional) Target event. For a direct kind 34236 trigger this is the video event's own id. Otherwise it is root-aware: the NIP-22 uppercase `E` root scope when present, else the lowercase `e` tag — so comments anchor to the root video, not the parent comment |
 | `referencedAddress` | string | (optional) Authoritative addressable target coordinate `kind:pubkey:d-tag`. Built from a direct kind 34236 trigger's own identity, or taken from the event's `A` (NIP-22 root) or `a` tag for an indirect reference |
@@ -118,10 +125,10 @@ When the triggering event is not addressable and carries no addressable referenc
 |-------|------|-------------|
 | `title` | string | Human-readable title (e.g. "New like") |
 | `body` | string | Human-readable body (e.g. "Alice liked your post") |
-| `senderName` | string | Display name or truncated npub of the sender |
+| `senderName` | string | (omitted for `directMessage`) Display name or truncated npub of the sender |
 | `receiverNpub` | bech32 | Bech32-encoded npub of the recipient |
 | `eventKind` | string | Triggering Nostr event kind as a string (e.g. "7") |
-| `timestamp` | string | Unix timestamp of the triggering event as a string |
+| `timestamp` | string | (omitted for `directMessage`) Unix timestamp of the triggering event as a string |
 
 The `referenced*` coordinate fields are emitted when the triggering event is a kind 34236 addressable video, or when it references an addressable event via `a`/`A` — currently videos referenced by likes, reposts, and NIP-22 comments (kind 1111). Likes/reposts/comments on non-addressable targets and plain-note mentions omit them.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,11 +224,17 @@ fn default_token_max_age() -> i64 {
 pub struct ServerSettings {
     #[serde(default = "default_listen_addr")]
     pub listen_addr: String,
+    /// Bearer token for trusted internal notification requests.
+    ///
+    /// The internal endpoint is unavailable when this is unset.
+    #[serde(default)]
+    pub internal_api_token: Option<String>,
 }
 
 fn default_server_settings() -> ServerSettings {
     ServerSettings {
         listen_addr: default_listen_addr(),
+        internal_api_token: None,
     }
 }
 
@@ -271,6 +277,7 @@ fn default_preference_kinds() -> Vec<u16> {
         1,     // Text notes (comments, mentions)
         7,     // Reactions/likes
         16,    // Reposts
+        1059,  // Direct messages from classified internal hooks
         30023, // Long-form content
         34236, // Videos from subscribed creators (new-post "bells")
     ]
@@ -405,6 +412,17 @@ impl Settings {
             }
         }
 
+        if self
+            .server
+            .internal_api_token
+            .as_deref()
+            .is_some_and(str::is_empty)
+        {
+            return Err(ConfigError::Message(
+                "server.internal_api_token must not be empty when configured".to_string(),
+            ));
+        }
+
         Ok(())
     }
 
@@ -439,6 +457,7 @@ mod tests {
         assert!(!prefs.kinds.contains(&3)); // Contact lists are not notification triggers
         assert!(prefs.kinds.contains(&7)); // Likes
         assert!(prefs.kinds.contains(&16)); // Reposts
+        assert!(prefs.kinds.contains(&1059)); // Classified direct messages
         assert!(prefs.kinds.contains(&30023)); // Long-form
     }
 
@@ -557,6 +576,17 @@ mod tests {
                 "video-coordinate delivery records must outlive event-id claims"
             );
         }
+    }
+
+    #[test]
+    fn test_empty_internal_api_token_is_rejected() {
+        let mut settings = load_runtime_settings("settings.yaml");
+        settings.server.internal_api_token = Some(String::new());
+
+        let error = settings
+            .validate()
+            .expect_err("empty token must be rejected");
+        assert!(error.to_string().contains("server.internal_api_token"));
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -3,7 +3,8 @@
 //! Handles Nostr events and routes them to appropriate notification handlers.
 //! Supports:
 //! - Token registration/deregistration (kinds 3079/3080)
-//! - Notification types: likes, comments, mentions, reposts, and new posts
+//! - Notification types: likes, comments, mentions, reposts, direct messages,
+//!   and new posts
 
 use crate::{
     crypto::CryptoService,
@@ -38,6 +39,7 @@ pub enum EventContext {
 const KIND_REGISTRATION: u16 = 3079;
 const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
+const KIND_GIFT_WRAP: u16 = 1059;
 const KIND_VIDEO: u16 = 34236;
 const MAX_FANOUT_ATTEMPTS: u16 = 12;
 
@@ -567,6 +569,14 @@ async fn handle_content_event(
     } else if kind_num == 16 {
         // Kind 16: Repost - notify the author of the reposted event
         targets_of(NotificationType::Repost, find_repost_recipients(event))
+    } else if kind_num == KIND_GIFT_WRAP {
+        // NIP-17 routes each gift wrap through its cleartext recipient p tag.
+        // The wrapper author is an ephemeral key and its content is encrypted;
+        // neither is suitable notification copy.
+        targets_of(
+            NotificationType::DirectMessage,
+            find_mentioned_pubkeys(event),
+        )
     } else if kind_num == 30023 {
         // Kind 30023: Long-form content - check for mentions
         targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
@@ -1198,8 +1208,15 @@ struct EventScopedCopy {
 fn renders_event_content(notification_type: NotificationType) -> bool {
     match notification_type {
         NotificationType::Comment | NotificationType::Mention => true,
-        NotificationType::Like | NotificationType::Repost | NotificationType::NewPost => false,
+        NotificationType::Like
+        | NotificationType::Repost
+        | NotificationType::DirectMessage
+        | NotificationType::NewPost => false,
     }
+}
+
+fn renders_sender(notification_type: NotificationType) -> bool {
+    !matches!(notification_type, NotificationType::DirectMessage)
 }
 
 /// The event-scoped copy, resolved at most once and only if it is needed.
@@ -1240,6 +1257,8 @@ fn renders_event_content(notification_type: NotificationType) -> bool {
 /// notifications.
 struct LazyEventCopy {
     cell: tokio::sync::OnceCell<EventScopedCopy>,
+    /// Whether any target renders the event author.
+    needs_sender: bool,
     /// Whether any target renders the event body, decided over the whole target
     /// list rather than the one recipient that happens to resolve it first.
     needs_content: bool,
@@ -1249,6 +1268,9 @@ impl LazyEventCopy {
     fn for_targets(targets: &[NotificationTarget]) -> Self {
         Self {
             cell: tokio::sync::OnceCell::new(),
+            needs_sender: targets
+                .iter()
+                .any(|target| renders_sender(target.notification_type)),
             needs_content: targets
                 .iter()
                 .any(|target| renders_event_content(target.notification_type)),
@@ -1259,13 +1281,16 @@ impl LazyEventCopy {
     fn resolved(copy: EventScopedCopy) -> Self {
         Self {
             cell: tokio::sync::OnceCell::new_with(Some(copy)),
+            needs_sender: false,
             needs_content: false,
         }
     }
 
     async fn get(&self, state: &AppState, event: &Event) -> &EventScopedCopy {
         self.cell
-            .get_or_init(|| resolve_event_scoped_copy(state, event, self.needs_content))
+            .get_or_init(|| {
+                resolve_event_scoped_copy(state, event, self.needs_sender, self.needs_content)
+            })
             .await
     }
 }
@@ -1277,8 +1302,16 @@ impl LazyEventCopy {
 async fn resolve_event_scoped_copy(
     state: &AppState,
     event: &Event,
+    needs_sender: bool,
     needs_content: bool,
 ) -> EventScopedCopy {
+    if !needs_sender && !needs_content {
+        return EventScopedCopy {
+            sender_name: String::new(),
+            formatted_content: None,
+        };
+    }
+
     let Some(mention_parser) = state.mention_parser_service.as_ref() else {
         return EventScopedCopy {
             sender_name: format_short_npub(&event.pubkey),
@@ -2031,6 +2064,10 @@ fn create_fcm_payload(
             let body = format!("{} reposted your post", sender_name);
             (title, body)
         }
+        NotificationType::DirectMessage => (
+            "New message".to_string(),
+            "You have a new message".to_string(),
+        ),
         NotificationType::NewPost => {
             // Provisional copy. divine-mobile/brand-guidelines/TONE_OF_VOICE.md
             // governs user-facing strings; confirm before release.
@@ -2046,24 +2083,25 @@ fn create_fcm_payload(
     data.insert("eventId".to_string(), event.id.to_hex());
     data.insert("title".to_string(), title.clone());
     data.insert("body".to_string(), body.clone());
-    data.insert("senderPubkey".to_string(), event.pubkey.to_hex());
-    data.insert("senderName".to_string(), sender_name);
     data.insert("receiverPubkey".to_string(), target_pubkey.to_hex());
     data.insert(
         "receiverNpub".to_string(),
         target_pubkey.to_bech32().unwrap_or_default(),
     );
     data.insert("eventKind".to_string(), event.kind.as_u16().to_string());
-    data.insert(
-        "timestamp".to_string(),
-        event.created_at.as_secs().to_string(),
-    );
+    if notification_type != NotificationType::DirectMessage {
+        data.insert("senderPubkey".to_string(), event.pubkey.to_hex());
+        data.insert("senderName".to_string(), sender_name);
+        data.insert(
+            "timestamp".to_string(),
+            event.created_at.as_secs().to_string(),
+        );
 
-    // Add authoritative routing/attribution target fields: the referenced event
-    // id and, for addressable targets (e.g. kind 34236 videos), the signed
-    // coordinate (`referencedAddress` + components) so the client never has to
-    // guess the target's owner.
-    insert_trigger_reference_fields(&mut data, event);
+        // Add authoritative routing/attribution target fields: the referenced
+        // event id and, for addressable targets (e.g. kind 34236 videos), the
+        // signed coordinate so the client never has to guess the target owner.
+        insert_trigger_reference_fields(&mut data, event);
+    }
 
     FcmPayload {
         notification: None, // Data-only message for better client control
@@ -2405,6 +2443,28 @@ mod tests {
 
         let pubkeys = find_mentioned_pubkeys(&event);
         assert_eq!(pubkeys.len(), 3);
+    }
+
+    #[test]
+    fn test_gift_wrap_routes_to_its_p_tag_as_a_direct_message() {
+        let wrapper = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let event = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), "encrypted gift wrap")
+            .tag(Tag::public_key(recipient))
+            .sign_with_keys(&wrapper)
+            .unwrap();
+
+        let targets = targets_of(
+            NotificationType::DirectMessage,
+            find_mentioned_pubkeys(&event),
+        );
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].recipient, recipient);
+        assert_eq!(
+            targets[0].notification_type,
+            NotificationType::DirectMessage
+        );
     }
 
     #[test]
@@ -2911,6 +2971,39 @@ mod tests {
             data.get("body"),
             Some(&"Alice posted a new vine".to_string())
         );
+    }
+
+    #[test]
+    fn test_direct_message_payload_is_contentless_and_senderless() {
+        let wrapper = Keys::generate();
+        let recipient = Keys::generate().public_key();
+        let encrypted_content = "private-ciphertext-must-not-leak";
+        let event = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), encrypted_content)
+            .tag(Tag::public_key(recipient))
+            .sign_with_keys(&wrapper)
+            .unwrap();
+        let copy = EventScopedCopy {
+            sender_name: "ephemeral wrapper author".to_string(),
+            formatted_content: Some(encrypted_content.to_string()),
+        };
+
+        let payload =
+            create_fcm_payload(&event, &recipient, NotificationType::DirectMessage, &copy);
+        let data = payload.data.expect("data-only payload");
+
+        assert_eq!(data.get("type"), Some(&"directMessage".to_string()));
+        assert_eq!(data.get("title"), Some(&"New message".to_string()));
+        assert_eq!(
+            data.get("body"),
+            Some(&"You have a new message".to_string())
+        );
+        assert!(!data.contains_key("senderPubkey"));
+        assert!(!data.contains_key("senderName"));
+        assert!(!data.contains_key("timestamp"));
+        assert!(!data.values().any(|value| value.contains(encrypted_content)));
+        assert!(!data
+            .values()
+            .any(|value| value.contains(&event.pubkey.to_hex())));
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -2170,19 +2170,17 @@ fn create_fcm_payload(
         target_pubkey.to_bech32().unwrap_or_default(),
     );
     data.insert("eventKind".to_string(), event.kind.as_u16().to_string());
-    if notification_type != NotificationType::DirectMessage {
-        data.insert("senderPubkey".to_string(), event.pubkey.to_hex());
-        data.insert("senderName".to_string(), sender_name);
-        data.insert(
-            "timestamp".to_string(),
-            event.created_at.as_secs().to_string(),
-        );
+    data.insert("senderPubkey".to_string(), event.pubkey.to_hex());
+    data.insert("senderName".to_string(), sender_name);
+    data.insert(
+        "timestamp".to_string(),
+        event.created_at.as_secs().to_string(),
+    );
 
-        // Add authoritative routing/attribution target fields: the referenced
-        // event id and, for addressable targets (e.g. kind 34236 videos), the
-        // signed coordinate so the client never has to guess the target owner.
-        insert_trigger_reference_fields(&mut data, event);
-    }
+    // Add authoritative routing/attribution target fields: the referenced
+    // event id and, for addressable targets (e.g. kind 34236 videos), the
+    // signed coordinate so the client never has to guess the target owner.
+    insert_trigger_reference_fields(&mut data, event);
 
     FcmPayload {
         notification: None, // Data-only message for better client control
@@ -2195,7 +2193,10 @@ fn create_fcm_payload(
 
 fn create_direct_message_payload(event_id: EventId, target_pubkey: &PublicKey) -> FcmPayload {
     let mut data = std::collections::HashMap::new();
-    data.insert("type".to_string(), "directMessage".to_string());
+    data.insert(
+        "type".to_string(),
+        NotificationType::DirectMessage.display_name().to_string(),
+    );
     data.insert("eventId".to_string(), event_id.to_hex());
     data.insert("title".to_string(), "New message".to_string());
     data.insert("body".to_string(), "You have a new message".to_string());
@@ -2204,7 +2205,10 @@ fn create_direct_message_payload(event_id: EventId, target_pubkey: &PublicKey) -
         "receiverNpub".to_string(),
         target_pubkey.to_bech32().unwrap_or_default(),
     );
-    data.insert("eventKind".to_string(), "1059".to_string());
+    data.insert(
+        "eventKind".to_string(),
+        NotificationType::DirectMessage.kind().to_string(),
+    );
 
     FcmPayload {
         notification: None,
@@ -3101,7 +3105,7 @@ mod tests {
     }
 
     #[test]
-    fn test_internal_direct_message_payload_matches_the_mobile_contract() {
+    fn test_internal_direct_message_payload_matches_the_documented_contract() {
         let recipient = Keys::generate().public_key();
         let event_id =
             EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1138,6 +1138,35 @@ struct NotificationTarget {
     notification_type: NotificationType,
 }
 
+/// Source data needed by the common recipient-delivery path.
+enum DeliveryTrigger<'a> {
+    Nostr(&'a Event),
+    DirectMessage(EventId),
+}
+
+impl DeliveryTrigger<'_> {
+    fn event_id(&self) -> EventId {
+        match self {
+            Self::Nostr(event) => event.id,
+            Self::DirectMessage(event_id) => *event_id,
+        }
+    }
+
+    fn kind(&self) -> Kind {
+        match self {
+            Self::Nostr(event) => event.kind,
+            Self::DirectMessage(_) => Kind::from(1059),
+        }
+    }
+
+    fn nostr_event(&self) -> Option<&Event> {
+        match self {
+            Self::Nostr(event) => Some(event),
+            Self::DirectMessage(_) => None,
+        }
+    }
+}
+
 /// Drop targets that are the event's own author.
 ///
 /// An event that `p`-tags its own sender — a self-reaction, a self-repost —
@@ -1277,9 +1306,10 @@ impl LazyEventCopy {
         }
     }
 
-    async fn get(&self, state: &AppState, event: &Event) -> &EventScopedCopy {
+    async fn get(&self, state: &AppState, event: Option<&Event>) -> &EventScopedCopy {
         self.cell
             .get_or_init(|| {
+                let event = event.expect("only pre-resolved copies omit a Nostr event");
                 resolve_event_scoped_copy(state, event, self.needs_sender, self.needs_content)
             })
             .await
@@ -1618,7 +1648,51 @@ async fn send_notification_to_user(
     copy: &LazyEventCopy,
     token: CancellationToken,
 ) -> Result<()> {
-    let event_id = event.id;
+    send_notification_trigger_to_user(
+        state,
+        DeliveryTrigger::Nostr(event),
+        target_pubkey,
+        notification_type,
+        copy,
+        token,
+    )
+    .await
+}
+
+/// Deliver a classified direct-message push from a trusted internal caller.
+///
+/// The caller supplies the published gift-wrap id for replay deduplication. No
+/// wrapped content or sender metadata enters the push payload.
+pub async fn send_direct_message_notification(
+    state: &AppState,
+    event_id: EventId,
+    target_pubkey: &PublicKey,
+    token: CancellationToken,
+) -> Result<()> {
+    let copy = LazyEventCopy::resolved(EventScopedCopy {
+        sender_name: String::new(),
+        formatted_content: None,
+    });
+    send_notification_trigger_to_user(
+        state,
+        DeliveryTrigger::DirectMessage(event_id),
+        target_pubkey,
+        NotificationType::DirectMessage,
+        &copy,
+        token,
+    )
+    .await
+}
+
+async fn send_notification_trigger_to_user(
+    state: &AppState,
+    trigger: DeliveryTrigger<'_>,
+    target_pubkey: &PublicKey,
+    notification_type: NotificationType,
+    copy: &LazyEventCopy,
+    token: CancellationToken,
+) -> Result<()> {
+    let event_id = trigger.event_id();
     let pubkey_hex = target_pubkey.to_hex();
 
     // Check pubkey allowlist (for non-production environments)
@@ -1663,10 +1737,13 @@ async fn send_notification_to_user(
 
     let mut delivery_type = notification_type;
     if !delivery_type.is_enabled(&prefs) {
-        let can_fall_back_to_bell = if event.kind.as_u16() == KIND_VIDEO
+        let can_fall_back_to_bell = if trigger.kind().as_u16() == KIND_VIDEO
             && delivery_type == NotificationType::Mention
             && NotificationType::NewPost.is_enabled(&prefs)
         {
+            let event = trigger
+                .nostr_event()
+                .expect("video notifications always originate from a Nostr event");
             match redis_store::is_notify_watcher(&state.redis_pool, &event.pubkey, target_pubkey)
                 .await
             {
@@ -1704,18 +1781,24 @@ async fn send_notification_to_user(
         }
     }
 
-    if event.kind.as_u16() == KIND_VIDEO
-        && has_video_claim(state, event, target_pubkey, delivery_type, &token).await?
-    {
-        trace!(
-            event_id = %event_id,
-            target_pubkey = %target_pubkey,
-            "Skipping video recipient already notified for this coordinate"
-        );
-        return Ok(());
+    if trigger.kind().as_u16() == KIND_VIDEO {
+        let event = trigger
+            .nostr_event()
+            .expect("video notifications always originate from a Nostr event");
+        if has_video_claim(state, event, target_pubkey, delivery_type, &token).await? {
+            trace!(
+                event_id = %event_id,
+                target_pubkey = %target_pubkey,
+                "Skipping video recipient already notified for this coordinate"
+            );
+            return Ok(());
+        }
     }
 
     if delivery_type == NotificationType::NewPost {
+        let event = trigger
+            .nostr_event()
+            .expect("new-post notifications always originate from a Nostr event");
         let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
         let within_window = tokio::select! {
             biased;
@@ -1790,11 +1873,14 @@ async fn send_notification_to_user(
             }
             return Err(crate::error::ServiceError::Cancelled);
         }
-        resolved = copy.get(state, event) => resolved
+        resolved = copy.get(state, trigger.nostr_event()) => resolved
     };
 
     // Create FCM payload
-    let payload = create_fcm_payload(event, target_pubkey, delivery_type, copy);
+    let payload = match trigger.nostr_event() {
+        Some(event) => create_fcm_payload(event, target_pubkey, delivery_type, copy),
+        None => create_direct_message_payload(event_id, target_pubkey),
+    };
 
     // Send to all tokens
     info!(
@@ -1913,6 +1999,9 @@ async fn send_notification_to_user(
     // bounded, and low-harm; silently eating an hour of notifications on an FCM
     // blip is worse. Do not "fix" this into `SET NX EX`.
     if delivery_type == NotificationType::NewPost && success_count > 0 {
+        let event = trigger
+            .nostr_event()
+            .expect("new-post notifications always originate from a Nostr event");
         let rate_key = redis_store::build_notify_rate_key(target_pubkey, &event.pubkey);
         // Log and continue rather than `?`. Everything from here down is
         // bookkeeping about a push that has already shipped, so propagating
@@ -1941,14 +2030,16 @@ async fn send_notification_to_user(
         // here: `satisfied_video_claims` can yield two records, and `?` on
         // the first left the second unwritten. That is exactly the
         // half-written state the type-scoped claim exists to prevent.
-        record_video_claims(
-            state,
-            event,
-            target_pubkey,
-            delivery_type,
-            "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify",
-        )
-        .await;
+        if let Some(event) = trigger.nostr_event() {
+            record_video_claims(
+                state,
+                event,
+                target_pubkey,
+                delivery_type,
+                "Failed to record a video-coordinate claim after a delivered push; an edit may re-notify",
+            )
+            .await;
+        }
     }
 
     // Remove invalid tokens
@@ -2096,6 +2187,28 @@ fn create_fcm_payload(
 
     FcmPayload {
         notification: None, // Data-only message for better client control
+        data: Some(data),
+        android: None,
+        webpush: None,
+        apns: None,
+    }
+}
+
+fn create_direct_message_payload(event_id: EventId, target_pubkey: &PublicKey) -> FcmPayload {
+    let mut data = std::collections::HashMap::new();
+    data.insert("type".to_string(), "directMessage".to_string());
+    data.insert("eventId".to_string(), event_id.to_hex());
+    data.insert("title".to_string(), "New message".to_string());
+    data.insert("body".to_string(), "You have a new message".to_string());
+    data.insert("receiverPubkey".to_string(), target_pubkey.to_hex());
+    data.insert(
+        "receiverNpub".to_string(),
+        target_pubkey.to_bech32().unwrap_or_default(),
+    );
+    data.insert("eventKind".to_string(), "1059".to_string());
+
+    FcmPayload {
+        notification: None,
         data: Some(data),
         android: None,
         webpush: None,
@@ -2986,6 +3099,34 @@ mod tests {
         assert!(!data
             .values()
             .any(|value| value.contains(&event.pubkey.to_hex())));
+    }
+
+    #[test]
+    fn test_internal_direct_message_payload_matches_the_mobile_contract() {
+        let recipient = Keys::generate().public_key();
+        let event_id =
+            EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+
+        let payload = create_direct_message_payload(event_id, &recipient);
+        let data = payload.data.expect("data-only payload");
+
+        assert_eq!(data.get("type"), Some(&"directMessage".to_string()));
+        assert_eq!(data.get("eventId"), Some(&event_id.to_hex()));
+        assert_eq!(data.get("eventKind"), Some(&"1059".to_string()));
+        assert_eq!(data.get("receiverPubkey"), Some(&recipient.to_hex()));
+        for omitted in [
+            "senderPubkey",
+            "senderName",
+            "timestamp",
+            "referencedEventId",
+            "referencedAddress",
+            "referencedKind",
+            "referencedAuthorPubkey",
+            "referencedDTag",
+        ] {
+            assert!(!data.contains_key(omitted), "{omitted} must stay omitted");
+        }
     }
 
     #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -39,7 +39,6 @@ pub enum EventContext {
 const KIND_REGISTRATION: u16 = 3079;
 const KIND_DEREGISTRATION: u16 = 3080;
 const KIND_PREFERENCES_UPDATE: u16 = 3083;
-const KIND_GIFT_WRAP: u16 = 1059;
 const KIND_VIDEO: u16 = 34236;
 const MAX_FANOUT_ATTEMPTS: u16 = 12;
 
@@ -569,14 +568,6 @@ async fn handle_content_event(
     } else if kind_num == 16 {
         // Kind 16: Repost - notify the author of the reposted event
         targets_of(NotificationType::Repost, find_repost_recipients(event))
-    } else if kind_num == KIND_GIFT_WRAP {
-        // NIP-17 routes each gift wrap through its cleartext recipient p tag.
-        // The wrapper author is an ephemeral key and its content is encrypted;
-        // neither is suitable notification copy.
-        targets_of(
-            NotificationType::DirectMessage,
-            find_mentioned_pubkeys(event),
-        )
     } else if kind_num == 30023 {
         // Kind 30023: Long-form content - check for mentions
         targets_of(NotificationType::Mention, find_mentioned_pubkeys(event))
@@ -2446,28 +2437,6 @@ mod tests {
     }
 
     #[test]
-    fn test_gift_wrap_routes_to_its_p_tag_as_a_direct_message() {
-        let wrapper = Keys::generate();
-        let recipient = Keys::generate().public_key();
-        let event = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), "encrypted gift wrap")
-            .tag(Tag::public_key(recipient))
-            .sign_with_keys(&wrapper)
-            .unwrap();
-
-        let targets = targets_of(
-            NotificationType::DirectMessage,
-            find_mentioned_pubkeys(&event),
-        );
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].recipient, recipient);
-        assert_eq!(
-            targets[0].notification_type,
-            NotificationType::DirectMessage
-        );
-    }
-
-    #[test]
     fn test_video_notification_resolves_mentions_with_mention_type() {
         let sender = Keys::generate();
         let mentioned1 = Keys::generate();
@@ -2655,7 +2624,20 @@ mod tests {
 
         assert!(!renders_event_content(NotificationType::Like));
         assert!(!renders_event_content(NotificationType::Repost));
+        assert!(!renders_event_content(NotificationType::DirectMessage));
         assert!(!renders_event_content(NotificationType::NewPost));
+    }
+
+    #[test]
+    fn test_direct_messages_need_neither_sender_nor_content() {
+        assert!(!renders_sender(NotificationType::DirectMessage));
+
+        let copy = LazyEventCopy::for_targets(&[NotificationTarget {
+            recipient: Keys::generate().public_key(),
+            notification_type: NotificationType::DirectMessage,
+        }]);
+        assert!(!copy.needs_sender);
+        assert!(!copy.needs_content);
     }
 
     #[test]
@@ -2978,7 +2960,7 @@ mod tests {
         let wrapper = Keys::generate();
         let recipient = Keys::generate().public_key();
         let encrypted_content = "private-ciphertext-must-not-leak";
-        let event = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), encrypted_content)
+        let event = EventBuilder::new(Kind::from(1059), encrypted_content)
             .tag(Tag::public_key(recipient))
             .sign_with_keys(&wrapper)
             .unwrap();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -2146,10 +2146,9 @@ fn create_fcm_payload(
             let body = format!("{} reposted your post", sender_name);
             (title, body)
         }
-        NotificationType::DirectMessage => (
-            "New message".to_string(),
-            "You have a new message".to_string(),
-        ),
+        NotificationType::DirectMessage => {
+            return create_direct_message_payload(event.id, target_pubkey);
+        }
         NotificationType::NewPost => {
             // Provisional copy. divine-mobile/brand-guidelines/TONE_OF_VOICE.md
             // governs user-facing strings; confirm before release.

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -56,6 +56,7 @@ pub enum NotificationType {
     ///
     /// The wrapper reveals neither the real sender nor the message, so its push
     /// copy must remain generic.
+    // TODO(#65): Route this only after the service receives classified gift wraps.
     DirectMessage,
     /// A creator the recipient subscribed to published a new video.
     ///

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -52,6 +52,11 @@ pub enum NotificationType {
     Comment,
     Mention,
     Repost,
+    /// A NIP-17 gift wrap addressed to the recipient.
+    ///
+    /// The wrapper reveals neither the real sender nor the message, so its push
+    /// copy must remain generic.
+    DirectMessage,
     /// A creator the recipient subscribed to published a new video.
     ///
     /// Unlike every other variant this is not triggered by someone acting on the
@@ -68,6 +73,7 @@ impl NotificationType {
             NotificationType::Comment => 1,
             NotificationType::Mention => 1, // Same as Comment - both are kind 1
             NotificationType::Repost => 16,
+            NotificationType::DirectMessage => 1059,
             // Distinct from Mention's kind 1 even though video mentions also
             // arrive on kind 34236 events, so the two toggle independently.
             NotificationType::NewPost => 34236,
@@ -86,6 +92,7 @@ impl NotificationType {
             NotificationType::Comment => "comment",
             NotificationType::Mention => "mention",
             NotificationType::Repost => "repost",
+            NotificationType::DirectMessage => "directMessage",
             NotificationType::NewPost => "newPost",
         }
     }
@@ -197,6 +204,7 @@ mod tests {
         assert_eq!(NotificationType::Comment.kind(), 1);
         assert_eq!(NotificationType::Mention.kind(), 1);
         assert_eq!(NotificationType::Repost.kind(), 16);
+        assert_eq!(NotificationType::DirectMessage.kind(), 1059);
     }
 
     #[test]
@@ -212,6 +220,7 @@ mod tests {
         assert!(NotificationType::Like.is_enabled(&prefs));
         assert!(!NotificationType::Comment.is_enabled(&prefs));
         assert!(!NotificationType::Mention.is_enabled(&prefs));
+        assert!(!NotificationType::DirectMessage.is_enabled(&prefs));
     }
 
     #[test]
@@ -229,6 +238,21 @@ mod tests {
     #[test]
     fn test_new_post_kind_is_video_kind() {
         assert_eq!(NotificationType::NewPost.kind(), 34236);
+    }
+
+    #[test]
+    fn test_direct_message_preference_uses_gift_wrap_kind() {
+        let enabled = UserPreferences { kinds: vec![1059] };
+        let disabled = UserPreferences {
+            kinds: vec![1, 7, 16],
+        };
+
+        assert!(NotificationType::DirectMessage.is_enabled(&enabled));
+        assert!(!NotificationType::DirectMessage.is_enabled(&disabled));
+        assert_eq!(
+            NotificationType::DirectMessage.display_name(),
+            "directMessage"
+        );
     }
 
     #[test]

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -23,6 +23,7 @@ impl Default for UserPreferences {
                 1,     // Text notes (comments, mentions)
                 7,     // Reactions/likes
                 16,    // Reposts
+                1059,  // Direct messages from classified internal hooks
                 30023, // Long-form content
                 34236, // Videos from subscribed creators (new-post "bells")
             ],
@@ -56,7 +57,7 @@ pub enum NotificationType {
     ///
     /// The wrapper reveals neither the real sender nor the message, so its push
     /// copy must remain generic.
-    // TODO(#65): Route this only after the service receives classified gift wraps.
+    // Routed only from authenticated, classified internal delivery requests.
     DirectMessage,
     /// A creator the recipient subscribed to published a new video.
     ///
@@ -196,6 +197,7 @@ mod tests {
         assert!(!prefs.kinds.contains(&3));
         assert!(prefs.kinds.contains(&7));
         assert!(prefs.kinds.contains(&16));
+        assert!(prefs.kinds.contains(&1059));
         assert!(prefs.kinds.contains(&30023));
     }
 
@@ -215,6 +217,7 @@ mod tests {
         assert!(NotificationType::Like.is_enabled(&prefs));
         assert!(NotificationType::Comment.is_enabled(&prefs));
         assert!(NotificationType::Mention.is_enabled(&prefs));
+        assert!(NotificationType::DirectMessage.is_enabled(&prefs));
 
         // Only kind 7 enabled
         let prefs = UserPreferences { kinds: vec![7] };

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,18 +1,47 @@
 //! HTTP server exposing health and Prometheus metrics.
 
+use async_trait::async_trait;
 use axum::{
     extract::State,
-    http::{header, StatusCode},
-    routing::get,
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
     Json, Router,
 };
 use metrics_exporter_prometheus::PrometheusHandle;
+use nostr_sdk::{EventId, PublicKey};
+use serde::Deserialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
+use crate::error::Result;
+use crate::event_handler;
 use crate::health::{CriticalTask, TaskHealth};
 use crate::state::AppState;
+
+#[async_trait]
+trait DirectMessageDelivery: Send + Sync {
+    async fn deliver(&self, event_id: EventId, recipient: PublicKey) -> Result<()>;
+}
+
+struct AppDirectMessageDelivery {
+    app_state: Arc<AppState>,
+    token: CancellationToken,
+}
+
+#[async_trait]
+impl DirectMessageDelivery for AppDirectMessageDelivery {
+    async fn deliver(&self, event_id: EventId, recipient: PublicKey) -> Result<()> {
+        event_handler::send_direct_message_notification(
+            &self.app_state,
+            event_id,
+            &recipient,
+            self.token.clone(),
+        )
+        .await
+    }
+}
 
 /// Router state: the health endpoint reports both service identity and the
 /// liveness of the delivery tasks.
@@ -21,20 +50,40 @@ pub struct ServerState {
     service_pubkey: Option<String>,
     health: Arc<TaskHealth>,
     metrics: PrometheusHandle,
+    internal_api_token: Option<String>,
+    direct_message_delivery: Arc<dyn DirectMessageDelivery>,
 }
 
 impl ServerState {
     pub fn new(
-        service_pubkey: Option<String>,
+        app_state: Arc<AppState>,
         health: Arc<TaskHealth>,
         metrics: PrometheusHandle,
+        token: CancellationToken,
     ) -> Self {
         Self {
-            service_pubkey,
+            service_pubkey: app_state.service_pubkey_hex(),
             health,
             metrics,
+            internal_api_token: app_state.settings.server.internal_api_token.clone(),
+            direct_message_delivery: Arc::new(AppDirectMessageDelivery { app_state, token }),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DirectMessageRequest {
+    event_id: String,
+    recipient_pubkey: String,
+    message_type: DirectMessageType,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DirectMessageType {
+    ModerationNotice,
+    ReportOutcome,
 }
 
 /// Reports `503` when any critical task has died, so a pod whose delivery
@@ -78,10 +127,73 @@ async fn metrics(
     )
 }
 
+async fn direct_message(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    Json(request): Json<DirectMessageRequest>,
+) -> Response {
+    let Some(expected_token) = state.internal_api_token.as_deref() else {
+        tracing::error!("Internal push endpoint is disabled because no bearer token is configured");
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Internal push endpoint is not configured",
+        );
+    };
+
+    if !has_bearer_token(&headers, expected_token) {
+        return error_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+    }
+
+    let event_id = match EventId::from_hex(&request.event_id) {
+        Ok(event_id) => event_id,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "Invalid eventId"),
+    };
+    let recipient = match PublicKey::from_hex(&request.recipient_pubkey) {
+        Ok(recipient) => recipient,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "Invalid recipientPubkey"),
+    };
+
+    tracing::info!(
+        event_id = %event_id,
+        recipient = %recipient,
+        message_type = ?request.message_type,
+        "Processing trusted direct-message push request"
+    );
+
+    match state
+        .direct_message_delivery
+        .deliver(event_id, recipient)
+        .await
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => {
+            tracing::error!(event_id = %event_id, error = %error, "Direct-message push request failed");
+            error.into_response()
+        }
+    }
+}
+
+fn has_bearer_token(headers: &HeaderMap, expected_token: &str) -> bool {
+    let Some(provided_token) = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+    else {
+        return false;
+    };
+
+    blake3::hash(provided_token.as_bytes()) == blake3::hash(expected_token.as_bytes())
+}
+
+fn error_response(status: StatusCode, message: &'static str) -> Response {
+    (status, Json(serde_json::json!({ "error": message }))).into_response()
+}
+
 pub fn router(state: ServerState) -> Router {
     Router::new()
         .route("/health", get(health_check))
         .route("/metrics", get(metrics))
+        .route("/internal/v1/direct-message", post(direct_message))
         .with_state(state)
 }
 
@@ -92,9 +204,10 @@ pub async fn run_server(
     token: CancellationToken,
 ) {
     let app = router(ServerState::new(
-        app_state.service_pubkey_hex(),
+        Arc::clone(&app_state),
         health,
         metrics,
+        token.clone(),
     ));
 
     // Failure paths below deliberately just return. Cancelling the token here
@@ -143,11 +256,31 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use metrics_exporter_prometheus::PrometheusBuilder;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
+
+    #[derive(Default)]
+    struct MockDelivery {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl DirectMessageDelivery for MockDelivery {
+        async fn deliver(&self, _event_id: EventId, _recipient: PublicKey) -> Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
 
     fn server_state(health: Arc<TaskHealth>) -> ServerState {
         let metrics = PrometheusBuilder::new().build_recorder().handle();
-        ServerState::new(Some("pubkey-hex".to_string()), health, metrics)
+        ServerState {
+            service_pubkey: Some("pubkey-hex".to_string()),
+            health,
+            metrics,
+            internal_api_token: Some("test-token".to_string()),
+            direct_message_delivery: Arc::new(MockDelivery::default()),
+        }
     }
 
     async fn get_health(health: Arc<TaskHealth>) -> (StatusCode, serde_json::Value) {
@@ -233,11 +366,13 @@ mod tests {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         ::metrics::with_local_recorder(&recorder, crate::metrics::event_received);
-        let response = router(ServerState::new(
-            Some("pubkey-hex".to_string()),
-            Arc::new(TaskHealth::new()),
-            handle,
-        ))
+        let response = router(ServerState {
+            service_pubkey: Some("pubkey-hex".to_string()),
+            health: Arc::new(TaskHealth::new()),
+            metrics: handle,
+            internal_api_token: Some("test-token".to_string()),
+            direct_message_delivery: Arc::new(MockDelivery::default()),
+        })
         .oneshot(
             Request::builder()
                 .uri("/metrics")
@@ -255,5 +390,64 @@ mod tests {
         assert!(String::from_utf8(body.to_vec())
             .unwrap()
             .contains("push_events_received_total 1"));
+    }
+
+    fn direct_message_request(token: Option<&str>, body: &str) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/internal/v1/direct-message")
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(token) = token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        builder.body(Body::from(body.to_string())).unwrap()
+    }
+
+    #[tokio::test]
+    async fn direct_message_requires_the_internal_bearer_token() {
+        let response = router(server_state(Arc::new(TaskHealth::new())))
+            .oneshot(direct_message_request(
+                Some("wrong-token"),
+                r#"{"eventId":"1111111111111111111111111111111111111111111111111111111111111111","recipientPubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","messageType":"moderation_notice"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn direct_message_rejects_unclassified_messages() {
+        let response = router(server_state(Arc::new(TaskHealth::new())))
+            .oneshot(direct_message_request(
+                Some("test-token"),
+                r#"{"eventId":"1111111111111111111111111111111111111111111111111111111111111111","recipientPubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","messageType":"reaction"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn direct_message_delivers_a_valid_classified_request() {
+        let delivery = Arc::new(MockDelivery::default());
+        let state = ServerState {
+            service_pubkey: Some("pubkey-hex".to_string()),
+            health: Arc::new(TaskHealth::new()),
+            metrics: PrometheusBuilder::new().build_recorder().handle(),
+            internal_api_token: Some("test-token".to_string()),
+            direct_message_delivery: delivery.clone(),
+        };
+        let response = router(state)
+            .oneshot(direct_message_request(
+                Some("test-token"),
+                r#"{"eventId":"1111111111111111111111111111111111111111111111111111111111111111","recipientPubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","messageType":"moderation_notice"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(delivery.calls.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,8 +2,9 @@
 
 use async_trait::async_trait;
 use axum::{
-    extract::State,
+    extract::{Request, State},
     http::{header, HeaderMap, StatusCode},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
@@ -129,21 +130,8 @@ async fn metrics(
 
 async fn direct_message(
     State(state): State<ServerState>,
-    headers: HeaderMap,
     Json(request): Json<DirectMessageRequest>,
 ) -> Response {
-    let Some(expected_token) = state.internal_api_token.as_deref() else {
-        tracing::error!("Internal push endpoint is disabled because no bearer token is configured");
-        return error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Internal push endpoint is not configured",
-        );
-    };
-
-    if !has_bearer_token(&headers, expected_token) {
-        return error_response(StatusCode::UNAUTHORIZED, "Unauthorized");
-    }
-
     let event_id = match EventId::from_hex(&request.event_id) {
         Ok(event_id) => event_id,
         Err(_) => return error_response(StatusCode::BAD_REQUEST, "Invalid eventId"),
@@ -173,6 +161,26 @@ async fn direct_message(
     }
 }
 
+async fn require_internal_api_token(
+    State(state): State<ServerState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(expected_token) = state.internal_api_token.as_deref() else {
+        tracing::error!("Internal push endpoint is disabled because no bearer token is configured");
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Internal push endpoint is not configured",
+        );
+    };
+
+    if !has_bearer_token(request.headers(), expected_token) {
+        return error_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+    }
+
+    next.run(request).await
+}
+
 fn has_bearer_token(headers: &HeaderMap, expected_token: &str) -> bool {
     let Some(provided_token) = headers
         .get(header::AUTHORIZATION)
@@ -193,7 +201,13 @@ pub fn router(state: ServerState) -> Router {
     Router::new()
         .route("/health", get(health_check))
         .route("/metrics", get(metrics))
-        .route("/internal/v1/direct-message", post(direct_message))
+        .route(
+            "/internal/v1/direct-message",
+            post(direct_message).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_internal_api_token,
+            )),
+        )
         .with_state(state)
 }
 
@@ -409,6 +423,19 @@ mod tests {
             .oneshot(direct_message_request(
                 Some("wrong-token"),
                 r#"{"eventId":"1111111111111111111111111111111111111111111111111111111111111111","recipientPubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","messageType":"moderation_notice"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn direct_message_authenticates_before_parsing_the_body() {
+        let response = router(server_state(Arc::new(TaskHealth::new())))
+            .oneshot(direct_message_request(
+                Some("wrong-token"),
+                r#"{"messageType":"reaction"}"#,
             ))
             .await
             .unwrap();

--- a/tests/preferences_test.rs
+++ b/tests/preferences_test.rs
@@ -139,6 +139,7 @@ async fn test_notification_type_filtering_with_kinds() {
     assert!(!NotificationType::Comment.is_enabled(&prefs)); // kind 1 ✗
     assert!(!NotificationType::Mention.is_enabled(&prefs)); // kind 1 ✗
     assert!(NotificationType::Repost.is_enabled(&prefs)); // kind 16 ✓
+    assert!(!NotificationType::DirectMessage.is_enabled(&prefs)); // kind 1059 ✗
 }
 
 #[tokio::test]
@@ -211,6 +212,10 @@ fn test_notification_type_display_names() {
     assert_eq!(NotificationType::Comment.display_name(), "comment");
     assert_eq!(NotificationType::Mention.display_name(), "mention");
     assert_eq!(NotificationType::Repost.display_name(), "repost");
+    assert_eq!(
+        NotificationType::DirectMessage.display_name(),
+        "directMessage"
+    );
 }
 
 #[test]
@@ -219,6 +224,7 @@ fn test_notification_type_kind_values() {
     assert_eq!(NotificationType::Comment.kind(), 1);
     assert_eq!(NotificationType::Mention.kind(), 1); // Same as Comment
     assert_eq!(NotificationType::Repost.kind(), 16);
+    assert_eq!(NotificationType::DirectMessage.kind(), 1059);
 }
 
 #[test]
@@ -243,6 +249,7 @@ fn test_empty_preferences_disables_all() {
     assert!(!NotificationType::Comment.is_enabled(&prefs));
     assert!(!NotificationType::Mention.is_enabled(&prefs));
     assert!(!NotificationType::Repost.is_enabled(&prefs));
+    assert!(!NotificationType::DirectMessage.is_enabled(&prefs));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Moderation direct messages are encrypted, so the push service cannot tell a real incoming message from a sender copy, reaction, or file by watching gift wraps on public relays.
This adds a small authenticated internal hook that accepts an already-classified moderation message and sends a generic, content-free push to the recipient.

## What Changed

The service now accepts bearer-authenticated requests for automated moderation notices and report outcomes.
It reuses the existing preference, token, deduplication, pruning, and Firebase delivery paths without giving the push service a NIP-17 decryption key or adding kind 1059 to its relay subscription.

- Authenticates before parsing the request body.
- Uses the gift-wrap event ID and recipient for replay deduplication.
- Sends only generic `New message` copy and omits sender, content, timestamp, and reference metadata.
- Documents the endpoint's best-effort response semantics and rollout requirements.

The moderation-service caller is in companion draft PR divinevideo/divine-moderation-service#210.

## Testing

- `cargo test --verbose`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/deploy-payload-contract-test.sh` (5/5 cases)

The semantic PR workflow has no local command and will run in GitHub.

## Risks

Do not enable callers until Divine Mobile publishes kind 1059 preferences, bumps its published-kinds schema, and routes `directMessage` taps to the message inbox.
A reachable internal URL and shared bearer secret also need platform provisioning.

A `204` means the request was processed, not that a device received the push.
The caller is deliberately best-effort and does not retry, so push failures never delay or fail moderation.
Manual moderator replies and community warnings are outside this initial two-class contract.

Refs #65
