### PR TITLE
fix(push): add a second profile relay so sender names survive purplepag.es being down

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -7,8 +7,17 @@ nostr:
   # passes with no event. A relay CLOSED resubscribes immediately, so there
   # the next quiet window is the one that fails health.
   event_silence_timeout_secs: 300
+  # Sender-name lookups only. These are queried by a separate client from the
+  # one carrying the notification subscription, so a relay here can never
+  # introduce an event that triggers a push.
+  #
+  # Kind 0 is an "indexed kind": no ordinary relay holds the latest profile for
+  # every pubkey, so a handful of purpose-built aggregators do. Listing more
+  # than one matters because a reaction can come from anywhere on the network,
+  # and relay.divine.video only holds profiles for people who reached us.
   profile_relays:
     - wss://relay.divine.video
+    - wss://relay.nos.social
     - wss://purplepag.es
   profile_cache_ttl_secs: 300
   query_timeout_secs: 3


### PR DESCRIPTION
## Summary

Adds `relay.nos.social` to `profile_relays`, so sender-name lookups have a working aggregator while `purplepag.es` is unreachable.

## Motivation

Both production pods log a TLS handshake failure against `purplepag.es` on every startup. It resolves (`157.180.102.242`) but TCP 443 times out, and it does so from outside the cluster too, so this is the relay being down rather than an egress problem on our side.

That left profile lookups running on `relay.divine.video` alone. `purplepag.es` was in the list precisely because it aggregates kind-0 for pubkeys that never published to a diVine relay, which is the case that matters here: someone from the wider network liking a diVine video. A failed lookup degrades the notification body, since it is built as "alice liked your post".

Kind 0 is an indexed kind. No ordinary relay holds the latest profile for every pubkey, so a small number of purpose-built aggregators do, and listing more than one is the whole point.

`purplepag.es` stays in the list. A dead relay in a multi-relay lookup costs a connection attempt and nothing else, and it may come back.

## Scope

This only affects metadata. `profile_relays` is queried by `profile_client`, a separate client from the `nostr_client` that carries the notification subscription (`src/state.rs:85-120`), so a relay added here cannot introduce an event that triggers a push.

## Test plan

- `cargo test`: 221 passed, 0 failed.
- `cargo clippy --all-targets --all-features`: no new warnings.
- `cargo fmt --check`: clean.
- Verified with `nak` that `relay.nos.social` returns kind-0 for 4 of 4 well-known pubkeys, matching `relay.divine.video`.

I also measured `user.kindpag.es`, suggested as a like-for-like replacement, and left it out: it connects and serves kind-0, but returned only 1 of the same 4 pubkeys.

## Known limits

The 4-pubkey check proves each relay answers. It is not a coverage comparison across the wider-network accounts this is meant to help, which would need a sample of real reactor pubkeys.

`relay.nos.social` is one we operate, so it is dependable but weakest exactly where `purplepag.es` was strongest: accounts that never reached us.
